### PR TITLE
Fix device info and node BasicInformation

### DIFF
--- a/matter_server/common/models/node.py
+++ b/matter_server/common/models/node.py
@@ -203,7 +203,9 @@ class MatterNode:
         return cast(
             str,
             self.get_attribute(
-                self.root_device_type_instance.endpoint, Clusters.Basic, "NodeLabel"
+                self.root_device_type_instance.endpoint,
+                Clusters.BasicInformation,
+                "NodeLabel",
             ).value,
         )
 
@@ -213,7 +215,9 @@ class MatterNode:
         return cast(
             str,
             self.get_attribute(
-                self.root_device_type_instance.endpoint, Clusters.Basic, "UniqueID"
+                self.root_device_type_instance.endpoint,
+                Clusters.BasicInformation,
+                "UniqueID",
             ).value,
         )
 

--- a/matter_server/common/models/node_device.py
+++ b/matter_server/common/models/node_device.py
@@ -23,7 +23,7 @@ class AbstractMatterNodeDevice(ABC):
         """Return the node of this device."""
 
     @abstractmethod
-    def device_info(self) -> Clusters.Basic | Clusters.BridgedDeviceBasic:
+    def device_info(self) -> Clusters.BasicInformation | Clusters.BridgedDeviceBasic:
         """Return device info."""
 
     @abstractmethod
@@ -42,9 +42,11 @@ class MatterNodeDevice(AbstractMatterNodeDevice):
         """Return the node of this device."""
         return self._node
 
-    def device_info(self) -> Clusters.Basic:
+    def device_info(self) -> Clusters.BasicInformation:
         """Return device info."""
-        return self._node.root_device_type_instance.get_cluster(Clusters.Basic)
+        return self._node.root_device_type_instance.get_cluster(
+            Clusters.BasicInformation
+        )
 
     def device_type_instances(self) -> list[MatterDeviceTypeInstance]:
         """Return device type instances."""


### PR DESCRIPTION
- `chip.clusters.Objects.Basic` was renamed to `chip.clusters.Objects.BasicInformation` in chip SDK v1.0.0.2.
- We didn't completely handle this in our version 2.0.0 release. Fix that now.

fixes #180