### PR TITLE
Validate GitHub release on publish

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -2,7 +2,7 @@ name: Publish releases to PyPI
 
 on:
   release:
-    types: [published, prereleased]
+    types: [published]
 
 jobs:
   build-and-publish:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.5.3
+      - name: Get tag
+        id: vars
+        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
       - name: Set up Python 3.10
         uses: actions/setup-python@v4.6.1
         with:
@@ -17,6 +20,13 @@ jobs:
       - name: Install build
         run: >-
           pip install build
+      - name: Validate tag matches Python project version
+        shell: python
+        run: |-
+          import tomli
+          with open("pyproject.toml", "rb") as f:
+            pyproject = tomli.load(f)
+          assert pyproject["project"]["version"] == "${{ steps.vars.outputs.tag }}"
       - name: Build
         run: >-
           python3 -m build


### PR DESCRIPTION
Make sure the tag created by the GitHub release matches the Python project metadata.

This is in preparation for Docker image build, which will rely on the release tag to fetch the latest Matter Server from PyPI.