### PR TITLE
Add show_stored_node script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,8 +31,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-test.txt
       - name: Flake8
-        run: flake8 custom_components matter_server/client matter_server/common matter_server/server
+        run: flake8 scripts custom_components matter_server/client matter_server/common matter_server/server
       - name: Black
-        run: black --check custom_components matter_server/client matter_server/common matter_server/server
+        run: black --check scripts custom_components matter_server/client matter_server/common matter_server/server
       - name: isort
-        run: isort --check custom_components matter_server/client matter_server/common matter_server/server
+        run: isort --check scripts custom_components matter_server/client matter_server/common matter_server/server
+      - name: test show stored node script
+        run: python3 -m scripts.show_stored_node tests/fixtures/nodes/lighting-example-app.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-test.txt
+          pip install -e . -r requirements-test.txt
       - name: Flake8
         run: flake8 scripts custom_components matter_server/client matter_server/common matter_server/server
       - name: Black

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e . -r requirements-test.txt
+          pip install -e . -r requirements-test.txt homeassistant
       - name: Flake8
         run: flake8 scripts custom_components matter_server/client matter_server/common matter_server/server
       - name: Black

--- a/matter_server/client/model/device.py
+++ b/matter_server/client/model/device.py
@@ -165,3 +165,6 @@ class MatterDevice(Generic[_DEVICE_TYPE_T]):
 
         if self._on_update_listener:
             self._on_update_listener()
+
+    def __repr__(self):
+        return f"<MatterDevice {self.device_type.__name__} (N:{self.node.node_id}, E:{self.endpoint_id})>"

--- a/scripts/chip_synchronize.py
+++ b/scripts/chip_synchronize.py
@@ -1,4 +1,5 @@
 import pathlib
+
 import git
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent
@@ -6,11 +7,13 @@ REPO_ROOT = pathlib.Path(__file__).parent.parent
 CHIP_ROOT = REPO_ROOT / "../connectedhomeip"
 
 CLUSTER_OBJECTS = REPO_ROOT / "matter_server/vendor/chip/clusters/Objects.py"
-CLUSTER_OBJECTS_VERSION = REPO_ROOT / "matter_server/vendor/chip/clusters/ObjectsVersion.py"
+CLUSTER_OBJECTS_VERSION = (
+    REPO_ROOT / "matter_server/vendor/chip/clusters/ObjectsVersion.py"
+)
 
 REPLACE_IMPORT = {
     "from chip import ChipUtility\n": "from .. import ChipUtility\n",
-    "from chip.tlv import uint, float32\n": "from ..tlv import uint, float32\n"
+    "from chip.tlv import uint, float32\n": "from ..tlv import uint, float32\n",
 }
 
 
@@ -18,13 +21,17 @@ def main():
     repo = git.Repo(CHIP_ROOT)
 
     with open(CLUSTER_OBJECTS, "w") as cluster_outfile:
-        with open(CHIP_ROOT / "src/controller/python/chip/clusters/Objects.py", "r") as cluster_file:
+        with open(
+            CHIP_ROOT / "src/controller/python/chip/clusters/Objects.py", "r"
+        ) as cluster_file:
             for line in cluster_file:
                 if line in REPLACE_IMPORT.keys():
                     line = REPLACE_IMPORT[line]
                 cluster_outfile.write(line)
     with open(CLUSTER_OBJECTS_VERSION, "w") as cluster_version_outfile:
