### PR TITLE
Fix scripts/generate_devices.py scripts

### DIFF
--- a/scripts/generate_devices.py
+++ b/scripts/generate_devices.py
@@ -28,6 +28,8 @@ def gen_cls_name(name: str):
         if char in ("-", "/"):
             next_upper = True
             continue
+        elif char in ('.'):
+            continue
         elif next_upper:
             char = char.upper()
             next_upper = False


### PR DESCRIPTION
Fix `gen_cls_name` function to generate the class name correctly even if `.` is in the device type name

I found `generate_devices.py` script has a bug when creating a class for a cluster corresponding to `PM2.5 Concentration Measurement` in `matter-devices.xml`. So, I modified the script code to ignore `.` in the device type name to sync with the `connectedhomeip` repository