### PR TITLE
Allow toggling advanced lights

### DIFF
--- a/custom_components/matter_experimental/light.py
+++ b/custom_components/matter_experimental/light.py
@@ -136,4 +136,20 @@ DEVICE_ENTITY: dict[
             clusters.LevelControl.Attributes.CurrentLevel,
         ),
     ),
+    device_types.ColorTemperatureLight: MatterLightEntityDescriptionFactory(
+        key=device_types.ColorTemperatureLight,
+        subscribe_attributes=(
+            clusters.OnOff.Attributes.OnOff,
+            clusters.LevelControl.Attributes.CurrentLevel,
+            clusters.ColorControl,
+        ),
+    ),
+    device_types.ExtendedColorLight: MatterLightEntityDescriptionFactory(
+        key=device_types.ExtendedColorLight,
+        subscribe_attributes=(
+            clusters.OnOff.Attributes.OnOff,
+            clusters.LevelControl.Attributes.CurrentLevel,
+            clusters.ColorControl,
+        ),
+    ),
 }

--- a/tests/fixtures/nodes/fake_color_temperature_light.json
+++ b/tests/fixtures/nodes/fake_color_temperature_light.json
@@ -1,0 +1,117 @@
+{
+  "attributes": {
+    "0": {
+      "Descriptor": {
+        "deviceList": [
+          {
+            "type": 22,
+            "revision": 1,
+            "_type": "chip.clusters.Objects.Descriptor.Structs.DeviceType"
+          }
+        ],
+        "serverList": [29, 37, 40, 48, 49, 50, 51, 60, 62, 64, 65],
+        "clientList": [],
+        "partsList": [9, 10],
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 1, 2, 3, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.Descriptor"
+      },
+      "Basic": {
+        "dataModelRevision": 0,
+        "vendorName": "Mock Vendor",
+        "vendorID": 1234,
+        "productName": "Mock Device",
+        "productID": 2,
+        "nodeLabel": "My Mock Device",
+        "location": "nl",
+        "hardwareVersion": 123,
+        "hardwareVersionString": "TEST_VERSION",
+        "softwareVersion": 12345,
+        "softwareVersionString": "123.4.5",
+        "manufacturingDate": null,
+        "partNumber": null,
+        "productURL": null,
+        "productLabel": null,
+        "serialNumber": null,
+        "localConfigDisabled": null,
+        "reachable": null,
+        "uniqueID": "mock-device-id",
+        "capabilityMinima": null,
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [
+          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 18, 65528, 65529, 65531, 65532,
+          65533
+        ],
+        "featureMap": 0,
+        "clusterRevision": 3,
+        "_type": "chip.clusters.Objects.Basic"
+      }
+    },
+    "9": {
+      "Descriptor": {
+        "deviceList": [
+          {
+            "type": 268,
+            "revision": 1,
+            "_type": "chip.clusters.Objects.Descriptor.Structs.DeviceType"
+          }
+        ],
+        "serverList": [6, 29, 57, 768, 8, 40],
+        "clientList": [],
+        "partsList": [],
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 1, 2, 3, 65528, 65529, 65531, 65533],
+        "featureMap": null,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.Descriptor"
+      },
+      "OnOff": {
+        "onOff": true,
+        "globalSceneControl": true,
+        "onTime": 0,
+        "offWaitTime": 0,
+        "startUpOnOff": null,
+        "generatedCommandList": [],
+        "acceptedCommandList": [0, 1, 2, 64, 65, 66],
+        "attributeList": [
+          0, 16384, 16385, 16386, 16387, 65528, 65529, 65531, 65532, 65533
+        ],
+        "featureMap": 1,
+        "clusterRevision": 4,
+        "_type": "chip.clusters.Objects.OnOff"
+      },
+      "LevelControl": {
+        "currentLevel": 4,
+        "remainingTime": 0,
+        "minLevel": 1,
+        "maxLevel": 254,
+        "currentFrequency": 0,
+        "minFrequency": 0,
+        "maxFrequency": 0,
+        "options": 0,
+        "onOffTransitionTime": 0,
+        "onLevel": null,
+        "onTransitionTime": 0,
+        "offTransitionTime": 0,
+        "defaultMoveRate": 50,
+        "startUpCurrentLevel": null,
+        "generatedCommandList": [],
+        "acceptedCommandList": [0, 1, 2, 3, 4, 5, 6, 7],
+        "attributeList": [
+          0, 1, 2, 3, 4, 5, 6, 15, 16, 17, 18, 19, 20, 16384, 65528, 65529,
+          65531, 65532, 65533
+        ],
+        "featureMap": 3,
+        "clusterRevision": 5,
+        "_type": "chip.clusters.Objects.LevelControl"
+      }
+    }
+  },
+  "events": [],
+  "node_id": 4338
+}

