### PR TITLE
Fix lint and test issues on main

### DIFF
--- a/matter_server/server/const.py
+++ b/matter_server/server/const.py
@@ -1,4 +1,18 @@
 """Server-only constants for the Python Matter Server."""
+import pathlib
+from typing import Final
 
 # The minimum schema version (of a client) the server can support
 MIN_SCHEMA_VERSION = 2
+
+# the paa-root-certs path is hardcoded in the sdk at this time
+# and always uses the development subfolder
+# regardless of anything you pass into instantiating the controller
+# revisit this once matter 1.1 is released
+PAA_ROOT_CERTS_DIR: Final[pathlib.Path] = (
+    pathlib.Path(__file__)
+    .parent.resolve()
+    .parent.resolve()
+    .parent.resolve()
+    .joinpath("credentials/development/paa-root-certs")
+)

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -33,8 +33,9 @@ from ..common.helpers.util import (
 from ..common.models import APICommand, EventType, MatterNodeData
 
 if TYPE_CHECKING:
-    from .server import MatterServer
     from chip.ChipDeviceCtrl import ChipDeviceController
+
+    from .server import MatterServer
 
 _T = TypeVar("_T")
 

--- a/matter_server/server/helpers/paa_certificates.py
+++ b/matter_server/server/helpers/paa_certificates.py
@@ -9,12 +9,14 @@ All rights reserved.
 
 import asyncio
 import logging
-import pathlib
+from os import makedirs
 import re
 
 from aiohttp import ClientError, ClientSession
 from cryptography import x509
 from cryptography.hazmat.primitives import serialization
+
+from matter_server.server.const import PAA_ROOT_CERTS_DIR
 
 LOGGER = logging.getLogger(__name__)
 PRODUCTION_URL = "https://on.dcl.csa-iot.org"
@@ -23,16 +25,14 @@ TEST_URL = "https://on.test-net.dcl.csa-iot.org"
 LAST_CERT_IDS: set[str] = set()
 
 
-async def write_paa_root_cert(
-    certificate: str, subject: str, root_path: pathlib.Path
-) -> None:
+async def write_paa_root_cert(certificate: str, subject: str) -> None:
     """Write certificate from string to file."""
 
     def _write() -> None:
         filename_base = "dcld_mirror_" + re.sub(
             "[^a-zA-Z0-9_-]", "", re.sub("[=, ]", "_", subject)
         )
-        filepath_base = root_path.joinpath(filename_base)
+        filepath_base = PAA_ROOT_CERTS_DIR.joinpath(filename_base)
         # handle PEM certificate file
         file_path_pem = f"{filepath_base}.pem"
         LOGGER.debug("Writing certificate %s", file_path_pem)
@@ -50,12 +50,14 @@ async def write_paa_root_cert(
 
 
 async def fetch_certificates(
-    paa_trust_store_path: pathlib.Path,
     fetch_test_certificates: bool = True,
     fetch_production_certificates: bool = True,
 ) -> int:
     """Fetch PAA Certificates."""
     LOGGER.info("Fetching the latest PAA root certificates from DCL.")
+    if not PAA_ROOT_CERTS_DIR.is_dir():
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, makedirs, PAA_ROOT_CERTS_DIR)
     fetch_count: int = 0
     base_urls = set()
     # determine which url's need to be queried.
@@ -94,7 +96,6 @@ async def fetch_certificates(
                     await write_paa_root_cert(
                         certificate,
                         subject,
-                        paa_trust_store_path,
                     )
                     LAST_CERT_IDS.add(paa["subjectKeyId"])
                     fetch_count += 1

--- a/matter_server/server/helpers/paa_certificates.py
+++ b/matter_server/server/helpers/paa_certificates.py
@@ -12,7 +12,7 @@ import logging
 import pathlib
 import re
 
-from aiohttp import ClientSession, ClientError
+from aiohttp import ClientError, ClientSession
 from cryptography import x509
 from cryptography.hazmat.primitives import serialization
 

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -87,6 +87,15 @@ def storage_controller_fixture() -> Generator[MagicMock, None, None]:
         yield storage_controller
 
 
+@pytest.fixture(name="fetch_certificates", autouse=True)
+def fetch_certificates_fixture() -> Generator[MagicMock, None, None]:
+    """Return a mocked fetch certificates."""
+    with patch(
+        "matter_server.server.device_controller.fetch_certificates", autospec=True
+    ) as fetch_certificates:
+        yield fetch_certificates
+
+
 @pytest.fixture(name="server")
 async def server_fixture() -> AsyncGenerator[MatterServer, None]:
     """Yield a server."""


### PR DESCRIPTION
- Address issues after https://github.com/home-assistant-libs/python-matter-server/pull/240.
- Move the certificates path constant to server constants. Use this constant directly in the helper script to fetch and generate certificates.
- Instantiate the chip controller when initializing the device controller instead of when instantiating the device controller.