### PR TITLE
Fix Commissioning

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -65,7 +65,9 @@ class MatterDeviceController:
 
     async def start(self) -> None:
         """Async initialize of controller."""
-        self.compressed_fabric_id = await self._call_sdk(self.chip_controller.GetCompressedFabricId)
+        self.compressed_fabric_id = await self._call_sdk(
+            self.chip_controller.GetCompressedFabricId
+        )
         # load nodes from persistent storage
         nodes_data = self.server.storage.get(DATA_KEY_NODES, {})
         for node_id_str, node_dict in nodes_data.items():
@@ -117,7 +119,9 @@ class MatterDeviceController:
             nodeid=node_id,
         )
         if not success:
-            raise NodeCommissionFailed(f"Commission with code failed for node {node_id}")
+            raise NodeCommissionFailed(
+                f"Commission with code failed for node {node_id}"
+            )
 
         # full interview of the device
         await self.interview_node(node_id)

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from collections import deque
 from datetime import datetime
 from functools import partial

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -56,19 +56,16 @@ class MatterDeviceController:
         self._nodes: dict[int, MatterNode] = {}
         self.wifi_credentials_set: bool = False
         self.thread_credentials_set: bool = False
+        self.compressed_fabric_id: int | None = None
 
     @property
     def fabric_id(self) -> int:
         """Return Fabric ID."""
         return self.chip_controller.fabricId
 
-    @property
-    def compressed_fabric_id(self) -> int:
-        """Return unique identifier for this initialized fabric."""
-        return self.chip_controller.GetCompressedFabricId()
-
     async def start(self) -> None:
         """Async initialize of controller."""
+        self.compressed_fabric_id = await self._call_sdk(self.chip_controller.GetCompressedFabricId)
         # load nodes from persistent storage
         nodes_data = self.server.storage.get(DATA_KEY_NODES, {})
         for node_id_str, node_dict in nodes_data.items():
@@ -114,22 +111,13 @@ class MatterDeviceController:
         """
         node_id = self._get_next_node_id()
 
-        # TODO TEMP !!!
-        # The call to CommissionWithCode returns early without waiting ?!
-        # This is most likely a bug in the SDK or its python wrapper
-        # success = await self._call_sdk(
-        #     self.chip_controller.CommissionWithCode,
-        #     setupPayload=code,
-        #     nodeid=node_id,
-        # )
-        # if not success:
-        #     raise NodeCommissionFailed(f"Commission with code failed for node {node_id}")
-        await self._call_sdk(
+        success = await self._call_sdk(
             self.chip_controller.CommissionWithCode,
             setupPayload=code,
             nodeid=node_id,
         )
-        await asyncio.sleep(60)
+        if not success:
+            raise NodeCommissionFailed(f"Commission with code failed for node {node_id}")
 
         # full interview of the device
         await self.interview_node(node_id)
@@ -154,6 +142,7 @@ class MatterDeviceController:
         Returns full NodeInfo once complete.
         """
         node_id = self._get_next_node_id()
+
         success = await self._call_sdk(
             self.chip_controller.CommissionOnNetwork,
             nodeId=node_id,
@@ -165,6 +154,7 @@ class MatterDeviceController:
             raise NodeCommissionFailed(
                 f"Commission on network failed for node {node_id}"
             )
+
         # full interview of the device
         await self.interview_node(node_id)
         # make sure we start a subscription for this newly added node

--- a/matter_server/server/server.py
+++ b/matter_server/server/server.py
@@ -125,6 +125,7 @@ class MatterServer:
     @api_command(APICommand.SERVER_INFO)
     def get_info(self) -> ServerInfo:
         """Return (version)info of the Matter Server."""
+        assert self.device_controller.compressed_fabric_id is not None
         return ServerInfo(
             fabric_id=self.device_controller.fabric_id,
             compressed_fabric_id=self.device_controller.compressed_fabric_id,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,12 +25,12 @@ dependencies = [
   "coloredlogs",
   "dacite",
   "orjson",
-  "home-assistant-chip-clusters==2022.11.1"
+  "home-assistant-chip-clusters==2022.12.0"
 ]
 
 [project.optional-dependencies]
 server = [
-  "home-assistant-chip-core==2022.11.1"
+  "home-assistant-chip-core==2022.12.0"
 ]
 test = [
   "black==22.10.0",


### PR DESCRIPTION
With latest changes of the CHIP SDK the commissioning now works as intended and we can remove the workaround.
Note that this does not yet fix the attestation error for devices without valid certificate.

Depend on chip wheels 2022.12.0 (which is bumped in this PR)