### PR TITLE
Fix sdk command return code error handling

### DIFF
--- a/matter_server/common/models/error.py
+++ b/matter_server/common/models/error.py
@@ -27,7 +27,3 @@ class NodeNotExists(MatterError):
 
 class VersionMismatch(MatterError):
     """Issue raised when SDK version mismatches."""
-
-
-class SDKCommandFailed(MatterError):
-    """Raised when command on the CHIP SDK Failed."""

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -21,7 +21,6 @@ from ..common.models.error import (
     NodeInterviewFailed,
     NodeNotExists,
     NodeNotResolving,
-    SDKCommandFailed,
 )
 from ..common.models.events import EventType
 from ..common.models.node import MatterAttribute, MatterNode
@@ -173,26 +172,22 @@ class MatterDeviceController:
     @api_command(APICommand.SET_WIFI_CREDENTIALS)
     async def set_wifi_credentials(self, ssid: str, credentials: str) -> None:
         """Set WiFi credentials for commissioning to a (new) device."""
-        error_code = await self._call_sdk(
+        await self._call_sdk(
             self.chip_controller.SetWiFiCredentials,
             ssid=ssid,
             credentials=credentials,
         )
 
-        if error_code != 0:
-            raise SDKCommandFailed("Set WiFi credentials failed.")
         self.wifi_credentials_set = True
 
     @api_command(APICommand.SET_THREAD_DATASET)
     async def set_thread_operational_dataset(self, dataset: str) -> None:
         """Set Thread Operational dataset in the stack."""
-        error_code = await self._call_sdk(
+        await self._call_sdk(
             self.chip_controller.SetThreadOperationalDataset,
             threadOperationalDataset=bytes.fromhex(dataset),
         )
 
-        if error_code != 0:
-            raise SDKCommandFailed("Set Thread credentials failed.")
         self.thread_credentials_set = True
 
     @api_command(APICommand.OPEN_COMMISSIONING_WINDOW)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python-matter-server"
-version = "2.0.0"
+version = "2.0.1"
 license     = {text = "Apache-2.0"}
 description = "Python Matter WebSocket Server"
 readme = "README.md"


### PR DESCRIPTION
- Two commands had changed return value in chip SDK v1.0.0.2. This caused us to raise errors in the server when checking the return values for those commands.
- Fix that and let the exceptions that are raised by the chip stack bubble up to our handler instead.
- Bump version to 2.0.1.