### PR TITLE
Add tests for sensors

### DIFF
--- a/tests/fixtures/nodes/_fake_template
+++ b/tests/fixtures/nodes/_fake_template
@@ -1,0 +1,78 @@
+{
+  "attributes": {
+    "0": {
+      "Descriptor": {
+        "deviceList": [
+          {
+            "type": 22,
+            "revision": 1,
+            "_type": "chip.clusters.Objects.Descriptor.Structs.DeviceType"
+          }
+        ],
+        "serverList": [29, 37, 40, 48, 49, 50, 51, 60, 62, 64, 65],
+        "clientList": [],
+        "partsList": [9, 10],
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 1, 2, 3, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.Descriptor"
+      },
+      "Basic": {
+        "dataModelRevision": 0,
+        "vendorName": "Mock Vendor",
+        "vendorID": 1234,
+        "productName": "Mock Device",
+        "productID": 2,
+        "nodeLabel": "My Mock Device",
+        "location": "nl",
+        "hardwareVersion": 123,
+        "hardwareVersionString": "TEST_VERSION",
+        "softwareVersion": 12345,
+        "softwareVersionString": "123.4.5",
+        "manufacturingDate": null,
+        "partNumber": null,
+        "productURL": null,
+        "productLabel": null,
+        "serialNumber": null,
+        "localConfigDisabled": null,
+        "reachable": null,
+        "uniqueID": "mock-device-id",
+        "capabilityMinima": null,
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [
+          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 18, 65528, 65529, 65531, 65532,
+          65533
+        ],
+        "featureMap": 0,
+        "clusterRevision": 3,
+        "_type": "chip.clusters.Objects.Basic"
+      }
+    },
+    "9": {
+      "Descriptor": {
+        "deviceList": [
+          {
+            "type": DEVICE_TYPE,
+            "revision": 1,
+            "_type": "chip.clusters.Objects.Descriptor.Structs.DeviceType"
+          }
+        ],
+        "serverList": [6, 29, 57, 768, 8, 40],
+        "clientList": [],
+        "partsList": [],
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 1, 2, 3, 65528, 65529, 65531, 65533],
+        "featureMap": null,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.Descriptor"
+      },
+      CLUSTER_DEF
+    }
+  },
+  "events": [],
+  "node_id": 4338
+}

--- a/tests/fixtures/nodes/fake-temperature-sensor.json
+++ b/tests/fixtures/nodes/fake-temperature-sensor.json
@@ -1,0 +1,89 @@
+{
+  "attributes": {
+    "0": {
+      "Descriptor": {
+        "deviceList": [
+          {
+            "type": 22,
+            "revision": 1,
+            "_type": "chip.clusters.Objects.Descriptor.Structs.DeviceType"
+          }
+        ],
+        "serverList": [29, 37, 40, 48, 49, 50, 51, 60, 62, 64, 65],
+        "clientList": [],
+        "partsList": [9, 10],
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 1, 2, 3, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.Descriptor"
+      },
+      "Basic": {
+        "dataModelRevision": 0,
+        "vendorName": "Mock Vendor",
+        "vendorID": 1234,
+        "productName": "Mock Device",
+        "productID": 2,
+        "nodeLabel": "My Mock Device",
+        "location": "nl",
+        "hardwareVersion": 123,
+        "hardwareVersionString": "TEST_VERSION",
+        "softwareVersion": 12345,
+        "softwareVersionString": "123.4.5",
+        "manufacturingDate": null,
+        "partNumber": null,
+        "productURL": null,
+        "productLabel": null,
+        "serialNumber": null,
+        "localConfigDisabled": null,
+        "reachable": null,
+        "uniqueID": "mock-device-id",
+        "capabilityMinima": null,
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [
+          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 18, 65528, 65529, 65531, 65532,
+          65533
+        ],
+        "featureMap": 0,
+        "clusterRevision": 3,
+        "_type": "chip.clusters.Objects.Basic"
+      }
+    },
+    "9": {
+      "Descriptor": {
+        "deviceList": [
+          {
+            "type": 770,
+            "revision": 1,
+            "_type": "chip.clusters.Objects.Descriptor.Structs.DeviceType"
+          }
+        ],
+        "serverList": [6, 29, 57, 768, 8, 40],
+        "clientList": [],
+        "partsList": [],
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 1, 2, 3, 65528, 65529, 65531, 65533],
+        "featureMap": null,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.Descriptor"
+      },
+      "TemperatureMeasurement": {
+        "measuredValue": 2100,
+        "minMeasuredValue": null,
+        "maxMeasuredValue": null,
+        "tolerance": 0,
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 1, 2, 3, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 4,
+        "_type": "chip.clusters.Objects.TemperatureMeasurement"
+      }
+    }
+  },
+  "events": [],
+  "node_id": 4338
+}

