### PR TITLE
Add missing test VID certificates

### DIFF
--- a/matter_server/server/helpers/paa_certificates.py
+++ b/matter_server/server/helpers/paa_certificates.py
@@ -21,6 +21,11 @@ from matter_server.server.const import PAA_ROOT_CERTS_DIR
 LOGGER = logging.getLogger(__name__)
 PRODUCTION_URL = "https://on.dcl.csa-iot.org"
 TEST_URL = "https://on.test-net.dcl.csa-iot.org"
+GIT_URL = "https://github.com/project-chip/connectedhomeip/raw/master/credentials/development/paa-root-certs"
+GIT_CERTS = [
+    "Chip-Test-PAA-FFF1-Cert",
+    "Chip-Test-PAA-NoVID-Cert",
+]
 
 LAST_CERT_IDS: set[str] = set()
 
@@ -105,4 +110,23 @@ async def fetch_certificates(
         )
     else:
         LOGGER.info("Fetched %s PAA root certificates from DCL.", fetch_count)
+
+    # fetch the certificates from the git repo
+    if fetch_test_certificates:
+        try:
+            async with ClientSession(raise_for_status=True) as http_session:
+                for cert in GIT_CERTS:
+                    if cert in LAST_CERT_IDS:
+                        continue
+
+                    async with http_session.get(f"{GIT_URL}/{cert}.pem") as response:
+                        certificate = await response.text()
+                    LAST_CERT_IDS.add(cert)
+                    await write_paa_root_cert(certificate, cert)
+                fetch_count += 1
+        except ClientError as err:
+            LOGGER.warning(
+                "Fetching latest certificates failed: error %s", err, exc_info=err
+            )
+
     return fetch_count


### PR DESCRIPTION
This will add the required test VID certificates from the matter git but in the future, we should add a way to change this behavior from the UI, like that the end user can choose which certificates to allow.

Fixes https://github.com/home-assistant-libs/python-matter-server/issues/255