### PR TITLE
Refactor/fix Docker

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM python:3.10-slim-bullseye
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -9,30 +9,25 @@ RUN \
     set -x \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    libuv1 \
-    openssl \
-    zlib1g \
-    libjson-c5 \
-    python3-venv \
-    python3-pip \
-    python3-gi \
-    python3-gi-cairo \
-    python3-dbus \
-    python3-psutil \
-    unzip \
-    libcairo2 \
-    gdb \
-    git \
+        libuv1 \
+        openssl \
+        zlib1g \
+        libjson-c5 \
+        unzip \
+        libcairo2 \
+        gdb \
+        git \
     && git clone --depth 1 -b master \
-    https://github.com/project-chip/connectedhomeip \
+        https://github.com/project-chip/connectedhomeip \
     && cp -r connectedhomeip/credentials /app/credentials \
     && mv /app/credentials/production/paa-root-certs/* \
           /app/credentials/development/paa-root-certs/ \
     && rm -rf connectedhomeip \
     && apt-get purge -y --auto-remove \
-    git \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /usr/src/*
+        git \
+    && rm -rf \
+        /var/lib/apt/lists/* \
+        /usr/src/*
 
 
 COPY . ./

--- a/README.md
+++ b/README.md
@@ -198,12 +198,12 @@ Please note that development is only possible on Linux and MacOS, no Windows sup
 ### Build
 
 ```sh
-docker-compose build --no-cache matter-server
+docker compose build --no-cache
 ```
 
 ### Run
 
 ```sh
-docker-compose up -d matter-server
-docker-compose logs -f matter-server
+docker compose up -d
+docker compose logs -f
 ```

--- a/compose.yml
+++ b/compose.yml
@@ -11,7 +11,7 @@ services:
     # Required for mDNS to work correctly
     network_mode: host
     security_opt:
-      # needed for bluetooth via dbus
+      # Needed for Bluetooth via dbus
       - apparmor:unconfined
     volumes:
       # Create an .env file that sets the USERDIR environment variable.


### PR DESCRIPTION
Refactors/fixes the Docker version of the Python Matter server.

- Bumps base image to use official Python-provided Docker images
	- Based on Debian Bulleyes
	- Using Python 3.10
- Rename legacy `docker-compose.yml` to current default `compose.yml`
- Update readme to remove legacy commands; removed unneeded container reference in commands.
- Some small styling & typo squatting.

Tested and worked against the integration currently in the Home Assistant `dev` branch.

../Frenck

fixes #214