--- a/tests/fixtures/nodes/fake_flow_sensor.json
+++ b/tests/fixtures/nodes/fake_flow_sensor.json
@@ -1,0 +1,89 @@
+{
+  "attributes": {
+    "0": {
+      "Descriptor": {
+        "deviceList": [
+          {
+            "type": 22,
+            "revision": 1,
+            "_type": "chip.clusters.Objects.Descriptor.Structs.DeviceType"
+          }
+        ],
+        "serverList": [29, 37, 40, 48, 49, 50, 51, 60, 62, 64, 65],
+        "clientList": [],
+        "partsList": [9, 10],
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 1, 2, 3, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.Descriptor"
+      },
+      "Basic": {
+        "dataModelRevision": 0,
+        "vendorName": "Mock Vendor",
+        "vendorID": 1234,
+        "productName": "Mock Device",
+        "productID": 2,
+        "nodeLabel": "My Mock Device",
+        "location": "nl",
+        "hardwareVersion": 123,
+        "hardwareVersionString": "TEST_VERSION",
+        "softwareVersion": 12345,
+        "softwareVersionString": "123.4.5",
+        "manufacturingDate": null,
+        "partNumber": null,
+        "productURL": null,
+        "productLabel": null,
+        "serialNumber": null,
+        "localConfigDisabled": null,
+        "reachable": null,
+        "uniqueID": "mock-device-id",
+        "capabilityMinima": null,
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [
+          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 18, 65528, 65529, 65531, 65532,
+          65533
+        ],
+        "featureMap": 0,
+        "clusterRevision": 3,
+        "_type": "chip.clusters.Objects.Basic"
+      }
+    },
+    "9": {
+      "Descriptor": {
+        "deviceList": [
+          {
+            "type": 774,
+            "revision": 1,
+            "_type": "chip.clusters.Objects.Descriptor.Structs.DeviceType"
+          }
+        ],
+        "serverList": [6, 29, 57, 768, 8, 40],
+        "clientList": [],
+        "partsList": [],
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 1, 2, 3, 65528, 65529, 65531, 65533],
+        "featureMap": null,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.Descriptor"
+      },
+      "FlowMeasurement": {
+        "measuredValue": 2,
+        "minMeasuredValue": 0,
+        "maxMeasuredValue": 0,
+        "tolerance": 0,
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 1, 2, 3, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 3,
+        "_type": "chip.clusters.Objects.FlowMeasurement"
+      }
+    }
+  },
+  "events": [],
+  "node_id": 4338
+}

--- a/tests/fixtures/nodes/fake_humidity_sensor.json
+++ b/tests/fixtures/nodes/fake_humidity_sensor.json
@@ -1,0 +1,89 @@
+{
+  "attributes": {
+    "0": {
+      "Descriptor": {
+        "deviceList": [
+          {
+            "type": 22,
+            "revision": 1,
+            "_type": "chip.clusters.Objects.Descriptor.Structs.DeviceType"
+          }
+        ],
+        "serverList": [29, 37, 40, 48, 49, 50, 51, 60, 62, 64, 65],
+        "clientList": [],
+        "partsList": [9, 10],
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 1, 2, 3, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.Descriptor"
+      },
+      "Basic": {
+        "dataModelRevision": 0,
+        "vendorName": "Mock Vendor",
+        "vendorID": 1234,
+        "productName": "Mock Device",
+        "productID": 2,
+        "nodeLabel": "My Mock Device",
+        "location": "nl",
+        "hardwareVersion": 123,
+        "hardwareVersionString": "TEST_VERSION",
+        "softwareVersion": 12345,
+        "softwareVersionString": "123.4.5",
+        "manufacturingDate": null,
+        "partNumber": null,
+        "productURL": null,
+        "productLabel": null,
+        "serialNumber": null,
+        "localConfigDisabled": null,
+        "reachable": null,
+        "uniqueID": "mock-device-id",
+        "capabilityMinima": null,
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [
+          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 18, 65528, 65529, 65531, 65532,
+          65533
+        ],
+        "featureMap": 0,
+        "clusterRevision": 3,
+        "_type": "chip.clusters.Objects.Basic"
+      }
+    },
+    "9": {
+      "Descriptor": {
+        "deviceList": [
+          {
+            "type": 775,
+            "revision": 1,
+            "_type": "chip.clusters.Objects.Descriptor.Structs.DeviceType"
+          }
+        ],
+        "serverList": [6, 29, 57, 768, 8, 40],
+        "clientList": [],
+        "partsList": [],
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 1, 2, 3, 65528, 65529, 65531, 65533],
+        "featureMap": null,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.Descriptor"
+      },
+      "RelativeHumidityMeasurement": {
+        "measuredValue": 3000,
+        "minMeasuredValue": 0,
+        "maxMeasuredValue": 10000,
+        "tolerance": 0,
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 1, 2, 3, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 3,
+        "_type": "chip.clusters.Objects.RelativeHumidityMeasurement"
+      }
+    }
+  },
+  "events": [],
+  "node_id": 4338
+}

