### PR TITLE
Bump Matter SDK Wheels

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,15 +32,15 @@ repos:
         args:
           - --branch=main
       - id: trailing-whitespace
-  # - repo: local
-  #   hooks:
-  #     - id: mypy
-  #       name: mypy
-  #       entry: mypy
-  #       types: [python]
-  #       language: system
-  #       files: ^(matter_server)/.+\.py$
-  #       require_serial: true
+  - repo: local
+    hooks:
+      - id: mypy
+        name: mypy
+        entry: mypy
+        types: [python]
+        language: system
+        files: ^(matter_server)/.+\.py$
+        require_serial: true
 #      - id: pylint
 #        name: pylint
 #        entry: pylint -j 0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,15 +32,15 @@ repos:
         args:
           - --branch=main
       - id: trailing-whitespace
-  - repo: local
-    hooks:
-      - id: mypy
-        name: mypy
-        entry: mypy
-        types: [python]
-        language: system
-        files: ^(matter_server)/.+\.py$
-        require_serial: true
+  # - repo: local
+  #   hooks:
+  #     - id: mypy
+  #       name: mypy
+  #       entry: mypy
+  #       types: [python]
+  #       language: system
+  #       files: ^(matter_server)/.+\.py$
+  #       require_serial: true
 #      - id: pylint
 #        name: pylint
 #        entry: pylint -j 0

--- a/matter_server/client/models/device_types.py
+++ b/matter_server/client/models/device_types.py
@@ -108,7 +108,7 @@ class BridgedDevice(DeviceType, device_type=0x0013):
 
     clusters = {
         all_clusters.Descriptor,
-        all_clusters.BridgedDeviceBasic,
+        all_clusters.BridgedDeviceBasicInformation,
         all_clusters.PowerSourceConfiguration,
         all_clusters.PowerSource,
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,12 +26,12 @@ dependencies = [
   "coloredlogs",
   "dacite",
   "orjson",
-  "home-assistant-chip-clusters==2023.4.1"
+  "home-assistant-chip-clusters==2023.5.0"
 ]
 
 [project.optional-dependencies]
 server = [
-  "home-assistant-chip-core==2023.4.1",
+  "home-assistant-chip-core==2023.5.0",
   "cryptography==40.0.2"
 ]
 test = [


### PR DESCRIPTION
- Bump the core and cluster wheels to version 2023.5.0 which are based on SDK release 1.1.0.1
- Small change for the renamed 'BridgedDeviceBasicInformation' in SDK 1.1

Change is backwards compatible, meaning client/HA doe snot need to be bumped.