### PR TITLE
Fix gcc dependency error when building wheel for psutil

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -17,6 +17,8 @@ RUN \
         libcairo2 \
         gdb \
         git \
+        gcc \
+        python3-dev
     && git clone --depth 1 -b master \
         https://github.com/project-chip/connectedhomeip \
     && cp -r connectedhomeip/credentials /app/credentials \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -18,7 +18,7 @@ RUN \
         gdb \
         git \
         gcc \
-        python3-dev
+        python3-dev \
     && git clone --depth 1 -b master \
         https://github.com/project-chip/connectedhomeip \
     && cp -r connectedhomeip/credentials /app/credentials \


### PR DESCRIPTION
I am using a Raspberry Pi 4 with the default OS (not HAOS) and getting an error when building this image in Docker due to missing dependencies for both `gcc` and `python3-dev`. Sorry, I lost the logs from building.