### PR TITLE
Process nodes asynchronously

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -584,17 +584,17 @@ class MatterDeviceController:
 
         LOGGER.debug("Running %s tasks", len(tasks))
         # wait for all tasks to finish
-        futures: list[asyncio.Future] = await asyncio.gather(
+        results: list[Exception | None] = await asyncio.gather(
             *(_run_task(task) for task in tasks), return_exceptions=True
         )
         LOGGER.debug(
             "Done running %s tasks in %s seconds",
-            len(futures),
+            len(results),
             start_time - time.time(),
         )
         # check if any of the tasks failed
-        for future in futures:
-            if isinstance(future, Exception):
+        for result in results:
+            if isinstance(result, Exception):
                 # if any of the tasks failed, reschedule in 5 minutes
                 reschedule_interval = 300
                 break

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -43,7 +43,7 @@ DATA_KEY_NODES = "nodes"
 DATA_KEY_LAST_NODE_ID = "last_node_id"
 
 LOGGER = logging.getLogger(__name__)
-INTERVIEW_TASK_LIMIT = 5
+INTERVIEW_TASK_LIMIT = 10
 
 
 class MatterDeviceController:


### PR DESCRIPTION
This will process node interviews and subscriptions asynchronously and block from running the task again until all queued nodes have been processed.

fixes: https://github.com/home-assistant-libs/python-matter-server/issues/265