### PR TITLE
Update Dockerfile.dev - add dependencies for 3.5.0

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -13,6 +13,8 @@ RUN \
         openssl \
         zlib1g \
         libjson-c5 \
+        libnl-3-200 \
+        libnl-route-3-200 \
         unzip \
         libcairo2 \
         gdb \


### PR DESCRIPTION
Sync with changes made to addon dockerfile in https://github.com/home-assistant/addons/pull/3081

fixes #313 