### PR TITLE
Use device picker for commission window service call

### DIFF
--- a/custom_components/matter_experimental/services.yaml
+++ b/custom_components/matter_experimental/services.yaml
@@ -37,13 +37,11 @@ set_thread:
 open_commissioning_window:
   name: Open Commissioning Window
   description: >
-    Open Commissioning Window of a Matter node for 60s.
+    Open Commissioning Window of a Matter device for 60s.
   fields:
-    node_id:
-      name: Matter Node ID
+    device_id:
+      name: Device
       required: true
       selector:
-        number:
-          min: 0
-          max: 18446744004990074879
-          mode: box
+        device:
+          integration: matter_experimental


### PR DESCRIPTION
Allow users to pick a device instead of having to know the node id.

![image](https://user-images.githubusercontent.com/1444314/173615259-930391ae-f690-4ad0-8122-119390ac937f.png)
