### PR TITLE
Automatically re-interview a node if its software version has changed

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -819,8 +819,6 @@ class MatterDeviceController:
             node_data is None
             # re-interview if the schema has changed
             or node_data.interview_version < SCHEMA_VERSION
-            # re-interview every 30 days
-            or (datetime.utcnow() - node_data.last_interview).days > 30
         ):
             try:
                 await self.interview_node(node_id)

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -656,6 +656,14 @@ class MatterDeviceController:
                     )
                 return
 
+            # work out if software version changed
+            if (
+                path.AttributeType == Clusters.BasicInformation.softwareVersion
+                and new_value != old_value
+            ):
+                # schedule a full interview of the node if the software version changed
+                self.server.loop.create_task(self.interview_node(node_id))
+
             # store updated value in node attributes
             node.attributes[attr_path] = new_value
 


### PR DESCRIPTION
Instead of re-interviewing every 30 days, just check the software version number of a node.
If the software version changed, schedule a re-interview.