### PR TITLE
Debounce node availability a bit

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -758,7 +758,7 @@ class MatterDeviceController:
                 nextResubscribeIntervalMsec,
             )
             # mark node as unavailable and signal consumers
-            if node.available:
+            if nextResubscribeIntervalMsec > 10000 and node.available:
                 node.available = False
                 self.server.signal_event(EventType.NODE_UPDATED, node)
 


### PR DESCRIPTION
Debounce marking a node as unavailable a bit to ignore very quick reconnects (which are unavoidable in an IP based network). If a node is unavailable for 10 seconds or more, the node will be marked as unavailable. This is comperable to how other controllers (such as Apple Home, Google Home) do this so the experience will be more alike.