### PR TITLE
Bump SDK wheels to 2023.1.0 (=1.0.0.2)

### DIFF
--- a/matter_server/common/helpers/util.py
+++ b/matter_server/common/helpers/util.py
@@ -54,9 +54,10 @@ CHIP_CLUSTERS_PKG_NAME = "home-assistant-chip-clusters"
 CHIP_CORE_PKG_NAME = "home-assistant-chip-core"
 
 # TEMP: Basic Cluster got renamed in SDK version v1.0.0.2
-# we will fix this later when we're basic our datastructure
-# on the id's instead of types.
+# we will fix this later when we're basing our datastructure
+# on the ids instead of types.
 chip.clusters.Objects.Basic = chip.clusters.Objects.BasicInformation
+
 
 def dataclass_to_dict(obj_in: object, skip_none: bool = False) -> dict:
     """Convert dataclass instance to dict, optionally skip None values."""

--- a/matter_server/common/helpers/util.py
+++ b/matter_server/common/helpers/util.py
@@ -53,6 +53,10 @@ _T = TypeVar("_T")
 CHIP_CLUSTERS_PKG_NAME = "home-assistant-chip-clusters"
 CHIP_CORE_PKG_NAME = "home-assistant-chip-core"
 
+# TEMP: Basic Cluster got renamed in SDK version v1.0.0.2
+# we will fix this later when we're basic our datastructure
+# on the id's instead of types.
+chip.clusters.Objects.Basic = chip.clusters.Objects.BasicInformation
 
 def dataclass_to_dict(obj_in: object, skip_none: bool = False) -> dict:
     """Convert dataclass instance to dict, optionally skip None values."""

--- a/matter_server/common/models/device_types.py
+++ b/matter_server/common/models/device_types.py
@@ -44,7 +44,7 @@ class RootNode(DeviceType, device_type=0x0016):
 
     clusters = {
         all_clusters.AccessControl,
-        all_clusters.Basic,
+        all_clusters.BasicInformation,
         all_clusters.Descriptor,
         all_clusters.GeneralCommissioning,
         all_clusters.PowerSourceConfiguration,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,12 +25,12 @@ dependencies = [
   "coloredlogs",
   "dacite",
   "orjson",
-  "home-assistant-chip-clusters==2022.12.0"
+  "home-assistant-chip-clusters==2023.1.0"
 ]
 
 [project.optional-dependencies]
 server = [
-  "home-assistant-chip-core==2022.12.0"
+  "home-assistant-chip-core==2023.1.0"
 ]
 test = [
   "black==22.10.0",


### PR DESCRIPTION
Bump the SDK wheels to 2023.1.0 (built yesterday) which is based on official 1.0.0.2 patch release of the SDK