--- a/tests/fixtures/nodes/fake_light_sensor.json
+++ b/tests/fixtures/nodes/fake_light_sensor.json
@@ -1,0 +1,90 @@
+{
+  "attributes": {
+    "0": {
+      "Descriptor": {
+        "deviceList": [
+          {
+            "type": 22,
+            "revision": 1,
+            "_type": "chip.clusters.Objects.Descriptor.Structs.DeviceType"
+          }
+        ],
+        "serverList": [29, 37, 40, 48, 49, 50, 51, 60, 62, 64, 65],
+        "clientList": [],
+        "partsList": [9, 10],
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 1, 2, 3, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.Descriptor"
+      },
+      "Basic": {
+        "dataModelRevision": 0,
+        "vendorName": "Mock Vendor",
+        "vendorID": 1234,
+        "productName": "Mock Device",
+        "productID": 2,
+        "nodeLabel": "My Mock Device",
+        "location": "nl",
+        "hardwareVersion": 123,
+        "hardwareVersionString": "TEST_VERSION",
+        "softwareVersion": 12345,
+        "softwareVersionString": "123.4.5",
+        "manufacturingDate": null,
+        "partNumber": null,
+        "productURL": null,
+        "productLabel": null,
+        "serialNumber": null,
+        "localConfigDisabled": null,
+        "reachable": null,
+        "uniqueID": "mock-device-id",
+        "capabilityMinima": null,
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [
+          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 18, 65528, 65529, 65531, 65532,
+          65533
+        ],
+        "featureMap": 0,
+        "clusterRevision": 3,
+        "_type": "chip.clusters.Objects.Basic"
+      }
+    },
+    "9": {
+      "Descriptor": {
+        "deviceList": [
+          {
+            "type": 262,
+            "revision": 1,
+            "_type": "chip.clusters.Objects.Descriptor.Structs.DeviceType"
+          }
+        ],
+        "serverList": [6, 29, 57, 768, 8, 40],
+        "clientList": [],
+        "partsList": [],
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 1, 2, 3, 65528, 65529, 65531, 65533],
+        "featureMap": null,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.Descriptor"
+      },
+      "IlluminanceMeasurement": {
+        "measuredValue": 1000,
+        "minMeasuredValue": 1,
+        "maxMeasuredValue": 65534,
+        "tolerance": 0,
+        "lightSensorType": null,
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 1, 2, 3, 4, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 3,
+        "_type": "chip.clusters.Objects.IlluminanceMeasurement"
+      }
+    }
+  },
+  "events": [],
+  "node_id": 4338
+}

--- a/tests/fixtures/nodes/fake_pressure_sensor.json
+++ b/tests/fixtures/nodes/fake_pressure_sensor.json
@@ -1,0 +1,94 @@
+{
+  "attributes": {
+    "0": {
+      "Descriptor": {
+        "deviceList": [
+          {
+            "type": 22,
+            "revision": 1,
+            "_type": "chip.clusters.Objects.Descriptor.Structs.DeviceType"
+          }
+        ],
+        "serverList": [29, 37, 40, 48, 49, 50, 51, 60, 62, 64, 65],
+        "clientList": [],
+        "partsList": [9, 10],
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 1, 2, 3, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.Descriptor"
+      },
+      "Basic": {
+        "dataModelRevision": 0,
+        "vendorName": "Mock Vendor",
+        "vendorID": 1234,
+        "productName": "Mock Device",
+        "productID": 2,
+        "nodeLabel": "My Mock Device",
+        "location": "nl",
+        "hardwareVersion": 123,
+        "hardwareVersionString": "TEST_VERSION",
+        "softwareVersion": 12345,
+        "softwareVersionString": "123.4.5",
+        "manufacturingDate": null,
+        "partNumber": null,
+        "productURL": null,
+        "productLabel": null,
+        "serialNumber": null,
+        "localConfigDisabled": null,
+        "reachable": null,
+        "uniqueID": "mock-device-id",
+        "capabilityMinima": null,
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [
+          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 18, 65528, 65529, 65531, 65532,
+          65533
+        ],
+        "featureMap": 0,
+        "clusterRevision": 3,
+        "_type": "chip.clusters.Objects.Basic"
+      }
+    },
+    "9": {
+      "Descriptor": {
+        "deviceList": [
+          {
+            "type": 773,
+            "revision": 1,
+            "_type": "chip.clusters.Objects.Descriptor.Structs.DeviceType"
+          }
+        ],
+        "serverList": [6, 29, 57, 768, 8, 40],
+        "clientList": [],
+        "partsList": [],
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 1, 2, 3, 65528, 65529, 65531, 65533],
+        "featureMap": null,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.Descriptor"
+      },
+      "PressureMeasurement": {
+        "measuredValue": 0,
+        "minMeasuredValue": 0,
+        "maxMeasuredValue": 0,
+        "tolerance": null,
+        "scaledValue": null,
+        "minScaledValue": null,
+        "maxScaledValue": null,
+        "scaledTolerance": null,
+        "scale": null,
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 1, 2, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 3,
+        "_type": "chip.clusters.Objects.PressureMeasurement"
+      }
+    }
+  },
+  "events": [],
+  "node_id": 4338
+}

