### PR TITLE
Cleanup/clarify commission_on_network

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Inform the controller about the Thread credentials it needs to use when commissi
 ```
 
 **Commission with code**
-Commission a new device. For WiFi or Thread based devices, the credentials need to be set upfront, otherwise commisisoning will fail.
+Commission a new device. For WiFi or Thread based devices, the credentials need to be set upfront, otherwise commisisoning will fail. Supports both QR-code syntax (MT:...) and manual pairing code as string.
 The controller will use bluetooth for the commissioning of wireless devices. If the machine running the Python Matter Server controller lacks bluetooth support, commissioning will only work for devices already connected to the network (by cable or another controller).
 
 ```json
@@ -192,19 +192,6 @@ The controller will use bluetooth for the commissioning of wireless devices. If 
   "command": "commission_with_code",
   "args": {
     "code": "MT:Y.ABCDEFG123456789"
-  }
-}
-```
-
-**Commission on Network**
-Commission a device already connected to the network.
-
-```json
-{
-  "message_id": "2",
-  "command": "commission_on_network",
-  "args": {
-    "setup_pin_code": 1234567
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Inform the controller about the Thread credentials it needs to use when commissi
 ```
 
 **Commission with code**
-Commission a new device. For WiFi or Thread based devices, the credentials need to be set upfront, otherwise commisisoning will fail. Supports both QR-code syntax (MT:...) and manual pairing code as string.
+Commission a new device. For WiFi or Thread based devices, the credentials need to be set upfront, otherwise commissioning will fail. Supports both QR-code syntax (MT:...) and manual pairing code as string.
 The controller will use bluetooth for the commissioning of wireless devices. If the machine running the Python Matter Server controller lacks bluetooth support, commissioning will only work for devices already connected to the network (by cable or another controller).
 
 ```json

--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -122,10 +122,7 @@ class MatterClient:
 
     async def commission_on_network(self, setup_pin_code: int) -> MatterNodeData:
         """
-        Do the routine for OnNetworkCommissioning, with a filter for mDNS discovery.
-
-        The filter can be an integer,
-        a string or None depending on the actual type of selected filter.
+        Do the routine for OnNetworkCommissioning.
 
         NOTE: For advanced usecases only, use `commission_with_code`
         for regular commissioning.

--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -122,7 +122,8 @@ class MatterClient:
 
     async def commission_on_network(self, setup_pin_code: int) -> MatterNodeData:
         """
-        Does the routine for OnNetworkCommissioning, with a filter for mDNS discovery.
+        Do the routine for OnNetworkCommissioning, with a filter for mDNS discovery.
+
         The filter can be an integer,
         a string or None depending on the actual type of selected filter.
 

--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -122,7 +122,12 @@ class MatterClient:
 
     async def commission_on_network(self, setup_pin_code: int) -> MatterNodeData:
         """
-        Commission a device already connected to the network.
+        Does the routine for OnNetworkCommissioning, with a filter for mDNS discovery.
+        The filter can be an integer,
+        a string or None depending on the actual type of selected filter.
+
+        NOTE: For advanced usecases only, use `commission_with_code`
+        for regular commissioning.
 
         Returns basic MatterNodeData once complete.
         """

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -187,7 +187,8 @@ class MatterDeviceController:
         filter: Any = None,  # pylint: disable=redefined-builtin
     ) -> MatterNodeData:
         """
-        Does the routine for OnNetworkCommissioning, with a filter for mDNS discovery.
+        Do the routine for OnNetworkCommissioning, with a filter for mDNS discovery.
+
         The filter can be an integer,
         a string or None depending on the actual type of selected filter.
 

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -187,11 +187,13 @@ class MatterDeviceController:
         filter: Any = None,  # pylint: disable=redefined-builtin
     ) -> MatterNodeData:
         """
-        Commission a device already connected to the network.
-
         Does the routine for OnNetworkCommissioning, with a filter for mDNS discovery.
         The filter can be an integer,
         a string or None depending on the actual type of selected filter.
+
+        NOTE: For advanced usecases only, use `commission_with_code`
+        for regular commissioning.
+
         Returns full NodeInfo once complete.
         """
         if self.chip_controller is None:


### PR DESCRIPTION
commission_on_network has a very confusing name and is actually not used for commissioning. I left it in the public api to not break anything but I've updated the docstrings and readme. commission_with_code is used for all scenarios, even for on-network devices like bridges and sharing from another controller. This was not very clear at this point.

fixes #408 