### PR TITLE
Fix get vendor names endpoint

### DIFF
--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -183,7 +183,7 @@ class MatterClient:
                 vendor_id=f.vendorId,
                 fabric_index=f.fabricIndex,
                 fabric_label=f.label if f.label else None,
-                vendor_name=vendors_map.get(f.vendorId),
+                vendor_name=vendors_map.get(str(f.vendorId)),
             )
             for f in fabrics
         ]

--- a/matter_server/server/vendor_info.py
+++ b/matter_server/server/vendor_info.py
@@ -87,7 +87,7 @@ class VendorInfo:
         if filter_vendors:
             vendors: dict[int, str] = {}
             for vendor_id in filter_vendors:
-                if vendor_id in filter_vendors:
+                if vendor_id in filter_vendors and vendor_id in self._data:
                     vendors[vendor_id] = self._data[vendor_id].vendor_name
             return vendors
 


### PR DESCRIPTION
Fixes issue that caused get vendor names to raise an exception if the vendor_filters parameter was used with a vendor missing from the DCL database like the NabuCasa and Amazon vendor IDs.