### PR TITLE
Synchronize attribute reads and subscriptions on startup

### DIFF
--- a/custom_components/matter_experimental/adapter.py
+++ b/custom_components/matter_experimental/adapter.py
@@ -101,6 +101,7 @@ class MatterAdapter(AbstractMatterAdapter):
         self._store = get_matter_store(hass, config_entry)
         self.platform_handlers: dict[Platform, AddEntitiesCallback] = {}
         self._platforms_set_up = asyncio.Event()
+        self._node_lock: dict[int, asyncio.Lock] = {}
 
     def register_platform_handler(
         self, platform: Platform, add_entities: AddEntitiesCallback
@@ -129,6 +130,12 @@ class MatterAdapter(AbstractMatterAdapter):
 
     def get_client_session(self) -> aiohttp.ClientSession:
         return async_get_clientsession(self.hass)
+
+    def get_node_lock(self, nodeid) -> asyncio.Lock:
+        if nodeid not in self._node_lock:
+            self._node_lock[nodeid] = asyncio.Lock()
+        return self._node_lock[nodeid]
+
 
     async def setup_node(self, node: MatterNode) -> None:
         """Set up an node."""

--- a/custom_components/matter_experimental/adapter.py
+++ b/custom_components/matter_experimental/adapter.py
@@ -136,7 +136,6 @@ class MatterAdapter(AbstractMatterAdapter):
             self._node_lock[nodeid] = asyncio.Lock()
         return self._node_lock[nodeid]
 
-
     async def setup_node(self, node: MatterNode) -> None:
         """Set up an node."""
         await self._platforms_set_up.wait()

--- a/custom_components/matter_experimental/entity.py
+++ b/custom_components/matter_experimental/entity.py
@@ -82,7 +82,9 @@ class MatterEntity(entity.Entity):
         """Handle being added to Home Assistant."""
         await super().async_added_to_hass()
 
-        async with self._device.node.matter.adapter.get_node_lock(self._device.node.node_id):
+        async with self._device.node.matter.adapter.get_node_lock(
+            self._device.node.node_id
+        ):
             await self.init_matter_device()
 
     async def async_will_remove_from_hass(self) -> None:

--- a/custom_components/matter_experimental/entity.py
+++ b/custom_components/matter_experimental/entity.py
@@ -82,7 +82,7 @@ class MatterEntity(entity.Entity):
         """Handle being added to Home Assistant."""
         await super().async_added_to_hass()
 
-        async with self._device.node.node_lock:
+        async with self._device.node.matter.adapter.get_node_lock(self._device.node.node_id):
             await self.init_matter_device()
 
     async def async_will_remove_from_hass(self) -> None:

--- a/custom_components/matter_experimental/entity.py
+++ b/custom_components/matter_experimental/entity.py
@@ -30,10 +30,8 @@ class MatterEntity(entity.Entity):
         """Return device info for device registry."""
         return {"identifiers": {(DOMAIN, self._device.node.unique_id)}}
 
-    async def async_added_to_hass(self) -> None:
-        """Handle being added to Home Assistant."""
-        await super().async_added_to_hass()
-
+    async def init_matter_device(self) -> None:
+        """Initialize and subscribe device attributes."""
         device_name = (
             device_registry.async_get(self.hass)
             .async_get(self.registry_entry.device_id)
@@ -79,6 +77,13 @@ class MatterEntity(entity.Entity):
             self._attr_available = False
 
         self._update_from_device()
+
+    async def async_added_to_hass(self) -> None:
+        """Handle being added to Home Assistant."""
+        await super().async_added_to_hass()
+
+        async with self._device.node.node_lock:
+            await self.init_matter_device()
 
     async def async_will_remove_from_hass(self) -> None:
         """Run when entity will be removed from hass."""

--- a/matter_server/client/model/node.py
+++ b/matter_server/client/model/node.py
@@ -1,5 +1,6 @@
 """Matter node."""
 from __future__ import annotations
+import asyncio
 
 from typing import TYPE_CHECKING
 
@@ -16,6 +17,7 @@ class MatterNode:
     """Matter node."""
 
     root_device: MatterDevice[device_types.RootNode]
+    node_lock = asyncio.Lock()
 
     def __init__(self, matter: Matter, node_info: dict) -> None:
         self.matter = matter

--- a/matter_server/client/model/node.py
+++ b/matter_server/client/model/node.py
@@ -17,7 +17,6 @@ class MatterNode:
     """Matter node."""
 
     root_device: MatterDevice[device_types.RootNode]
-    node_lock = asyncio.Lock()
 
     def __init__(self, matter: Matter, node_info: dict) -> None:
         self.matter = matter

--- a/matter_server/client/model/node.py
+++ b/matter_server/client/model/node.py
@@ -1,6 +1,5 @@
 """Matter node."""
 from __future__ import annotations
-import asyncio
 
 from typing import TYPE_CHECKING
 


### PR DESCRIPTION
Avoid multiple entites requesting reads and subscriptions of the same
node. Nodes seem to be overwhelmed and return a BUSY error code, which
isn't handled gracefully throughout the stack (it seems).