--- a/tests/fixtures/nodes/fake_extended_color_light.json
+++ b/tests/fixtures/nodes/fake_extended_color_light.json
@@ -1,0 +1,117 @@
+{
+  "attributes": {
+    "0": {
+      "Descriptor": {
+        "deviceList": [
+          {
+            "type": 22,
+            "revision": 1,
+            "_type": "chip.clusters.Objects.Descriptor.Structs.DeviceType"
+          }
+        ],
+        "serverList": [29, 37, 40, 48, 49, 50, 51, 60, 62, 64, 65],
+        "clientList": [],
+        "partsList": [9, 10],
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 1, 2, 3, 65528, 65529, 65531, 65532, 65533],
+        "featureMap": 0,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.Descriptor"
+      },
+      "Basic": {
+        "dataModelRevision": 0,
+        "vendorName": "Mock Vendor",
+        "vendorID": 1234,
+        "productName": "Mock Device",
+        "productID": 2,
+        "nodeLabel": "My Mock Device",
+        "location": "nl",
+        "hardwareVersion": 123,
+        "hardwareVersionString": "TEST_VERSION",
+        "softwareVersion": 12345,
+        "softwareVersionString": "123.4.5",
+        "manufacturingDate": null,
+        "partNumber": null,
+        "productURL": null,
+        "productLabel": null,
+        "serialNumber": null,
+        "localConfigDisabled": null,
+        "reachable": null,
+        "uniqueID": "mock-device-id",
+        "capabilityMinima": null,
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [
+          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 18, 65528, 65529, 65531, 65532,
+          65533
+        ],
+        "featureMap": 0,
+        "clusterRevision": 3,
+        "_type": "chip.clusters.Objects.Basic"
+      }
+    },
+    "9": {
+      "Descriptor": {
+        "deviceList": [
+          {
+            "type": 269,
+            "revision": 1,
+            "_type": "chip.clusters.Objects.Descriptor.Structs.DeviceType"
+          }
+        ],
+        "serverList": [6, 29, 57, 768, 8, 40],
+        "clientList": [],
+        "partsList": [],
+        "generatedCommandList": [],
+        "acceptedCommandList": [],
+        "attributeList": [0, 1, 2, 3, 65528, 65529, 65531, 65533],
+        "featureMap": null,
+        "clusterRevision": 1,
+        "_type": "chip.clusters.Objects.Descriptor"
+      },
+      "OnOff": {
+        "onOff": true,
+        "globalSceneControl": true,
+        "onTime": 0,
+        "offWaitTime": 0,
+        "startUpOnOff": null,
+        "generatedCommandList": [],
+        "acceptedCommandList": [0, 1, 2, 64, 65, 66],
+        "attributeList": [
+          0, 16384, 16385, 16386, 16387, 65528, 65529, 65531, 65532, 65533
+        ],
+        "featureMap": 1,
+        "clusterRevision": 4,
+        "_type": "chip.clusters.Objects.OnOff"
+      },
+      "LevelControl": {
+        "currentLevel": 4,
+        "remainingTime": 0,
+        "minLevel": 1,
+        "maxLevel": 254,
+        "currentFrequency": 0,
+        "minFrequency": 0,
+        "maxFrequency": 0,
+        "options": 0,
+        "onOffTransitionTime": 0,
+        "onLevel": null,
+        "onTransitionTime": 0,
+        "offTransitionTime": 0,
+        "defaultMoveRate": 50,
+        "startUpCurrentLevel": null,
+        "generatedCommandList": [],
+        "acceptedCommandList": [0, 1, 2, 3, 4, 5, 6, 7],
+        "attributeList": [
+          0, 1, 2, 3, 4, 5, 6, 15, 16, 17, 18, 19, 20, 16384, 65528, 65529,
+          65531, 65532, 65533
+        ],
+        "featureMap": 3,
+        "clusterRevision": 5,
+        "_type": "chip.clusters.Objects.LevelControl"
+      }
+    }
+  },
+  "events": [],
+  "node_id": 4338
+}

--- a/tests/fixtures/nodes_in_ha/fake_color_temperature_light.json
+++ b/tests/fixtures/nodes_in_ha/fake_color_temperature_light.json
@@ -1,0 +1,24 @@
+{
+  "is_bridge": false,
+  "node_devices": [
+    {
+      "device_type_instances": [
+        {
+          "type": "ColorTemperatureLight",
+          "platforms": ["light"],
+          "entities": [
+            {
+              "entity_id": "light.my_mock_device",
+              "state": "on",
+              "attributes": {
+                "supported_features": 0,
+                "supported_color_modes": ["brightness"],
+                "brightness": 3
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/nodes_in_ha/fake_extended_color_light.json
+++ b/tests/fixtures/nodes_in_ha/fake_extended_color_light.json
@@ -1,0 +1,24 @@
+{
+  "is_bridge": false,
+  "node_devices": [
+    {
+      "device_type_instances": [
+        {
+          "type": "ExtendedColorLight",
+          "platforms": ["light"],
+          "entities": [
+            {
+              "entity_id": "light.my_mock_device",
+              "state": "on",
+              "attributes": {
+                "supported_features": 0,
+                "supported_color_modes": ["brightness"],
+                "brightness": 3
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This allows toggling "Color Temperature Lights" and "Extended Color Lights". Color modes have not been implemented. Previously we wouldn't even show the lights.

Related to #19
Related to #20