### PR TITLE
Add args support to send_device_command

### DIFF
--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Callable, Dict, Final, Optional, cast, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Final, Optional, Union, cast
 import uuid
 
 from aiohttp import ClientSession

--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Callable, Dict, Final, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Dict, Final, Optional, cast
 import uuid
 
 from aiohttp import ClientSession

--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Callable, Dict, Final, Optional, cast
+from typing import TYPE_CHECKING, Any, Callable, Dict, Final, Optional, cast, Union
 import uuid
 
 from aiohttp import ClientSession
@@ -166,7 +166,14 @@ class MatterClient:
         )
 
     async def send_device_command(
-        self, node_id: int, endpoint: int, command: ClusterCommand
+        self,
+        node_id: int,
+        endpoint: int,
+        command: ClusterCommand,
+        responseType=None,
+        timedRequestTimeoutMs: Union[None, int] = None,
+        interactionTimeoutMs: Union[None, int] = None,
+        busyWaitMs: Union[None, int] = None
     ) -> Any:
         """Send a command to a Matter node/device."""
         payload = dataclass_to_dict(command)
@@ -175,6 +182,10 @@ class MatterClient:
             node_id=node_id,
             endpoint=endpoint,
             payload=payload,
+            responseType=responseType,
+            timedRequestTimeoutMs=timedRequestTimeoutMs,
+            interactionTimeoutMs=interactionTimeoutMs,
+            busyWaitMs=busyWaitMs
         )
 
     async def remove_node(self, node_id: int) -> None:

--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -173,7 +173,6 @@ class MatterClient:
         responseType=None,
         timedRequestTimeoutMs: Union[None, int] = None,
         interactionTimeoutMs: Union[None, int] = None,
-        busyWaitMs: Union[None, int] = None
     ) -> Any:
         """Send a command to a Matter node/device."""
         payload = dataclass_to_dict(command)
@@ -185,7 +184,6 @@ class MatterClient:
             responseType=responseType,
             timedRequestTimeoutMs=timedRequestTimeoutMs,
             interactionTimeoutMs=interactionTimeoutMs,
-            busyWaitMs=busyWaitMs
         )
 
     async def remove_node(self, node_id: int) -> None:

--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -171,8 +171,8 @@ class MatterClient:
         endpoint: int,
         command: ClusterCommand,
         response_type: Any | None = None,
-        timed_request_timeout_ms: Union[None, int] = None,
-        interaction_timeout_ms: Union[None, int] = None,
+        timed_request_timeout_ms: int | None = None,
+        interaction_timeout_ms: int | None = None,
     ) -> Any:
         """Send a command to a Matter node/device."""
         payload = dataclass_to_dict(command)

--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -170,9 +170,9 @@ class MatterClient:
         node_id: int,
         endpoint: int,
         command: ClusterCommand,
-        responseType=None,
-        timedRequestTimeoutMs: Union[None, int] = None,
-        interactionTimeoutMs: Union[None, int] = None,
+        response_type: Any | None = None,
+        timed_request_timeout_ms: Union[None, int] = None,
+        interaction_timeout_ms: Union[None, int] = None,
     ) -> Any:
         """Send a command to a Matter node/device."""
         payload = dataclass_to_dict(command)
@@ -181,9 +181,9 @@ class MatterClient:
             node_id=node_id,
             endpoint=endpoint,
             payload=payload,
-            responseType=responseType,
-            timedRequestTimeoutMs=timedRequestTimeoutMs,
-            interactionTimeoutMs=interactionTimeoutMs,
+            response_type=response_type,
+            timed_request_timeout_ms=timed_request_timeout_ms,
+            interaction_timeout_ms=interaction_timeout_ms,
         )
 
     async def remove_node(self, node_id: int) -> None:

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -7,7 +7,17 @@ from collections import deque
 from datetime import datetime
 from functools import partial
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Deque, Optional, Type, TypeVar, cast, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Deque,
+    Optional,
+    Type,
+    TypeVar,
+    cast,
+    Union,
+)
 
 from chip.ChipDeviceCtrl import CommissionableNode
 from chip.clusters import Attribute, ClusterCommand
@@ -275,18 +285,18 @@ class MatterDeviceController:
         node_id: int,
         endpoint: int,
         payload: ClusterCommand,
