### PR TITLE
Change schema version logic

### DIFF
--- a/matter_server/client/connection.py
+++ b/matter_server/client/connection.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Dict, Final, cast
 from aiohttp import ClientSession, ClientWebSocketResponse, WSMsgType, client_exceptions
 
 from ..common.helpers.json import json_dumps, json_loads
-from ..common.helpers.util import chip_clusters_version, parse_message
+from ..common.helpers.util import parse_message
 from ..common.models.events import EventType
 from ..common.models.message import CommandMessage, MessageType, ServerInfoMessage
 from ..common.models.node import MatterNode

--- a/matter_server/client/connection.py
+++ b/matter_server/client/connection.py
@@ -84,15 +84,6 @@ class MatterClientConnection:
                 f"the server requires at least {info.min_supported_schema_version} "
                 " - update the Matter client to a more recent version or downgrade the server."
             )
-        if abs(self.server_info.schema_version - SCHEMA_VERSION) > 1:
-            # server version differs more than one version, log to inform user
-            LOGGER.warning(
-                "Matter Server detected with schema version %s "
-                "which is different than the preferred api schema %s of this client"
-                " - you may run into compatibility issues. Check for updates.",
-                info.schema_version,
-                SCHEMA_VERSION,
-            )
 
         LOGGER.info(
             "Connected to Matter Fabric %s (%s), Schema version %s, CHIP SDK Version %s",

--- a/matter_server/client/const.py
+++ b/matter_server/client/const.py
@@ -1,3 +1,0 @@
-"""Constants for the Matter Client."""
-
-MIN_SCHEMA_VERSION = 1

--- a/matter_server/common/const.py
+++ b/matter_server/common/const.py
@@ -1,0 +1,12 @@
+"""Constants that are shared between server and client."""
+
+# schema version is used to determine compatibility between server and client
+SCHEMA_VERSION = 1
+
+# we allow the schema version to be one version behind
+MIN_SCHEMA_VERSION = SCHEMA_VERSION - 1
+
+# we allow the schema version to be 2 versions ahead
+# when making breaking changes (we shouldn't, I know),
+# just bump the schema version a few points.
+MAX_SCHEMA_VERSION = SCHEMA_VERSION + 2

--- a/matter_server/common/const.py
+++ b/matter_server/common/const.py
@@ -1,12 +1,5 @@
 """Constants that are shared between server and client."""
 
 # schema version is used to determine compatibility between server and client
+# bump schema if we add new features and/or make other (breaking) changes
 SCHEMA_VERSION = 1
-
-# we allow the schema version to be one version behind
-MIN_SCHEMA_VERSION = SCHEMA_VERSION - 1
-
-# we allow the schema version to be 2 versions ahead
-# when making breaking changes (we shouldn't, I know),
-# just bump the schema version a few points.
-MAX_SCHEMA_VERSION = SCHEMA_VERSION + 2

--- a/matter_server/common/models/server_information.py
+++ b/matter_server/common/models/server_information.py
@@ -12,6 +12,7 @@ class ServerInfo:
     fabric_id: int
     compressed_fabric_id: int
     schema_version: int
+    min_supported_schema_version: int
     sdk_version: str
     wifi_credentials_set: bool
     thread_credentials_set: bool

--- a/matter_server/server/const.py
+++ b/matter_server/server/const.py
@@ -1,0 +1,4 @@
+"""Server-only constants for the Python Matter Server."""
+
+# The minimum schema version (of a client) the server can support
+MIN_SCHEMA_VERSION = 1

--- a/matter_server/server/const.py
+++ b/matter_server/server/const.py
@@ -1,3 +1,0 @@
-"""Constants for the Matter server."""
-
-SCHEMA_VERSION = 1

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -13,6 +13,7 @@ from chip.ChipDeviceCtrl import CommissionableNode
 from chip.clusters import Attribute, ClusterCommand
 from chip.exceptions import ChipStackError
 
+from ..common.const import SCHEMA_VERSION
 from ..common.helpers.api import api_command
 from ..common.helpers.util import dataclass_from_dict
 from ..common.models.api_command import APICommand
@@ -24,7 +25,6 @@ from ..common.models.error import (
 )
 from ..common.models.events import EventType
 from ..common.models.node import MatterAttribute, MatterNode
-from .const import SCHEMA_VERSION
 
 if TYPE_CHECKING:
     from .server import MatterServer

--- a/matter_server/server/server.py
+++ b/matter_server/server/server.py
@@ -20,6 +20,7 @@ from ..server.client_handler import WebsocketClientHandler
 from .device_controller import MatterDeviceController
 from .stack import MatterStack
 from .storage import StorageController
+from .const import MIN_SCHEMA_VERSION
 
 
 def mount_websocket(server: MatterServer, path: str) -> None:
@@ -135,6 +136,7 @@ class MatterServer:
             fabric_id=self.device_controller.fabric_id,
             compressed_fabric_id=self.device_controller.compressed_fabric_id,
             schema_version=SCHEMA_VERSION,
+            min_supported_schema_version=MIN_SCHEMA_VERSION,
             sdk_version=chip_clusters_version(),
             wifi_credentials_set=self.device_controller.wifi_credentials_set,
             thread_credentials_set=self.device_controller.thread_credentials_set,

--- a/matter_server/server/server.py
+++ b/matter_server/server/server.py
@@ -17,10 +17,10 @@ from ..common.models.error import VersionMismatch
 from ..common.models.events import EventCallBackType, EventType
 from ..common.models.server_information import ServerDiagnostics, ServerInfo
 from ..server.client_handler import WebsocketClientHandler
+from .const import MIN_SCHEMA_VERSION
 from .device_controller import MatterDeviceController
 from .stack import MatterStack
 from .storage import StorageController
-from .const import MIN_SCHEMA_VERSION
 
 
 def mount_websocket(server: MatterServer, path: str) -> None:

--- a/matter_server/server/server.py
+++ b/matter_server/server/server.py
@@ -8,13 +8,12 @@ import weakref
 
 from aiohttp import web
 
-from matter_server.common.models.error import VersionMismatch
-from matter_server.server.const import SCHEMA_VERSION
-
+from ..common.const import SCHEMA_VERSION
 from ..common.helpers.api import APICommandHandler, api_command
 from ..common.helpers.json import json_dumps
 from ..common.helpers.util import chip_clusters_version, chip_core_version
 from ..common.models.api_command import APICommand
+from ..common.models.error import VersionMismatch
 from ..common.models.events import EventCallBackType, EventType
 from ..common.models.server_information import ServerDiagnostics, ServerInfo
 from ..server.client_handler import WebsocketClientHandler


### PR DESCRIPTION
Make the schema version checks less strict so we have some more freedom of updating the addon/core independently.

- Remove strict check of sdk version alltogether. If there are any breaking changes, we can bump the schema version accordingly. NOTE to myself is to include the sdk version in the diagnostics when I'm reworking that.

- Use schema version constant (integer value) which we can bump if there are any breaking changes or new features.

- Define minimal supported schema version in the server itself, we should just keep things backwards compatible.
- Log warning if schema version does not match
- Keep logic in place to tie a feature to a schema version