### PR TITLE
Add basic issue template config to show links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: I have an issue or bug regarding using Matter with Home Assistant
+    url: https://github.com/home-assistant/core/issues?q=is:issue+is:open+label:%22integration:+matter%22
+    about: This is the issue tracker for Matter server library. Unless you are an application developer utilizing this library, please do not post issues directly in here. Instead report them at our Home Assistant core project.
+  - name: I'm looking for documentation how to setup Matter in Home Assistant
+    url: https://www.home-assistant.io/integrations/matter/
+    about: We have extended documentation for Matter on our website.


### PR DESCRIPTION
We want to redirect the issue where to get support and report issues. 

1) Show a page here to redirect to core repository
2) Have an additional issue template on core repo with additional questions important for Matter.