### PR TITLE
Fix Docker build, missing dependency

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -17,6 +17,7 @@ RUN \
         libcairo2 \
         gdb \
         git \
+        build-essential \
     && git clone --depth 1 -b master \
         https://github.com/project-chip/connectedhomeip \
     && cp -r connectedhomeip/credentials /app/credentials \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -17,7 +17,9 @@ RUN \
         libcairo2 \
         gdb \
         git \
-        build-essential \
+        gcc \
+        linux-libc-dev \
+        libc6-dev \
     && git clone --depth 1 -b master \
         https://github.com/project-chip/connectedhomeip \
     && cp -r connectedhomeip/credentials /app/credentials \


### PR DESCRIPTION
To have a working docker build, `build-essential` package is required,
as psutils python modules is getting compiled and requires a gcc.