### PR TITLE
Relax setuptools dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools~=62.3", "wheel~=0.37.1"]
+requires = ["setuptools>=62.3"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
The latest version of setuptools is 68.1.2. Would it be possible to relax the dependency so that they can be used?

I have also removed listing `wheel` explicitly. According to the [setuptools documentation](https://setuptools.pypa.io/en/latest/userguide/quickstart.html#basic-use):

> Historically this documentation has unnecessarily listed wheel in the requires list, and many projects still do that. This is not recommended. The backend automatically adds wheel dependency when it is required, and listing it explicitly causes it to be unnecessarily required for source distribution builds. You should only include wheel in requires if you need to explicitly access it during build time (e.g. if your project needs a setup.py script that imports wheel).