### PR TITLE
Split lint and test in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@v3.2.0
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v4.3.1
         with:
           python-version: "3.9"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,34 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  lint:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Check out code from GitHub
+        uses: actions/checkout@v3.2.0
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4.3.1
+        with:
+          python-version: "3.9"
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgirepository1.0-dev
+          python -m pip install --upgrade pip
+          pip install -e .[server] -r requirements-test.txt
+      - name: Flake8
+        run: flake8 scripts/ matter_server/
+      - name: Black
+        run: black --check scripts/ matter_server/
+      - name: isort
+        run: isort --check scripts/ matter_server/
+      - name: pylint
+        run: pylint matter_server/
+
+  test:
+    if: ${{ false }} # disable until tests are fixed
     runs-on: ubuntu-latest
     continue-on-error: true
     strategy:
@@ -21,9 +48,8 @@ jobs:
           - "3.10"
 
     steps:
-      - uses: actions/checkout@v3.2.0
-        with:
-          fetch-depth: 2
+      - name: Check out code from GitHub
+        uses: actions/checkout@v3.2.0
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4.3.1
         with:
@@ -33,18 +59,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgirepository1.0-dev
           python -m pip install --upgrade pip
-          pip install -e .[server] -r requirements-test.txt homeassistant
-      - name: Flake8
-        run: flake8 scripts matter_server/client matter_server/common matter_server/server
-      - name: Black
-        run: black --check scripts matter_server/client matter_server/common matter_server/server
-      - name: isort
-        run: isort --check scripts matter_server/client matter_server/common matter_server/server
-      - name: pylint
-        run: pylint matter_server/client matter_server/common matter_server/server
-      # - name: test show stored node script
-      #   run: python3 -m scripts.show_stored_node tests/fixtures/nodes/lighting-example-app.json
-      # - name: test dump fixer script
-      #   run: python3 -m scripts.dump_fixer tests/fixtures/nodes/lighting-example-app.json
-      # - name: Pytest
-      #   run: pytest tests
+          pip install -e .[server] -r requirements-test.txt
+      - name: test show stored node script
+        run: python3 -m scripts.show_stored_node tests/fixtures/nodes/lighting-example-app.json
+      - name: test dump fixer script
+        run: python3 -m scripts.dump_fixer tests/fixtures/nodes/lighting-example-app.json
+      - name: Pytest
+        run: pytest tests


### PR DESCRIPTION
- Split lint and test in two different jobs.
- The lint job should only run on the minimum Python version. The test job should run on all supported minor Python versions.
- Disable the test job for now, until the tests are fixed.