### PR TITLE
Add read attribute command/feature

### DIFF
--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -231,6 +231,19 @@ class MatterClient:
             interaction_timeout_ms=interaction_timeout_ms,
         )
 
+    async def read_attribute(
+        self,
+        node_id: int,
+        attribute_path: str | list[str],
+    ) -> Any:
+        """Read a single attribute on a node."""
+        return await self.send_command(
+            APICommand.READ_ATTRIBUTE,
+            require_schema=4,
+            node_id=node_id,
+            attribute_path=attribute_path,
+        )
+
     async def remove_node(self, node_id: int) -> None:
         """Remove a Matter node/device from the fabric."""
         await self.send_command(APICommand.REMOVE_NODE, node_id=node_id)

--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -236,7 +236,7 @@ class MatterClient:
     async def read_attribute(
         self,
         node_id: int,
-        attribute_path: str | list[str],
+        attribute_path: str,
     ) -> Any:
         """Read a single attribute on a node."""
         return await self.send_command(

--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -35,6 +35,8 @@ if TYPE_CHECKING:
 
 SUB_WILDCARD: Final = "*"
 
+# pylint: disable=too-many-public-methods
+
 
 class MatterClient:
     """Manage a Matter server over WebSockets."""

--- a/matter_server/common/models.py
+++ b/matter_server/common/models.py
@@ -41,6 +41,7 @@ class APICommand(str, Enum):
     REMOVE_NODE = "remove_node"
     GET_VENDOR_NAMES = "get_vendor_names"
     SUBSCRIBE_ATTRIBUTE = "subscribe_attribute"
+    READ_ATTRIBUTE = "read_attribute"
 
 
 EventCallBackType = Callable[[EventType, Any], None]

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -387,7 +387,7 @@ class MatterDeviceController:
     async def read_attribute(
         self,
         node_id: int,
-        attribute_path: str | list[str],
+        attribute_path: str,
     ) -> Any:
         """Read a single attribute on a node."""
         if self.chip_controller is None:


### PR DESCRIPTION
Add a command to read a live attribute value from a node

Usecase is a one-off read of some value (Like the thread diagnostics) where a subscription is not needed/wanted.