### PR TITLE
Bump chip clusters to 2023.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 
 [project.optional-dependencies]
 server = [
-  "home-assistant-chip-core==2023.2.2",
+  "home-assistant-chip-core==2023.4.0",
   "cryptography==40.0.2"
 ]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "coloredlogs",
   "dacite",
   "orjson",
-  "home-assistant-chip-clusters==2023.2.2"
+  "home-assistant-chip-clusters==2023.4.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Bump the CHIP clusters wheel to 2023.4 this includes the patch for the "Schema not found" error we've seen with several devices that send custom attributes on the vendor specific cluster.

Fixes #270 

Fixes https://github.com/home-assistant/core/issues/88986