### PR TITLE
Bump API schema to version 3

### DIFF
--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -173,6 +173,7 @@ class MatterClient:
 
         vendors_map = await self.send_command(
             APICommand.GET_VENDOR_NAMES,
+            require_schema=3,
             filter_vendors=[f.vendorId for f in fabrics],
         )
 

--- a/matter_server/common/const.py
+++ b/matter_server/common/const.py
@@ -2,4 +2,4 @@
 
 # schema version is used to determine compatibility between server and client
 # bump schema if we add new features and/or make other (breaking) changes
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3


### PR DESCRIPTION
No breaking changes but a new command was introduced: GET_VENDOR_NAMES hence the schema bump.