### PR TITLE
Use stable tag in example compose file

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 services:
   # python-matter-server
   matter-server:
-    image: matter-server:latest
+    image: matter-server:stable
     container_name: matter-server
     restart: unless-stopped
     # Required for mDNS to work correctly


### PR DESCRIPTION
Users are supposed to use the latest stable version of the container which is available under the tag "stable". The tag "latest" currently doesn't exist.