### PR TITLE
Fix persistency were controller failed loading commissioned devices

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -68,9 +68,6 @@ class MatterDeviceController:
         self.compressed_fabric_id = await self._call_sdk(
             self.chip_controller.GetCompressedFabricId
         )
-        LOGGER.debug("CHIP Device Controller Initialized")
-
-    async def load_nodes(self) -> None:
         # load nodes from persistent storage
         nodes_data = self.server.storage.get(DATA_KEY_NODES, {})
         for node_id_str, node_dict in nodes_data.items():
@@ -84,7 +81,7 @@ class MatterDeviceController:
                 LOGGER.warning("Node %s is not resolving, skipping...", node_id)
         # create task to check for nodes that need any re(interviews)
         asyncio.create_task(self._check_interviews())
-        LOGGER.debug("Loaded nodes from persistent storage")
+        LOGGER.debug("CHIP Device Controller Initialized")
 
     async def stop(self) -> None:
         """Handle logic on server stop."""
@@ -157,7 +154,6 @@ class MatterDeviceController:
             filterType=filter_type,
             filter=filter,
         )
-
         if not success:
             raise NodeCommissionFailed(
                 f"Commission on network failed for node {node_id}"

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -63,11 +63,14 @@ class MatterDeviceController:
         """Return Fabric ID."""
         return cast(int, self.chip_controller.fabricId)
 
-    async def start(self) -> None:
+    async def initialize(self) -> None:
         """Async initialize of controller."""
         self.compressed_fabric_id = await self._call_sdk(
             self.chip_controller.GetCompressedFabricId
         )
+        LOGGER.debug("CHIP Device Controller Initialized")
+        
+    async def start(self) -> None:
         # load nodes from persistent storage
         nodes_data = self.server.storage.get(DATA_KEY_NODES, {})
         for node_id_str, node_dict in nodes_data.items():
@@ -81,7 +84,7 @@ class MatterDeviceController:
                 LOGGER.warning("Node %s is not resolving, skipping...", node_id)
         # create task to check for nodes that need any re(interviews)
         asyncio.create_task(self._check_interviews())
-        LOGGER.debug("CHIP Device Controller Initialized")
+        LOGGER.debug("Loaded %s nodes", len(self._nodes))
 
     async def stop(self) -> None:
         """Handle logic on server stop."""

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -9,7 +9,7 @@ from functools import partial
 import logging
 from typing import TYPE_CHECKING, Any, Callable, Deque, Optional, Type, TypeVar, cast
 
-from chip.ChipDeviceCtrl import CommissionableNode
+from chip.ChipDeviceCtrl import CommissionableNode, DiscoveryFilterType
 from chip.clusters import Attribute, ClusterCommand
 from chip.exceptions import ChipStackError
 

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -9,7 +9,7 @@ from functools import partial
 import logging
 from typing import TYPE_CHECKING, Any, Callable, Deque, Optional, Type, TypeVar, cast
 
-from chip.ChipDeviceCtrl import CommissionableNode, DiscoveryFilterType
+from chip.ChipDeviceCtrl import CommissionableNode
 from chip.clusters import Attribute, ClusterCommand
 from chip.exceptions import ChipStackError
 

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -69,8 +69,9 @@ class MatterDeviceController:
             self.chip_controller.GetCompressedFabricId
         )
         LOGGER.debug("CHIP Device Controller Initialized")
-        
+
     async def start(self) -> None:
+        """Handle logic on controller start."""
         # load nodes from persistent storage
         nodes_data = self.server.storage.get(DATA_KEY_NODES, {})
         for node_id_str, node_dict in nodes_data.items():

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -9,7 +9,7 @@ from functools import partial
 import logging
 from typing import TYPE_CHECKING, Any, Callable, Deque, Optional, Type, TypeVar, cast
 