-        cluster_version_outfile.write(f"CLUSTER_OBJECT_VERSION = \"{repo.head.object.hexsha}\"")
+        cluster_version_outfile.write(
+            f'CLUSTER_OBJECT_VERSION = "{repo.head.object.hexsha}"'
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/list_unmapped_devices.py
+++ b/scripts/list_unmapped_devices.py
@@ -5,7 +5,6 @@ Run with python3 -m scripts.list_unmapped_devices
 from custom_components.matter_experimental.device_platform import DEVICE_PLATFORM
 from matter_server.vendor import device_types
 
-
 IGNORE_DEVICES = {
     device_types.AllClustersAppServerExample,
     device_types.Bridge,

--- a/scripts/show_stored_node.py
+++ b/scripts/show_stored_node.py
@@ -1,0 +1,103 @@
+"""Show mappings for given JSON."""
+
+import dataclasses
+import json
+import logging
+import os
+import pathlib
+import sys
+from unittest.mock import Mock
+
+from custom_components.matter_experimental.device_platform import DEVICE_PLATFORM
+from matter_server.client.model.device import MatterDevice
+from matter_server.client.model.node import MatterNode
+from matter_server.common import json_utils
+
+
+def resolve_input():
+    if len(sys.argv) < 2:
+        print("Pass in path to JSON file containing single node or HA storage")
+        sys.exit(1)
+
+    path = sys.argv[1]
+
+    return (pathlib.Path(os.getcwd()) / path).read_text()
+
+
+def print_node(node: MatterNode):
+    print(node)
+    first = True
+    for device in node.devices:
+        if first:
+            first = False
+        else:
+            print()
+        print_device(device)
+
+
+def print_device(device: MatterDevice):
+    created = False
+    print(f"  {device}")
+
+    for platform, devices in DEVICE_PLATFORM.items():
+        device_mappings = devices.get(device.device_type)
+
+        if device_mappings is None:
+            continue
+
+        if not isinstance(device_mappings, list):
+            device_mappings = [device_mappings]
+
+        for device_mapping in device_mappings:
+            created = True
+            print(f"    - Platform: {platform}")
+
+            for key, value in sorted(dataclasses.asdict(device_mapping).items()):
+                if value is None:
+                    continue
+                if key == "entity_cls":
+                    value = value.__name__
+
+                if key != "subscribe_attributes":
+                    print(f"      {key}: {value}")
+                    continue
+
+                print("      Subscriptions:")
+
+                for sub in value:
+                    print(f"       - {sub.__qualname__}")
+
+                # Try instantiating to ensure the device mapping doesn't crash
+                device_mapping.entity_cls(device, device_mapping)
+
+    # Do not warng on root node
+    if not created:
+        print("  ** WARNING: NOT MAPPED IN HOME ASSISTANT")
+
+
+def main():
+    raw_data = resolve_input()
+    data = json.loads(raw_data, cls=json_utils.CHIPJSONDecoder)
+
+    # This is a HA storage file. Extract nodes
+    if "key" in data and data["key"].startswith("matter_experimental_"):
+        nodes = [d for d in data["data"]["nodes"].values() if d is not None]
+    else:
+        nodes = [data]
+
+    first = True
+
+    mock_matter = Mock(adapter=Mock(logger=logging.getLogger("show_mappings")))
+
+    for node_data in nodes:
+        if first:
+            first = False
+        else:
+            print()
+            print()
+
+        print_node(MatterNode(mock_matter, node_data))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/nodes/lighting-example-app.json
+++ b/tests/fixtures/nodes/lighting-example-app.json
@@ -1,0 +1,882 @@
+{
+  "attributes": {
+    "0": {
+      "Groups": {
+        "nameSupport": 128,
+        "generatedCommandList": [0, 1, 2, 3],
+        "acceptedCommandList": [0, 1, 2, 3, 4, 5],
+        "attributeList": [0, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 4,
+        "_type": "chip.clusters.Objects.Groups"
+      },
+      "Descriptor": {
+        "deviceList": [
+          {
+            "type": 22,
+            "revision": 1,
+            "_type": "chip.clusters.Objects.Descriptor.Structs.DeviceType"
+          }
+        ],
+        "serverList": [
+          4, 29, 31, 40, 42, 43, 44, 48, 49, 50, 51, 52, 53, 54, 55, 59, 60, 62,
+          63, 64, 65
+        ],
+        "clientList": [41],
+        "partsList": [1],
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 1, 2, 3, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.Descriptor"
+      },
+      "AccessControl": {
+        "acl": [
+          {
+            "privilege": 5,
+            "authMode": 2,
+            "subjects": [1],
+            "targets": null,
+            "fabricIndex": 1,
+            "_type": "chip.clusters.Objects.AccessControl.Structs.AccessControlEntry"
+          }
+        ],
+        "extension": [],
+        "subjectsPerAccessControlEntry": 4,
+        "targetsPerAccessControlEntry": 3,
+        "accessControlEntriesPerFabric": 3,
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 1, 2, 3, 4, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.AccessControl"
+      },
+      "Basic": {
+        "dataModelRevision": 1,
+        "vendorName": "Nabu Casa",
+        "vendorID": 65521,
+        "productName": "M5STAMP Lighting App",
+        "productID": 32768,
+        "nodeLabel": "",
+        "location": "XX",
+        "hardwareVersion": 0,
+        "hardwareVersionString": "v1.0",
+        "softwareVersion": 1,
+        "softwareVersionString": "55ab764bea",
+        "manufacturingDate": "20200101",
+        "partNumber": "",
+        "productURL": "",
+        "productLabel": "",
+        "serialNumber": "",
+        "localConfigDisabled": false,
+        "reachable": true,
+        "uniqueID": "BE8F70AA40DDAE41",
+        "capabilityMinima": {
+          "caseSessionsPerFabric": 3,
+          "subscriptionsPerFabric": 65506,
+          "_type": "chip.clusters.Objects.Basic.Structs.CapabilityMinimaStruct"
+        },
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [
+          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+          65528, 65529, 65531, 65532, 65533
+        ],
+        "featureMap": 0,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.Basic"
+      },
+      "OtaSoftwareUpdateRequestor": {
+        "defaultOtaProviders": [],
+        "updatePossible": true,
+        "updateState": 0,
+        "updateStateProgress": 0,
+        "generatedCommandList": [],
+        "acceptedCommandList": [0],
+        "attributeList": [0, 1, 2, 3, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.OtaSoftwareUpdateRequestor"
+      },
+      "LocalizationConfiguration": {
+        "activeLocale": "en-US",
+        "supportedLocales": [
+          "en-US",
+          "de-DE",
+          "fr-FR",
+          "en-GB",
+          "es-ES",
+          "zh-CN",
+          "it-IT",
+          "ja-JP"
+        ],
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 1, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.LocalizationConfiguration"
+      },
+      "TimeFormatLocalization": {
+        "hourFormat": 0,
+        "activeCalendarType": 0,
+        "supportedCalendarTypes": [0, 1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 7],
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 1, 2, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.TimeFormatLocalization"
+      },
+      "GeneralCommissioning": {
+        "breadcrumb": 0,
+        "basicCommissioningInfo": {
+          "failSafeExpiryLengthSeconds": 60,
+          "_type": "chip.clusters.Objects.GeneralCommissioning.Structs.BasicCommissioningInfo"
+        },
+        "regulatoryConfig": 0,
+        "locationCapability": 0,
+        "supportsConcurrentConnection": true,
+        "generatedCommandList": [1, 3, 5],
+        "acceptedCommandList": [0, 2, 4],
+        "attributeList": [0, 1, 2, 3, 4, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 6,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.GeneralCommissioning"
+      },
+      "NetworkCommissioning": {
+        "maxNetworks": 1,
+        "networks": [
+          {
+            "networkID": {
+              "_type": "bytes",
+              "value": "TGF6eUlvVA=="
+            },
+            "connected": true,
+            "_type": "chip.clusters.Objects.NetworkCommissioning.Structs.NetworkInfo"
+          }
+        ],
+        "scanMaxTimeSeconds": 10,
+        "connectMaxTimeSeconds": 30,
+        "interfaceEnabled": true,
+        "lastNetworkingStatus": 0,
+        "lastNetworkID": {
+          "_type": "bytes",
+          "value": "TGF6eUlvVA=="
+        },
+        "lastConnectErrorValue": null,
+        "generatedCommandList": [1, 5, 7],
+        "acceptedCommandList": [0, 2, 4, 6, 8],
+        "attributeList": [
+          0, 1, 2, 3, 4, 5, 6, 7, 65528, 65529, 65531, 65532, 65533
+        ],
+        "featureMap": 1,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.NetworkCommissioning"
+      },
+      "DiagnosticLogs": {
+        "generatedCommandList": [1],
+        "acceptedCommandList": [0],
+        "attributeList": [65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.DiagnosticLogs"
+      },
+      "GeneralDiagnostics": {
+        "networkInterfaces": [
+          {
+            "name": "WIFI_AP_DEF",
+            "isOperational": true,
+            "offPremiseServicesReachableIPv4": null,
+            "offPremiseServicesReachableIPv6": null,
+            "hardwareAddress": {
+              "_type": "bytes",
+              "value": "AAAAAAAA"
+            },
+            "IPv4Addresses": [],
+            "IPv6Addresses": [],
+            "type": 1,
+            "_type": "chip.clusters.Objects.GeneralDiagnostics.Structs.NetworkInterfaceType"
+          },
+          {
+            "name": "WIFI_STA_DEF",
+            "isOperational": true,
+            "offPremiseServicesReachableIPv4": null,
+            "offPremiseServicesReachableIPv6": null,
+            "hardwareAddress": {
+              "_type": "bytes",
+              "value": "hPcDJ8rI"
+            },
+            "IPv4Addresses": [],
+            "IPv6Addresses": [],
+            "type": 1,
+            "_type": "chip.clusters.Objects.GeneralDiagnostics.Structs.NetworkInterfaceType"
+          }
+        ],
+        "rebootCount": 12,
+        "upTime": 458,
+        "totalOperationalHours": 0,
+        "bootReasons": 1,
+        "activeHardwareFaults": [],
+        "activeRadioFaults": [],
+        "activeNetworkFaults": [],
+        "testEventTriggersEnabled": false,
+        "generatedCommandList": [],
+        "acceptedCommandList": [0],
+        "attributeList": [
+          0, 1, 2, 3, 4, 5, 6, 7, 8, 65528, 65529, 65531, 65532, 65533
+        ],
+        "featureMap": 0,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.GeneralDiagnostics"
+      },
+      "SoftwareDiagnostics": {
+        "threadMetrics": [],
+        "currentHeapFree": 116140,
+        "currentHeapUsed": 138932,
+        "currentHeapHighWatermark": 153796,
+        "generatedCommandList": [],
+        "acceptedCommandList": [0],
+        "attributeList": [0, 1, 2, 3, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.SoftwareDiagnostics"
+      },
+      "ThreadNetworkDiagnostics": {
+        "TLVValue": {
+          "0": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "1": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "2": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "3": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "4": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "5": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "6": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "7": [],
+          "8": [],
+          "9": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "10": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "11": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "12": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "13": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "14": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "15": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "16": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "17": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "18": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "19": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "20": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "21": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "22": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "23": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "24": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "25": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "26": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "27": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "28": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "29": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "30": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "31": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "32": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "33": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "34": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "35": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "36": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "37": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "38": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "39": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "40": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "41": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "42": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "43": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "44": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "45": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "46": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "47": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "48": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "49": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "50": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "51": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "52": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "53": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "54": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "55": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "56": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "57": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "58": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "59": [],
+          "60": {
+            "TLVValue": null,
+            "Reason": "InteractionModelError: Failure (0x1)"
+          },
+          "61": [],
+          "62": [],
+          "65532": 15,
+          "65533": 1,
+          "65528": [],
+          "65529": [0],
+          "65531": [
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+            19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35,
+            36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52,
+            53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 65528, 65529, 65531, 65532,
+            65533
+          ]
+        },
+        "Reason": "Failed to decode field [].channel, expected type <class 'chip.tlv.uint'>, got <class 'chip.clusters.Attribute.ValueDecodeFailure'>"
+      },
+      "WiFiNetworkDiagnostics": {
+        "bssid": {
+          "_type": "bytes",
+          "value": "1iH5ZUbu"
+        },
+        "securityType": 4,
+        "wiFiVersion": 3,
+        "channelNumber": 1,
+        "rssi": -38,
+        "beaconLostCount": 0,
+        "beaconRxCount": 0,
+        "packetMulticastRxCount": 0,
+        "packetMulticastTxCount": 0,
+        "packetUnicastRxCount": 0,
+        "packetUnicastTxCount": 0,
+        "currentMaxRate": 0,
+        "overrunCount": 0,
+        "generatedCommandList": [],
+        "acceptedCommandList": [0],
+        "attributeList": [
+          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 65528, 65529, 65531, 65532,
+          65533
+        ],
+        "featureMap": 3,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.WiFiNetworkDiagnostics"
+      },
+      "EthernetNetworkDiagnostics": {
+        "PHYRate": null,
+        "fullDuplex": null,
+        "packetRxCount": 0,
+        "packetTxCount": 0,
+        "txErrCount": 0,
+        "collisionCount": 0,
+        "overrunCount": 0,
+        "carrierDetect": null,
+        "timeSinceReset": 0,
+        "generatedCommandList": [],
+        "acceptedCommandList": [0],
+        "attributeList": [
+          0, 1, 2, 3, 4, 5, 6, 7, 8, 65528, 65529, 65531, 65532, 65533
+        ],
+        "featureMap": 3,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.EthernetNetworkDiagnostics"
+      },
+      "Switch": {
+        "numberOfPositions": null,
+        "currentPosition": null,
+        "multiPressMax": null,
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.Switch"
+      },
+      "AdministratorCommissioning": {
+        "windowStatus": 0,
+        "adminFabricIndex": 0,
+        "adminVendorId": 0,
+        "generatedCommandList": [],
+        "acceptedCommandList": [0, 1, 2],
+        "attributeList": [0, 1, 2, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.AdministratorCommissioning"
+      },
+      "OperationalCredentials": {
+        "NOCs": [
+          {
+            "noc": {
+              "_type": "bytes",
+              "value": "FTABAQEkAgE3AyQTARgmBIAigScmBYAlTTo3BiQVASUR8RAYJAcBJAgBMAlBBHQsjZ/8Hpm4iqznEv0dAO03bZx8LDgqpIOpBsHeysZu8KAmI0K+p6B8FuI1h3wld1V+tIj5OHVHtrigg6Ssl043CjUBKAEYJAIBNgMEAgQBGDAEFEWrZiyeoUgEIXz4c40+Nzq9cfxHMAUUSTs2LnMMrX7nj+dns0cSq3SmK3MYMAtAoFdxyvsbLm6VekNCQ6yqJOucAcRSVY3Si4ov1alKPK9CaIPl+u5dvBWNfyEPXSLsPmzyfd2njl8WRz8e7CBiSRg="
+            },
+            "icac": {
+              "_type": "bytes",
+              "value": "FTABAQAkAgE3AyQUABgmBIAigScmBYAlTTo3BiQTARgkBwEkCAEwCUEE09c6S9xVbf3/blpXSgRAZzKXx/4KQC274cEfa2tFjdVAJYJUvM/8PMurRHEroPpA3FXpJ8/hfabkNvHGi2l8tTcKNQEpARgkAmAwBBRJOzYucwytfueP52ezRxKrdKYrczAFFBf0ohq+KHQlEVBIMgEeZCBPR72hGDALQNwd63sOjWKYhjlvDJmcPtIzljSsXlQ10vFrB5j9V9CdiZHDfy537G39fo0RJmpU63EGXYEtXVrEfSMiafshKVcY"
+            },
+            "fabricIndex": 1,
+            "_type": "chip.clusters.Objects.OperationalCredentials.Structs.NOCStruct"
+          }
+        ],
+        "fabrics": [
+          {
+            "rootPublicKey": {
+              "_type": "bytes",
+              "value": "BBGg+O3i3tDVYryXkUmEXk1fnSMHN06+poGIfZODdvbZW4JvxHnrQVAxvZWIE6poLa0sKA8X8A7jmJsVFMUqLFM="
+            },
+            "vendorId": 35328,
+            "fabricId": 1,
+            "nodeId": 4337,
+            "label": "",
+            "fabricIndex": 1,
+            "_type": "chip.clusters.Objects.OperationalCredentials.Structs.FabricDescriptor"
+          }
+        ],
+        "supportedFabrics": 5,
+        "commissionedFabrics": 1,
+        "trustedRootCertificates": [
+          {
+            "_type": "bytes",
+            "value": "FTABAQAkAgE3AyQUABgmBIAigScmBYAlTTo3BiQUABgkBwEkCAEwCUEEEaD47eLe0NVivJeRSYReTV+dIwc3Tr6mgYh9k4N29tlbgm/EeetBUDG9lYgTqmgtrSwoDxfwDuOYmxUUxSosUzcKNQEpARgkAmAwBBQX9KIavih0JRFQSDIBHmQgT0e9oTAFFBf0ohq+KHQlEVBIMgEeZCBPR72hGDALQO3xFiF2cEXl+/kk0CQfedzHJxSJiziHEjWCMjIj7SVlDVx4CpvNYHnheq+9vJFgcL8JQhAEdz6p6C3INBDL7dsY"
+          }
+        ],
+        "currentFabricIndex": 1,
+        "generatedCommandList": [1, 3, 5, 8],
+        "acceptedCommandList": [0, 2, 4, 6, 7, 9, 10, 11],
+        "attributeList": [0, 1, 2, 3, 4, 5, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.OperationalCredentials"
+      },
+      "GroupKeyManagement": {
+        "groupKeyMap": [],
+        "groupTable": [],
+        "maxGroupsPerFabric": 3,
+        "maxGroupKeysPerFabric": 2,
+        "generatedCommandList": [2, 5],
+        "acceptedCommandList": [0, 1, 3, 4],
+        "attributeList": [0, 1, 2, 3, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.GroupKeyManagement"
+      },
+      "FixedLabel": {
+        "labelList": [
+          {
+            "label": "room",
+            "value": "bedroom 2",
+            "_type": "chip.clusters.Objects.FixedLabel.Structs.LabelStruct"
+          },
+          {
+            "label": "orientation",
+            "value": "North",
+            "_type": "chip.clusters.Objects.FixedLabel.Structs.LabelStruct"
+          },
+          {
+            "label": "floor",
+            "value": "2",
+            "_type": "chip.clusters.Objects.FixedLabel.Structs.LabelStruct"
+          },
+          {
+            "label": "direction",
+            "value": "up",
+            "_type": "chip.clusters.Objects.FixedLabel.Structs.LabelStruct"
+          }
+        ],
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.FixedLabel"
+      },
+      "UserLabel": {
+        "labelList": [],
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.UserLabel"
+      }
+    },
+    "1": {
+      "Identify": {
+        "identifyTime": 0,
+        "identifyType": 0,
+        "generatedCommandList": [],
+        "acceptedCommandList": [0, 64],
+        "attributeList": [0, 1, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 4,
+        "_type": "chip.clusters.Objects.Identify"
+      },
+      "Groups": {
+        "nameSupport": 128,
+        "generatedCommandList": [0, 1, 2, 3],
+        "acceptedCommandList": [0, 1, 2, 3, 4, 5],
+        "attributeList": [0, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 4,
+        "_type": "chip.clusters.Objects.Groups"
+      },
+      "OnOff": {
+        "onOff": false,
+        "globalSceneControl": true,
+        "onTime": 0,
+        "offWaitTime": 0,
+        "startUpOnOff": null,
+        "generatedCommandList": [],
+        "acceptedCommandList": [0, 1, 2, 64, 65, 66],
+        "attributeList": [
+          0, 16384, 16385, 16386, 16387, 65528, 65529, 65531, 65532, 65533
+        ],
+        "featureMap": 1,
+        "clusterRevision": 4,
+        "_type": "chip.clusters.Objects.OnOff"
+      },
+      "LevelControl": {
+        "currentLevel": 254,
+        "remainingTime": 0,
+        "minLevel": 0,
+        "maxLevel": 254,
+        "currentFrequency": 0,
+        "minFrequency": 0,
+        "maxFrequency": 0,
+        "options": 0,
+        "onOffTransitionTime": 0,
+        "onLevel": null,
+        "onTransitionTime": 0,
+        "offTransitionTime": 0,
+        "defaultMoveRate": 50,
+        "startUpCurrentLevel": null,
+        "generatedCommandList": [],
+        "acceptedCommandList": [0, 1, 2, 3, 4, 5, 6, 7],
+        "attributeList": [
+          0, 1, 2, 3, 4, 5, 6, 15, 16, 17, 18, 19, 20, 16384, 65528, 65529,
+          65531, 65532, 65533
+        ],
+        "featureMap": 3,
+        "clusterRevision": 5,
+        "_type": "chip.clusters.Objects.LevelControl"
+      },
+      "Descriptor": {
+        "deviceList": [
+          {
+            "type": 257,
+            "revision": 1,
+            "_type": "chip.clusters.Objects.Descriptor.Structs.DeviceType"
+          }
+        ],
+        "serverList": [3, 4, 6, 8, 29, 768, 1030],
+        "clientList": [],
+        "partsList": [],
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 1, 2, 3, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.Descriptor"
+      },
+      "ColorControl": {
+        "currentHue": 0,
+        "currentSaturation": 0,
+        "remainingTime": 0,
+        "currentX": 24939,
+        "currentY": 24701,
+        "driftCompensation": null,
+        "compensationText": null,
+        "colorTemperature": 0,
+        "colorMode": 2,
+        "options": 0,
+        "numberOfPrimaries": 0,
+        "primary1X": null,
+        "primary1Y": null,
+        "primary1Intensity": null,
+        "primary2X": null,
+        "primary2Y": null,
+        "primary2Intensity": null,
+        "primary3X": null,
+        "primary3Y": null,
+        "primary3Intensity": null,
+        "primary4X": null,
+        "primary4Y": null,
+        "primary4Intensity": null,
+        "primary5X": null,
+        "primary5Y": null,
+        "primary5Intensity": null,
+        "primary6X": null,
+        "primary6Y": null,
+        "primary6Intensity": null,
+        "whitePointX": null,
+        "whitePointY": null,
+        "colorPointRX": null,
+        "colorPointRY": null,
+        "colorPointRIntensity": null,
+        "colorPointGX": null,
+        "colorPointGY": null,
+        "colorPointGIntensity": null,
+        "colorPointBX": null,
+        "colorPointBY": null,
+        "colorPointBIntensity": null,
+        "enhancedCurrentHue": 0,
+        "enhancedColorMode": 2,
+        "colorLoopActive": 0,
+        "colorLoopDirection": 0,
+        "colorLoopTime": 25,
+        "colorLoopStartEnhancedHue": 8960,
+        "colorLoopStoredEnhancedHue": 0,
+        "colorCapabilities": 0,
+        "colorTempPhysicalMinMireds": 0,
+        "colorTempPhysicalMaxMireds": 65279,
+        "coupleColorTempToLevelMinMireds": 0,
+        "startUpColorTemperatureMireds": 0,
+        "generatedCommandList": [],
+        "acceptedCommandList": [
+          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 64, 65, 66, 67, 68, 71, 75, 76
+        ],
+        "attributeList": [
+          0, 1, 2, 3, 4, 7, 8, 15, 16, 16384, 16385, 16386, 16387, 16388, 16389,
+          16390, 16394, 16395, 16396, 16397, 16400, 65528, 65529, 65531, 65532,
+          65533
+        ],
+        "featureMap": 31,
+        "clusterRevision": 5,
+        "_type": "chip.clusters.Objects.ColorControl"
+      },
+      "OccupancySensing": {
+        "occupancy": 0,
+        "occupancySensorType": 0,
+        "occupancySensorTypeBitmap": 1,
+        "pirOccupiedToUnoccupiedDelay": null,
+        "pirUnoccupiedToOccupiedDelay": null,
+        "pirUnoccupiedToOccupiedThreshold": null,
+        "ultrasonicOccupiedToUnoccupiedDelay": null,
+        "ultrasonicUnoccupiedToOccupiedDelay": null,
+        "ultrasonicUnoccupiedToOccupiedThreshold": null,
+        "physicalContactOccupiedToUnoccupiedDelay": null,
+        "physicalContactUnoccupiedToOccupiedDelay": null,
+        "physicalContactUnoccupiedToOccupiedThreshold": null,
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 1, 2, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 3,
+        "_type": "chip.clusters.Objects.OccupancySensing"
+      }
+    }
+  },
+  "events": [
+    {
+      "Header": {
+        "EndpointId": 0,
+        "ClusterId": 40,
+        "EventId": 0,
+        "EventNumber": 262144,
+        "Priority": 2,
+        "Timestamp": 2019,
+        "TimestampType": 0
+      },
+      "Status": 0,
+      "Data": {
+        "softwareVersion": 1,
+        "_type": "chip.clusters.Objects.Basic.Events.StartUp"
+      }
+    },
+    {
+      "Header": {
+        "EndpointId": 0,
+        "ClusterId": 51,
+        "EventId": 3,
+        "EventNumber": 262145,
+        "Priority": 2,
+        "Timestamp": 2020,
+        "TimestampType": 0
+      },
+      "Status": 0,
+      "Data": {
+        "bootReason": 1,
+        "_type": "chip.clusters.Objects.GeneralDiagnostics.Events.BootReason"
+      }
+    },
+    {
+      "Header": {
+        "EndpointId": 0,
+        "ClusterId": 54,
+        "EventId": 2,
+        "EventNumber": 262146,
+        "Priority": 1,
+        "Timestamp": 2216,
+        "TimestampType": 0
+      },
+      "Status": 0,
+      "Data": {
+        "connectionStatus": 0,
+        "_type": "chip.clusters.Objects.WiFiNetworkDiagnostics.Events.ConnectionStatus"
+      }
+    }
+  ],
+  "node_id": 4337
+}


### PR DESCRIPTION
Add a script to parse a node dump or a matter_experimental custom integration storage file and print out all nodes and the entities they map to.

Added the output of the lighting example app as a fixture and run CI against it. This can be expanded to a lot more entities in the future.

```
❯ python3 -m scripts.show_stored_node tests/fixtures/nodes/lighting-example-app.json
<MatterNode 4337>
  <MatterDevice DimmableLight (N:4337, E:1)>
    - Platform: light
      entity_cls: MatterLight
      Subscriptions:
       - OnOff.Attributes.OnOff
       - LevelControl.Attributes.CurrentLevel
```