### PR TITLE
Set network mode host and add default USERDIR in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     image: matter-server:latest
     container_name: matter-server
     restart: unless-stopped
+    # Required for mDNS to work correctly
+    network_mode: host
     security_opt:
       # needed for bluetooth via dbus
       - apparmor:unconfined
@@ -15,5 +17,5 @@ services:
       - "5580:5580"
     volumes:
       # Create an .env file that sets the USERDIR environment variable.
-      - ${USERDIR}/docker/matter-server/data:/data/
+      - ${USERDIR:-$HOME}/docker/matter-server/data:/data/
       - /run/dbus:/run/dbus:ro


### PR DESCRIPTION
Running in host mode is required for mDNS discovery which is needed when commissioning devices that are already on the network like the hue bridge.