-from chip.ChipDeviceCtrl import CommissionableNode
+from chip.ChipDeviceCtrl import CommissionableNode, DiscoveryFilterType
 from chip.clusters import Attribute, ClusterCommand
 from chip.exceptions import ChipStackError
 
@@ -68,6 +68,9 @@ class MatterDeviceController:
         self.compressed_fabric_id = await self._call_sdk(
             self.chip_controller.GetCompressedFabricId
         )
+        LOGGER.debug("CHIP Device Controller Initialized")
+
+    async def load_nodes(self) -> None:
         # load nodes from persistent storage
         nodes_data = self.server.storage.get(DATA_KEY_NODES, {})
         for node_id_str, node_dict in nodes_data.items():
@@ -81,7 +84,7 @@ class MatterDeviceController:
                 LOGGER.warning("Node %s is not resolving, skipping...", node_id)
         # create task to check for nodes that need any re(interviews)
         asyncio.create_task(self._check_interviews())
-        LOGGER.debug("CHIP Device Controller Initialized")
+        LOGGER.debug("Loaded nodes from persistent storage")
 
     async def stop(self) -> None:
         """Handle logic on server stop."""
@@ -154,6 +157,7 @@ class MatterDeviceController:
             filterType=filter_type,
             filter=filter,
         )
+
         if not success:
             raise NodeCommissionFailed(
                 f"Commission on network failed for node {node_id}"

--- a/matter_server/server/server.py
+++ b/matter_server/server/server.py
@@ -85,8 +85,11 @@ class MatterServer:
                 "CHIP Core version does not match CHIP Clusters version."
             )
         self.loop = asyncio.get_running_loop()
-        await self.storage.start()
+
         await self.device_controller.start()
+        await self.storage.start()
+        await self.device_controller.load_nodes()
+
         mount_websocket(self, "/ws")
         self.app.router.add_route("GET", "/", self._handle_info)
         self._runner = web.AppRunner(self.app, access_log=None)

--- a/matter_server/server/server.py
+++ b/matter_server/server/server.py
@@ -85,6 +85,7 @@ class MatterServer:
                 "CHIP Core version does not match CHIP Clusters version."
             )
         self.loop = asyncio.get_running_loop()
+        await self.device_controller.initialize()
         await self.storage.start()
         await self.device_controller.start()
         mount_websocket(self, "/ws")

--- a/matter_server/server/server.py
+++ b/matter_server/server/server.py
@@ -85,11 +85,8 @@ class MatterServer:
                 "CHIP Core version does not match CHIP Clusters version."
             )
         self.loop = asyncio.get_running_loop()
-
-        await self.device_controller.start()
         await self.storage.start()
-        await self.device_controller.load_nodes()
-
+        await self.device_controller.start()
         mount_websocket(self, "/ws")
         self.app.router.add_route("GET", "/", self._handle_info)
         self._runner = web.AppRunner(self.app, access_log=None)

--- a/matter_server/server/storage.py
+++ b/matter_server/server/storage.py
@@ -27,6 +27,7 @@ class StorageController:
     @property
     def filename(self) -> str:
         """Return full path to (fabric-specific) storage file."""
+        LOGGER.debug(f"Compressed Fabric ID: {self.server.device_controller.compressed_fabric_id}")
         return os.path.join(
             self.server.storage_path,
             f"{self.server.device_controller.compressed_fabric_id}.json",

--- a/matter_server/server/storage.py
+++ b/matter_server/server/storage.py
@@ -27,7 +27,6 @@ class StorageController:
     @property
     def filename(self) -> str:
         """Return full path to (fabric-specific) storage file."""
-        LOGGER.debug(f"Compressed Fabric ID: {self.server.device_controller.compressed_fabric_id}")
         return os.path.join(
             self.server.storage_path,
             f"{self.server.device_controller.compressed_fabric_id}.json",


### PR DESCRIPTION
`compressed_fabric_id` isn't set until the device controller is initialized, and we need the fabric id for loading from the storage path.