### PR TITLE
Use release tag as project version when creating a release

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -2,7 +2,7 @@ name: Publish releases to PyPI
 
 on:
   release:
-    types: [published, prereleased]
+    types: [published]
 
 jobs:
   build-and-publish:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,13 +10,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.5.3
+      - name: Get tag
+        id: vars
+        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
       - name: Set up Python 3.10
         uses: actions/setup-python@v4.6.1
         with:
           python-version: "3.10"
       - name: Install build
         run: >-
-          pip install build
+          pip install build tomli tomli-w
+      - name: Set Python project version from tag
+        shell: python
+        run: |-
+          import tomli
+          import tomli_w
+
+          with open("pyproject.toml", "rb") as f:
+            pyproject = tomli.load(f)
+
+          pyproject["project"]["version"] = "${{ steps.vars.outputs.tag }}"
+
+          with open("pyproject.toml", "wb") as f:
+            tomli_w.dump(pyproject, f)
       - name: Build
         run: >-
           python3 -m build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python-matter-server"
-version = "3.5.1"
+version = "0.0.0"
 license     = {text = "Apache-2.0"}
 description = "Python Matter WebSocket Server"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python-matter-server"
+# The version is set by GH action on release
 version = "0.0.0"
 license     = {text = "Apache-2.0"}
 description = "Python Matter WebSocket Server"


### PR DESCRIPTION
Use the tag created by the GitHub release and write it in the Python project metadata.

This is in preparation for Docker image build, which will rely on the release tag to fetch the latest Matter Server from PyPI.
