### PR TITLE
Add some workaround logic to poll devices that are unavailable for a longer period of time

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -707,6 +707,7 @@ class MatterDeviceController:
                 # https://github.com/project-chip/connectedhomeip/pull/26718
                 sub.Shutdown()
                 self._subscriptions.pop(node_id)
+                assert self.server.loop
                 self.server.loop.create_task(
                     self._check_interview_and_subscription(node_id, MAX_POLL_INTERVAL)
                 )

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -808,7 +808,7 @@ class MatterDeviceController:
                 "will retry later in the background.",
                 node_id,
             )
-            # TODO: fix this once OerationalNodeDiscovery is available:
+            # TODO: fix this once OperationalNodeDiscovery is available:
             # https://github.com/project-chip/connectedhomeip/pull/26718
             reschedule()
 

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -51,6 +51,7 @@ DATA_KEY_LAST_NODE_ID = "last_node_id"
 
 LOGGER = logging.getLogger(__name__)
 INTERVIEW_TASK_LIMIT = 5
+MAX_POLL_INTERVAL = 600
 
 # a list of attributes we should always watch on all nodes
 DEFAULT_SUBSCRIBE_ATTRIBUTES: set[tuple[int | str, int | str, int | str]] = {
@@ -698,6 +699,17 @@ class MatterDeviceController:
             if node.available:
                 node.available = False
                 self.server.signal_event(EventType.NODE_UPDATED, node)
+            if nextResubscribeIntervalMsec / 1000 > MAX_POLL_INTERVAL:
+                # workaround to handle devices that are unplugged
+                # from power for a longer period of time
+                # cancel subscription and add this node to our node polling job
+                # TODO: fix this once OerationalNodeDiscovery is available:
+                # https://github.com/project-chip/connectedhomeip/pull/26718
+                sub.Shutdown()
+                self._subscriptions.pop(node_id)
+                self.server.loop.create_task(
+                    self._check_interview_and_subscription(node_id, MAX_POLL_INTERVAL)
+                )
 
         def resubscription_succeeded(
             transaction: Attribute.SubscriptionTransaction,
@@ -757,8 +769,9 @@ class MatterDeviceController:
                 asyncio.create_task,
                 self._check_interview_and_subscription(
                     node_id,
-                    # increase interval at each attempt with maximum of 10 minutes
-                    min(reschedule_interval + 10, 600),
+                    # increase interval at each attempt with maximum of
+                    # MAX_POLL_INTERVAL seconds (= 10 minutes)
+                    min(reschedule_interval + 10, MAX_POLL_INTERVAL),
                 ),
             )
 
@@ -794,6 +807,8 @@ class MatterDeviceController:
                 "will retry later in the background.",
                 node_id,
             )
+            # TODO: fix this once OerationalNodeDiscovery is available:
+            # https://github.com/project-chip/connectedhomeip/pull/26718
             reschedule()
 
     @staticmethod

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -860,7 +860,7 @@ class MatterDeviceController:
             raise RuntimeError("Device Controller not initialized.")
         try:
             async with node_lock, self._resolve_lock:
-                LOGGER.info("Attempting to resolve node %s...", node_id)
+                LOGGER.debug("Attempting to resolve node %s...", node_id)
                 await self._call_sdk(
                     self.chip_controller.ResolveNode,
                     nodeid=node_id,


### PR DESCRIPTION
Add a workaround that if a device is unavailable for a longer period of time (e.g. unplugged from power), we will fallback to regular polling (every 10 minutes) to detect if the device came back alive, just like we do with any devices that are offline when we startup the server.

By default we will use the resubscription logic within the SDK but if that resubsciption interval is higher then ours, we stop the subscription and create a job to poll this node on 10 minute intervals.

This is a workaround until the OperationalNodeDiscovery is implemented in the SDK, that way we can much more efficiently detect if a node is back online due to acting on the mdns packets.

Fixes #354 