### PR TITLE
Bump chip wheels to 2023.11.0b1 (sdk 1.2 rc1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,12 +27,12 @@ dependencies = [
   "coloredlogs",
   "dacite",
   "orjson",
-  "home-assistant-chip-clusters==2023.6.0"
+  "home-assistant-chip-clusters==2023.10.0b1"
 ]
 
 [project.optional-dependencies]
 server = [
-  "home-assistant-chip-core==2023.6.0",
+  "home-assistant-chip-core==2023.11.0b1",
   "cryptography==41.0.4"
 ]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 
 [project.optional-dependencies]
 server = [
-  "home-assistant-chip-core==2023.11.0b1",
+  "home-assistant-chip-core==2023.10.0b1",
   "cryptography==41.0.4"
 ]
 test = [


### PR DESCRIPTION
Bump main branch to Matter SDK version 1.2 (RC1)
Did some basic testing this afternoon and everything still works as expected so no backward compatibility issues (so far).

1.2 specific changes/new features can be added once main is at 1.2

NOTE: For HA core we-re going to create a temporary branch while the exact release data of 1.2 is not in sync with the HA release cycle.