### PR TITLE
Use Python 3.11 for the Development container

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.11-slim-bullseye
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -16,9 +16,6 @@ RUN \
         unzip \
         libcairo2 \
         gdb \
-        gcc \
-        linux-libc-dev \
-        libc6-dev \
     && apt-get purge -y --auto-remove \
     && rm -rf \
         /var/lib/apt/lists/* \


### PR DESCRIPTION
The add-on moved to use Python 3.11. Use the same version here too. Furthermore, the latest CHIP wheels do not require psutils, which should not require a full toolchain installed (even on aarch64).