-        responseType=None,
-        timedRequestTimeoutMs: Union[None, int] = None,
-        interactionTimeoutMs: Union[None, int] = None,
+        response_type: Any | None = None,
+        timed_request_timeout_ms: Union[None, int] = None,
+        interaction_timeout_ms: Union[None, int] = None,
     ) -> Any:
         """Send a command to a Matter node/device."""
         return await self.chip_controller.SendCommand(
             nodeid=node_id,
             endpoint=endpoint,
             payload=payload,
-            responseType=responseType,
-            timedRequestTimeoutMs=timedRequestTimeoutMs,
-            interactionTimeoutMs=interactionTimeoutMs,
+            responseType=response_type,
+            timedRequestTimeoutMs=timed_request_timeout_ms,
+            interactionTimeoutMs=interaction_timeout_ms,
         )
 
     @api_command(APICommand.REMOVE_NODE)

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -7,16 +7,7 @@ from collections import deque
 from datetime import datetime
 from functools import partial
 import logging
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Deque,
-    Optional,
-    Type,
-    TypeVar,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Callable, Deque, Optional, Type, TypeVar, cast
 
 from chip.ChipDeviceCtrl import CommissionableNode
 from chip.clusters import Attribute, ClusterCommand

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -15,8 +15,8 @@ from typing import (
     Optional,
     Type,
     TypeVar,
-    cast,
     Union,
+    cast,
 )
 
 from chip.ChipDeviceCtrl import CommissionableNode

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -15,7 +15,6 @@ from typing import (
     Optional,
     Type,
     TypeVar,
-    Union,
     cast,
 )
 

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -286,8 +286,8 @@ class MatterDeviceController:
         endpoint: int,
         payload: ClusterCommand,
         response_type: Any | None = None,
-        timed_request_timeout_ms: Union[None, int] = None,
-        interaction_timeout_ms: Union[None, int] = None,
+        timed_request_timeout_ms: int | None = None,
+        interaction_timeout_ms: int | None = None,
     ) -> Any:
         """Send a command to a Matter node/device."""
         return await self.chip_controller.SendCommand(

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -278,7 +278,6 @@ class MatterDeviceController:
         responseType=None,
         timedRequestTimeoutMs: Union[None, int] = None,
         interactionTimeoutMs: Union[None, int] = None,
-        busyWaitMs: Union[None, int] = None
     ) -> Any:
         """Send a command to a Matter node/device."""
         return await self.chip_controller.SendCommand(
@@ -288,7 +287,6 @@ class MatterDeviceController:
             responseType=responseType,
             timedRequestTimeoutMs=timedRequestTimeoutMs,
             interactionTimeoutMs=interactionTimeoutMs,
-            busyWaitMs=busyWaitMs
         )
 
     @api_command(APICommand.REMOVE_NODE)

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -7,7 +7,7 @@ from collections import deque
 from datetime import datetime
 from functools import partial
 import logging
-from typing import TYPE_CHECKING, Any, Callable, Deque, Optional, Type, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Callable, Deque, Optional, Type, TypeVar, cast, Union
 
 from chip.ChipDeviceCtrl import CommissionableNode
 from chip.clusters import Attribute, ClusterCommand
@@ -271,11 +271,24 @@ class MatterDeviceController:
 
     @api_command(APICommand.DEVICE_COMMAND)
     async def send_device_command(
-        self, node_id: int, endpoint: int, payload: ClusterCommand
+        self,
+        node_id: int,
+        endpoint: int,
+        payload: ClusterCommand,
+        responseType=None,
+        timedRequestTimeoutMs: Union[None, int] = None,
+        interactionTimeoutMs: Union[None, int] = None,
+        busyWaitMs: Union[None, int] = None
     ) -> Any:
         """Send a command to a Matter node/device."""
         return await self.chip_controller.SendCommand(
-            nodeid=node_id, endpoint=endpoint, payload=payload
+            nodeid=node_id,
+            endpoint=endpoint,
+            payload=payload,
+            responseType=responseType,
+            timedRequestTimeoutMs=timedRequestTimeoutMs,
+            interactionTimeoutMs=interactionTimeoutMs,
+            busyWaitMs=busyWaitMs
         )
 
     @api_command(APICommand.REMOVE_NODE)

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -228,7 +228,7 @@ async def test_server_start(
             {"node_id": 1, "endpoint": 2, "payload": mock_cluster_command},
             strict=True,
         )
-    ) == {"node_id": 1, "endpoint": 2, "payload": mock_cluster_command}
+    ) == {"node_id": 1, "endpoint": 2, "payload": mock_cluster_command, "response_type": None, "timed_request_timeout_ms": None, "interaction_timeout_ms": None}
     assert (
         parse_arguments(
             server.command_handlers[APICommand.REMOVE_NODE].signature,


### PR DESCRIPTION
Adds support for sending extra arguments like `timedRequestTimeoutMs` to the matter server through the send_device_command function.

This doesn't change any of the previos arguments the function takes and there are defaults set for every extra argument so the HA core code doesn't need any modifications.

Resolve: https://github.com/home-assistant-libs/python-matter-server/issues/193