--- a/tests/fixtures/nodes_in_ha/fake-temperature-sensor.json
+++ b/tests/fixtures/nodes_in_ha/fake-temperature-sensor.json
@@ -1,0 +1,24 @@
+{
+  "is_bridge": false,
+  "node_devices": [
+    {
+      "device_type_instances": [
+        {
+          "type": "TemperatureSensor",
+          "platforms": ["sensor"],
+          "entities": [
+            {
+              "entity_id": "sensor.matter_experimental_1234_mock_device_id_9_770",
+              "state": "21.0",
+              "attributes": {
+                "device_class": "temperature",
+                "state_class": "measurement",
+                "unit_of_measurement": "°C"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/nodes_in_ha/fake_flow_sensor.json
+++ b/tests/fixtures/nodes_in_ha/fake_flow_sensor.json
@@ -1,0 +1,23 @@
+{
+  "is_bridge": false,
+  "node_devices": [
+    {
+      "device_type_instances": [
+        {
+          "type": "FlowSensor",
+          "platforms": ["sensor"],
+          "entities": [
+            {
+              "entity_id": "sensor.matter_experimental_1234_mock_device_id_9_774",
+              "state": "0.2",
+              "attributes": {
+                "state_class": "measurement",
+                "unit_of_measurement": "m³/h"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/nodes_in_ha/fake_humidity_sensor.json
+++ b/tests/fixtures/nodes_in_ha/fake_humidity_sensor.json
@@ -1,0 +1,24 @@
+{
+  "is_bridge": false,
+  "node_devices": [
+    {
+      "device_type_instances": [
+        {
+          "type": "HumiditySensor",
+          "platforms": ["sensor"],
+          "entities": [
+            {
+              "entity_id": "sensor.matter_experimental_1234_mock_device_id_9_775",
+              "state": "30.0",
+              "attributes": {
+                "device_class": "humidity",
+                "state_class": "measurement",
+                "unit_of_measurement": "%"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/nodes_in_ha/fake_light_sensor.json
+++ b/tests/fixtures/nodes_in_ha/fake_light_sensor.json
@@ -1,0 +1,24 @@
+{
+  "is_bridge": false,
+  "node_devices": [
+    {
+      "device_type_instances": [
+        {
+          "type": "LightSensor",
+          "platforms": ["sensor"],
+          "entities": [
+            {
+              "entity_id": "sensor.matter_experimental_1234_mock_device_id_9_262",
+              "state": "1.3",
+              "attributes": {
+                "device_class": "illuminance",
+                "state_class": "measurement",
+                "unit_of_measurement": "lx"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/nodes_in_ha/fake_pressure_sensor.json
+++ b/tests/fixtures/nodes_in_ha/fake_pressure_sensor.json
@@ -1,0 +1,24 @@
+{
+  "is_bridge": false,
+  "node_devices": [
+    {
+      "device_type_instances": [
+        {
+          "type": "PressureSensor",
+          "platforms": ["sensor"],
+          "entities": [
+            {
+              "entity_id": "sensor.matter_experimental_1234_mock_device_id_9_773",
+              "state": "0.0",
+              "attributes": {
+                "device_class": "pressure",
+                "state_class": "measurement",
+                "unit_of_measurement": "kPa"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/matter_experimental/test_mapping.py
+++ b/tests/matter_experimental/test_mapping.py
@@ -22,7 +22,10 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 
-@pytest.mark.parametrize("node_fixture", NODE_FIXTURES_ROOT.iterdir())
+@pytest.mark.parametrize(
+    "node_fixture",
+    [fix for fix in NODE_FIXTURES_ROOT.iterdir() if not fix.name.startswith("_")],
+)
 async def test_fixture(hass: HomeAssistant, hass_storage, node_fixture):
     node = await setup_integration_with_node_fixture(
         hass, hass_storage, node_fixture.name.rpartition(".")[0]


### PR DESCRIPTION
Add fake fixtures (not from real devices) for sensors and mappings to verify they create the correct entities in HA. Cluster info based on a dump from the all clusters firmware.