### PR TITLE
Handle edgecase where descriptor cluster is missing

### DIFF
--- a/matter_server/client/models/node.py
+++ b/matter_server/client/models/node.py
@@ -197,14 +197,13 @@ class MatterEndpoint:
         for attribute_path, attribute_value in attributes_data.items():
             self.set_attribute_value(attribute_path, attribute_value)
         # extract device types from Descriptor Cluster
-        cluster = self.get_cluster(Clusters.Descriptor)
-        assert cluster is not None
-        for dev_info in cluster.deviceTypeList:  # type: ignore[unreachable]
-            device_type = DEVICE_TYPES.get(dev_info.deviceType)
-            if device_type is None:
-                LOGGER.debug("Found unknown device type %s", dev_info)
-                continue
-            self.device_types.add(device_type)
+        if cluster := self.get_cluster(Clusters.Descriptor):
+            for dev_info in cluster.deviceTypeList:  # type: ignore[unreachable]
+                device_type = DEVICE_TYPES.get(dev_info.deviceType)
+                if device_type is None:
+                    LOGGER.debug("Found unknown device type %s", dev_info)
+                    continue
+                self.device_types.add(device_type)
 
     def __repr__(self) -> str:
         """Return the representation."""
@@ -326,7 +325,8 @@ class MatterNode:
                 # (as that will also use partsList to indicate its child's)
                 continue
             descriptor = endpoint.get_cluster(Clusters.Descriptor)
-            assert descriptor is not None
+            if descriptor is None:
+                continue
             if descriptor.partsList:  # type: ignore[unreachable]
                 for endpoint_id in descriptor.partsList:
                     self._composed_endpoints[endpoint_id] = endpoint.endpoint_id

--- a/matter_server/client/models/node.py
+++ b/matter_server/client/models/node.py
@@ -326,6 +326,11 @@ class MatterNode:
                 continue
             descriptor = endpoint.get_cluster(Clusters.Descriptor)
             if descriptor is None:
+                LOGGER.warning(
+                    "Found endpoint without a Descriptor: Node %s, endpoint %s",
+                    self.node_id,
+                    endpoint.endpoint_id,
+                )
                 continue
             if descriptor.partsList:  # type: ignore[unreachable]
                 for endpoint_id in descriptor.partsList:


### PR DESCRIPTION
Strictly speaking this may not happen, yet during testing with Switchbot devices I came across the edge case that one of the endpoints does not have a Descriptor cluster at all (completely missing).

Handle this in the code so we do not crash when this happens.