### PR TITLE
Fixes variable that was renamed with sdk version 1.1.0.1

### DIFF
--- a/matter_server/client/models/node.py
+++ b/matter_server/client/models/node.py
@@ -200,7 +200,7 @@ class MatterEndpoint:
         cluster = self.get_cluster(Clusters.Descriptor)
         assert cluster is not None
         for dev_info in cluster.deviceTypeList:  # type: ignore[unreachable]
-            device_type = DEVICE_TYPES.get(dev_info.type)
+            device_type = DEVICE_TYPES.get(dev_info.deviceType)
             if device_type is None:
                 LOGGER.debug("Found unknown device type %s", dev_info)
                 continue


### PR DESCRIPTION
Fixes the name of the `DeviceTypeStruct` type variable from `type` to `deviceType` 
https://github.com/project-chip/connectedhomeip/blob/8f66f4215bc0708efc8cc73bda80620e67d8955f/src/controller/python/chip/clusters/Objects.py#L2764C19-L2776 