### PR TITLE
Drop requirement of WiFi credentials

### DIFF
--- a/matter_server/common/models/server_information.py
+++ b/matter_server/common/models/server_information.py
@@ -16,6 +16,8 @@ class ServerInfo:
     compressed_fabric_id: int
     schema_version: int
     sdk_version: str
+    wifi_credentials_set: bool
+    thread_credentials_set: bool
 
 
 @dataclass

--- a/matter_server/server/server.py
+++ b/matter_server/server/server.py
@@ -132,6 +132,8 @@ class MatterServer:
             compressed_fabric_id=self.device_controller.compressed_fabric_id,
             schema_version=SCHEMA_VERSION,
             sdk_version=chip_clusters_version(),
+            wifi_credentials_set=self.device_controller.wifi_credentials_set,
+            thread_credentials_set=self.device_controller.thread_credentials_set,
         )
 
     @api_command(APICommand.SERVER_DIAGNOSTICS)


### PR DESCRIPTION
devices can be commissioned while on the network, there is no hard requirement for the wifi creds.
Dropped the check and added a attribute instead so consumers can deal with it.