### PR TITLE
Allow pairing an on network device

### DIFF
--- a/custom_components/matter_experimental/__init__.py
+++ b/custom_components/matter_experimental/__init__.py
@@ -125,6 +125,22 @@ def _async_init_services(hass: HomeAssistant) -> None:
         vol.Schema({"code": str}),
     )
 
+    async def accept_shared_device(call: ServiceCall) -> None:
+        """Accept a shared device."""
+        matter: Matter = list(hass.data[DOMAIN].values())[0]
+        try:
+            await matter.commission_on_network(call.data["pin"])
+        except FailedCommand as err:
+            raise HomeAssistantError(str(err)) from err
+
+    async_register_admin_service(
+        hass,
+        DOMAIN,
+        "accept_shared_device",
+        accept_shared_device,
+        vol.Schema({"pin": vol.Coerce(int)}),
+    )
+
     async def set_wifi(call: ServiceCall) -> None:
         """Handle set wifi creds."""
         matter: Matter = list(hass.data[DOMAIN].values())[0]

--- a/custom_components/matter_experimental/services.yaml
+++ b/custom_components/matter_experimental/services.yaml
@@ -8,6 +8,17 @@ commission:
       required: true
       selector:
         text:
+accept_shared_device:
+  name: Accept shared device
+  description: >
+    Add a shared device to your Matter network.
+  fields:
+    pin:
+      name: Pin code
+      required: true
+      selector:
+        text:
+
 set_wifi:
   name: Set Wi-Fi credentials
   description: >

--- a/matter_server/client/model/device_controller.py
+++ b/matter_server/client/model/device_controller.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
-import enum
 
+import enum
 import logging
 import typing
 from typing import TYPE_CHECKING

--- a/matter_server/client/model/device_controller.py
+++ b/matter_server/client/model/device_controller.py
@@ -61,6 +61,15 @@ class DeviceController:
             },
         )
 
+    async def commission_on_network(self, nodeId: int, setupPinCode: int):
+        return await self._async_send_command(
+            "CommissionOnNetwork",
+            {
+                "nodeId": nodeId,
+                "setupPinCode": setupPinCode,
+            },
+        )
+
     async def set_wifi_credentials(self, ssid: str, credentials: str):
         return await self._async_send_command(
             "SetWiFiCredentials",

--- a/matter_server/client/model/device_controller.py
+++ b/matter_server/client/model/device_controller.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import enum
 
 import logging
 import typing
@@ -47,6 +48,19 @@ ReadEventsType = typing.List[
 ]
 
 
+class DiscoveryFilterType(enum.IntEnum):
+    # These must match chip::Dnssd::DiscoveryFilterType values (barring the naming convention)
+    NONE = 0
+    SHORT_DISCRIMINATOR = 1
+    LONG_DISCRIMINATOR = 2
+    VENDOR_ID = 3
+    DEVICE_TYPE = 4
+    COMMISSIONING_MODE = 5
+    INSTANCE_NAME = 6
+    COMMISSIONER = 7
+    COMPRESSED_FABRIC_ID = 8
+
+
 class DeviceController:
     def __init__(self, client: client.Client):
         self.client = client
@@ -61,12 +75,20 @@ class DeviceController:
             },
         )
 
-    async def commission_on_network(self, nodeId: int, setupPinCode: int):
+    async def commission_on_network(
+        self,
+        nodeId: int,
+        setupPinCode: int,
+        filterType: DiscoveryFilterType = DiscoveryFilterType.NONE,
+        filter: typing.Any = None,
+    ):
         return await self._async_send_command(
             "CommissionOnNetwork",
             {
                 "nodeId": nodeId,
                 "setupPinCode": setupPinCode,
+                "filterType": filterType,
+                "filter": filter,
             },
         )
 

--- a/matter_server/server/active_connection.py
+++ b/matter_server/server/active_connection.py
@@ -114,12 +114,30 @@ class ActiveConnection:
 
     @commands.register("device_controller.CommissionWithCode")
     async def _handle_device_controller_CommissionWithCode(self, msg: CommandMessage):
+        """Commission a device.
+
+        Return boolean if successful.
+        """
         if not self.server.stack.wifi_cred_set:
             self.logger.warning("Received commissioning without Wi-Fi set")
 
         result = await self.loop.run_in_executor(
             None,
             partial(self.server.stack.device_controller.CommissionWithCode, **msg.args),
+        )
+        self._send_message(SuccessResultMessage(msg.messageId, {"raw": result}))
+
+    @commands.register("device_controller.CommissionOnNetwork")
+    async def _handle_device_controller_CommissionOnNetwork(self, msg: CommandMessage):
+        """Commission a device already connected to the network.
+
+        Return boolean if successful.
+        """
+        result = await self.loop.run_in_executor(
+            None,
+            partial(
+                self.server.stack.device_controller.CommissionOnNetwork, **msg.args
+            ),
         )
         self._send_message(SuccessResultMessage(msg.messageId, {"raw": result}))
 


### PR DESCRIPTION
This allows pairing an on network device using a new debug service `accept_shared_device`. To use this service you need a pin. This pin code can be received by opening a commissioning window for a device in another Matter controller.

The commission_on_network was originally added to the Python wrapper in https://github.com/project-chip/connectedhomeip/pull/21567

I didn't test this with an actual pairing code.

CC @jpelgrom