### PR TITLE
Add support for ValueDecodeFailure

### DIFF
--- a/matter_server/common/helpers/util.py
+++ b/matter_server/common/helpers/util.py
@@ -23,7 +23,7 @@ import chip.clusters  # noqa: F401
 from chip.clusters import Objects  # noqa: F401
 from chip.clusters.Objects import *  # noqa: F401 F403
 from chip.clusters.Types import Nullable, NullValue  # noqa: F401
-from chip.clusters.Attribute import ValueDecodeFailure # noqa: F401
+from chip.clusters.Attribute import ValueDecodeFailure  # noqa: F401
 from chip.tlv import float32, uint
 
 from ..models.events import *  # noqa: F401 F403
@@ -160,7 +160,6 @@ def parse_value(
                 return parse_value(name, value, sub_arg_type)
             except (KeyError, TypeError, ValueError):
                 pass
-        
         # Before we give up, check if we have a ValueDecodeFailure
         if isinstance(value, dict) and "TLVValue" in value and "Reason" in value:
             return ValueDecodeFailure(value["TLVValue"], value["Reason"])
@@ -174,7 +173,6 @@ def parse_value(
         if NoneType not in sub_value_types:
             # raise exception, we have no idea how to handle this value
             raise TypeError(err)
-        
         # failed to parse the (sub) value but None allowed, log only
         logging.getLogger(__name__).warn(err)
         return None

--- a/matter_server/common/helpers/util.py
+++ b/matter_server/common/helpers/util.py
@@ -48,6 +48,7 @@ except:  # noqa
     NoneType = type(None)
     UnionType = type(Union)
 
+
 _T = TypeVar("_T")
 
 CHIP_CLUSTERS_PKG_NAME = "home-assistant-chip-clusters"
@@ -119,14 +120,12 @@ def parse_value(
             value_type = eval(value_type)
         except TypeError:
             pass
-    
+
     elif isinstance(value, dict):
         if hasattr(value_type, "from_dict"):
             return value_type.from_dict(value)
         if hasattr(value_type, "FromDict"):
             return value_type.FromDict(value)
-    
-    #logging.getLogger(__name__).warn("parse_value: %s %s %s %s", name, value, type(value), value_type)
 
     if value is None and not isinstance(default, type(MISSING)):
         return default
@@ -211,7 +210,7 @@ def parse_value(
         # Before we give up, check if we have a ValueDecodeFailure
         if isinstance(value, dict) and "TLVValue" in value and "Reason" in value:
             return ValueDecodeFailure(value["TLVValue"], value["Reason"])
-            
+
         raise TypeError(
             f"Value {value} of type {type(value)} is invalid for {name}, "
             f"expected value of type {value_type}"

--- a/matter_server/common/helpers/util.py
+++ b/matter_server/common/helpers/util.py
@@ -21,9 +21,9 @@ from typing import Any, TypeVar, Union, cast, get_args, get_origin
 import chip  # noqa: F401
 import chip.clusters  # noqa: F401
 from chip.clusters import Objects  # noqa: F401
+from chip.clusters.Attribute import ValueDecodeFailure  # noqa: F401
 from chip.clusters.Objects import *  # noqa: F401 F403
 from chip.clusters.Types import Nullable, NullValue  # noqa: F401
-from chip.clusters.Attribute import ValueDecodeFailure  # noqa: F401
 from chip.tlv import float32, uint
 
 from ..models.events import *  # noqa: F401 F403


### PR DESCRIPTION
Handles bad matter devices that have cluster attributes with the wrong values and are turned into `ValueDecodeFailure` types by the chip library.

Resolves https://github.com/home-assistant-libs/python-matter-server/issues/187

Hue Bridge is an example of a device in this case an ExtendedColorLight with attributes that can't be parsed by the chip controller
![Hue Bridge Example](https://i.arturonet.com/Ubfgpbq0w3.png)