### PR TITLE
Improve node resolving for nodes offline at startup

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -584,9 +584,9 @@ class MatterDeviceController:
                 node_logger.debug("Unsubscribing from existing subscription.")
                 await self._call_sdk(prev_sub.Shutdown)
 
-        node_logger.debug("Setting up attributes and events subscription.")
         self._attr_subscriptions[node_id] = attr_subscriptions
         async with node_lock:
+            node_logger.debug("Setting up attributes and events subscription.")
             sub: Attribute.SubscriptionTransaction = await self.chip_controller.Read(
                 nodeid=node_id,
                 # In order to prevent network congestion due to wildcard subscriptions on all nodes,
@@ -844,8 +844,8 @@ class MatterDeviceController:
         if self.chip_controller is None:
             raise RuntimeError("Device Controller not initialized.")
         try:
-            LOGGER.info("Attempting to resolve node %s...", node_id)
             async with node_lock, self._resolve_lock:
+                LOGGER.info("Attempting to resolve node %s...", node_id)
                 await self._call_sdk(
                     self.chip_controller.ResolveNode,
                     nodeid=node_id,

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -844,7 +844,6 @@ class MatterDeviceController:
         if self.chip_controller is None:
             raise RuntimeError("Device Controller not initialized.")
         try:
-            # last attempt allows PASE connection (last resort)
             LOGGER.info("Attempting to resolve node %s...", node_id)
             async with node_lock, self._resolve_lock:
                 await self._call_sdk(


### PR DESCRIPTION
- Prevent concurrent resolve actions with a lock
- Simplify retry logic
- Retry more often

When one or more nodes are offline/unavailable (e.g. powered off, out of range, out of battery) at server startup, no automatic subscription is set-up for that device. Because the SDK does not expose a way to add a callback when a known node is discovered on mDNS, we do a regular poll to see if the device is back alive. This is now fixed and the poll interval is a little bit increased. It will start with a 30 second interval, slowly increasing that with 10 seconds to a maximum of 10 minutes, meaning that if one of those devices comes back online, it will take max 10 minutes for the server to pick the device back up again.

Once a device subscription has been set-up, a resubscription is done within a few seconds by the SDK.
It will however take 3 minutes before we detect that a device is offline which seems like a fair tradeoff between traffic vs comfort.

If we want to improve this even further, we may consider implementing zeroconf discovery within the server to actively listen for mDNS broadcasts for nodes we're watching but as this is a bit of an edge case (the device offline just while restarting the server) it may not be the highest priority.