### PR TITLE
Add temporary guard for infinite loop in resub logic

### DIFF
--- a/matter_server/common/models.py
+++ b/matter_server/common/models.py
@@ -80,6 +80,7 @@ class MatterNodeData:
     attribute_subscriptions: set[tuple[int | str, int | str, int | str]] = field(
         default_factory=set
     )
+    last_subscription_attempt: float = 0
 
 
 @dataclass


### PR DESCRIPTION
We've got reports about an infinite loop in the sdk resubscription logic where the resubscription is attempted without respecting the timeout, causing an endless loop consuming a full cpu core.

Awaiting further investigation I have now put in a quick guard in the code that detects the infinite loop, logs it as error and tears down the subscription. The reconnect is then handled by our poll logic.

Closes #426 