### PR TITLE
Changed node removal behavior so fabric removal is optional

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -376,13 +376,16 @@ class MatterDeviceController:
         )
         fabric_index = node.attributes[attribute_path]
 
-        await self.chip_controller.SendCommand(
-            nodeid=node_id,
-            endpoint=0,
-            payload=Clusters.OperationalCredentials.Commands.RemoveFabric(
-                fabricIndex=fabric_index,
-            ),
-        )
+        try:
+            await self.chip_controller.SendCommand(
+                nodeid=node_id,
+                endpoint=0,
+                payload=Clusters.OperationalCredentials.Commands.RemoveFabric(
+                    fabricIndex=fabric_index,
+                ),
+            )
+        except ChipStackError as err:
+            LOGGER.error("Failed to remove node %s from fabric: %s", node_id, err)
 
         self.server.signal_event(EventType.NODE_DELETED, node_id)
 

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -376,18 +376,15 @@ class MatterDeviceController:
         )
         fabric_index = node.attributes[attribute_path]
 
-        try:
-            await self.chip_controller.SendCommand(
-                nodeid=node_id,
-                endpoint=0,
-                payload=Clusters.OperationalCredentials.Commands.RemoveFabric(
-                    fabricIndex=fabric_index,
-                ),
-            )
-        except ChipStackError as err:
-            LOGGER.error("Failed to remove node %s from fabric: %s", node_id, err)
-
         self.server.signal_event(EventType.NODE_DELETED, node_id)
+
+        await self.chip_controller.SendCommand(
+            nodeid=node_id,
+            endpoint=0,
+            payload=Clusters.OperationalCredentials.Commands.RemoveFabric(
+                fabricIndex=fabric_index,
+            ),
+        )
 
     async def subscribe_node(self, node_id: int) -> None:
         """


### PR DESCRIPTION
This change will make sure we always remove a node, even if it's offline or more importantly has been removed from our fabric by another controller or has been reset by the user.