### PR TITLE
Add IP utilities for diagnostics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN \
         libnl-route-3-200 \
         unzip \
         gdb \
+        iputils-ping \
+        iproute2 \
     && apt-get purge -y --auto-remove \
     && rm -rf \
         /var/lib/apt/lists/* \


### PR DESCRIPTION
To help diagnose connectivity issues we intend to add diagnostics functionality. We plan to use regular IP utilities for this, hence add them to the base container. They might also be helpful when manually debugging connectivity issues.