### PR TITLE
Support custom Clusters and Attributes

### DIFF
--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -242,13 +242,25 @@ class MatterClient:
         node_id: int,
         attribute_path: str,
     ) -> Any:
-        """Read a single attribute on a node."""
+        """Read attribute(s) on a node."""
         return await self.send_command(
             APICommand.READ_ATTRIBUTE,
             require_schema=4,
             node_id=node_id,
             attribute_path=attribute_path,
         )
+
+    async def refresh_attribute(
+        self,
+        node_id: int,
+        attribute_path: str,
+    ) -> Any:
+        """Read attribute(s) on a node and store the updated value(s)."""
+        updated_values = await self.read_attribute(node_id, attribute_path)
+        if not isinstance(updated_values, dict):
+            updated_values = {attribute_path: updated_values}
+        for attr_path, value in updated_values.items():
+            self._nodes[node_id].update_attribute(attr_path, value)
 
     async def write_attribute(
         self,

--- a/matter_server/client/models/clusters.py
+++ b/matter_server/client/models/clusters.py
@@ -3,13 +3,13 @@
 from dataclasses import dataclass
 from typing import ClassVar
 
+from chip import ChipUtility
 from chip.clusters.ClusterObjects import (
     Cluster,
     ClusterAttributeDescriptor,
     ClusterObjectDescriptor,
     ClusterObjectFieldDescriptor,
 )
-from chip import ChipUtility
 from chip.tlv import float32
 
 

--- a/matter_server/client/models/clusters.py
+++ b/matter_server/client/models/clusters.py
@@ -10,7 +10,7 @@ from chip.clusters.ClusterObjects import (
     ClusterObjectFieldDescriptor,
 )
 from chip import ChipUtility
-from chip.tlv import float32, uint
+from chip.tlv import float32
 
 
 @dataclass
@@ -21,6 +21,7 @@ class EveEnergyCluster(Cluster):
 
     @ChipUtility.classproperty
     def descriptor(cls) -> ClusterObjectDescriptor:
+        """Return descriptor for this cluster."""
         return ClusterObjectDescriptor(
             Fields=[
                 ClusterObjectFieldDescriptor(
@@ -50,80 +51,105 @@ class EveEnergyCluster(Cluster):
     class Attributes:
         @dataclass
         class Watt(ClusterAttributeDescriptor):
+            """Watt Attribute within the EveEnergy Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x130AFC01
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x130A000A
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=float32)
 
             value: float32 = 0
 
         @dataclass
         class WattAccumulated(ClusterAttributeDescriptor):
+            """WattAccumulated Attribute within the EveEnergy Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x130AFC01
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x130A000B
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=float32)
 
             value: float32 = 0
 
         @dataclass
         class wattAccumulatedControlPoint(ClusterAttributeDescriptor):
+            """wattAccumulatedControlPoint Attribute within the EveEnergy Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x130AFC01
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x130A000E
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=float32)
 
             value: float32 = 0
 
         @dataclass
         class Voltage(ClusterAttributeDescriptor):
+            """Voltage Attribute within the EveEnergy Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x130AFC01
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x130A0008
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=float32)
 
             value: float32 = 0
 
         @dataclass
         class Current(ClusterAttributeDescriptor):
+            """Current Attribute within the EveEnergy Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x130AFC01
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x130A0009
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=float32)
 
             value: float32 = 0

--- a/matter_server/client/models/clusters.py
+++ b/matter_server/client/models/clusters.py
@@ -12,6 +12,8 @@ from chip.clusters.ClusterObjects import (
 )
 from chip.tlv import float32
 
+# pylint: disable=invalid-name,arguments-renamed,no-self-argument
+
 
 @dataclass
 class EveEnergyCluster(Cluster):

--- a/matter_server/client/models/clusters.py
+++ b/matter_server/client/models/clusters.py
@@ -1,0 +1,129 @@
+"""Various models and helpers for (custom) Matter clusters."""
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+from chip.clusters.ClusterObjects import (
+    Cluster,
+    ClusterAttributeDescriptor,
+    ClusterObjectDescriptor,
+    ClusterObjectFieldDescriptor,
+)
+from chip import ChipUtility
+from chip.tlv import float32, uint
+
+
+@dataclass
+class EveEnergyCluster(Cluster):
+    """Custom (vendor-specific) cluster for Eve Energy plug."""
+
+    id: ClassVar[int] = 0x130AFC01
+
+    @ChipUtility.classproperty
+    def descriptor(cls) -> ClusterObjectDescriptor:
+        return ClusterObjectDescriptor(
+            Fields=[
+                ClusterObjectFieldDescriptor(
+                    Label="watt", Tag=0x130A000A, Type=float32
+                ),
+                ClusterObjectFieldDescriptor(
+                    Label="wattAccumulated", Tag=0x130A000B, Type=float32
+                ),
+                ClusterObjectFieldDescriptor(
+                    Label="wattAccumulatedControlPoint", Tag=0x130A000E, Type=float32
+                ),
+                ClusterObjectFieldDescriptor(
+                    Label="voltage", Tag=0x130A0008, Type=float32
+                ),
+                ClusterObjectFieldDescriptor(
+                    Label="current", Tag=0x130A0009, Type=float32
+                ),
+            ]
+        )
+
+    watt: float32 | None = None
+    wattAccumulated: float32 | None = None
+    wattAccumulatedControlPoint: float32 | None = None
+    voltage: float32 | None = None
+    current: float32 | None = None
+
+    class Attributes:
+        @dataclass
+        class Watt(ClusterAttributeDescriptor):
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                return 0x130AFC01
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                return 0x130A000A
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                return ClusterObjectFieldDescriptor(Type=float32)
+
+            value: float32 = 0
+
+        @dataclass
+        class WattAccumulated(ClusterAttributeDescriptor):
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                return 0x130AFC01
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                return 0x130A000B
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                return ClusterObjectFieldDescriptor(Type=float32)
+
+            value: float32 = 0
+
+        @dataclass
+        class wattAccumulatedControlPoint(ClusterAttributeDescriptor):
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                return 0x130AFC01
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                return 0x130A000E
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                return ClusterObjectFieldDescriptor(Type=float32)
+
+            value: float32 = 0
+
+        @dataclass
+        class Voltage(ClusterAttributeDescriptor):
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                return 0x130AFC01
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                return 0x130A0008
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                return ClusterObjectFieldDescriptor(Type=float32)
+
+            value: float32 = 0
+
+        @dataclass
+        class Current(ClusterAttributeDescriptor):
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                return 0x130AFC01
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                return 0x130A0009
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                return ClusterObjectFieldDescriptor(Type=float32)
+
+            value: float32 = 0

--- a/matter_server/client/models/clusters.py
+++ b/matter_server/client/models/clusters.py
@@ -49,6 +49,8 @@ class EveEnergyCluster(Cluster):
     current: float32 | None = None
 
     class Attributes:
+        """Attributes for the EveEnergy Cluster."""
+
         @dataclass
         class Watt(ClusterAttributeDescriptor):
             """Watt Attribute within the EveEnergy Cluster."""

--- a/matter_server/client/models/node.py
+++ b/matter_server/client/models/node.py
@@ -197,6 +197,8 @@ class MatterEndpoint:
             self.clusters[cluster_id] = cluster_instance
 
         # unpack cluster attribute, using the descriptor
+        assert cluster_id is not None
+        assert attribute_id is not None
         attribute_class: type[Clusters.ClusterAttributeDescriptor] = ALL_ATTRIBUTES[
             cluster_id
         ][attribute_id]

--- a/matter_server/client/models/node.py
+++ b/matter_server/client/models/node.py
@@ -96,7 +96,11 @@ class MatterEndpoint:
         return self.node.device_info
 
     def has_cluster(self, cluster: type[_CLUSTER_T] | int) -> bool:
-        """Check if endpoint has a specific cluster."""
+        """
+        Check if endpoint has a specific cluster.
+
+        Provide the cluster to lookup either as the class/type or the id.
+        """
         if isinstance(cluster, type):
             return cluster.id in self.clusters
         return cluster in self.clusters
@@ -105,6 +109,7 @@ class MatterEndpoint:
         """
         Get a full Cluster object containing all attributes.
 
+        Provide the cluster to lookup either as the class/type or the id.
         Return None if the Cluster is not present on the node.
         """
         if isinstance(cluster, type):
@@ -115,12 +120,12 @@ class MatterEndpoint:
         self,
         cluster: type[_CLUSTER_T] | int | None,
         attribute: int | type[_ATTRIBUTE_T],
-    ) -> type[_ATTRIBUTE_T] | Clusters.ClusterAttributeDescriptor | None:
+    ) -> Any:
         """
         Return Matter Cluster Attribute object for given parameters.
 
-        Send cluster as None to derive it from the Attribute.,
-        you must provide the attribute as type/class in that case.
+        Either supply a cluster id and attribute id or omit cluster
+        and supply the Attribute class/type.
         """
         if cluster is None:
             # allow sending None for Cluster to auto resolve it from the Attribute
@@ -149,7 +154,12 @@ class MatterEndpoint:
         cluster: type[_CLUSTER_T] | int | None,
         attribute: int | type[_ATTRIBUTE_T],
     ) -> bool:
-        """Perform a quick check if the endpoint has a specific attribute."""
+        """
+        Perform a quick check if the endpoint has a specific attribute.
+
+        Either supply a cluster id and attribute id or omit cluster
+        and supply the Attribute class/type.
+        """
         if cluster is None:
             if isinstance(attribute, int):
                 raise TypeError("Attribute can not be integer if Cluster is omitted")
@@ -171,6 +181,14 @@ class MatterEndpoint:
         Do not modify the data directly from a consumer.
         """
         _, cluster_id, attribute_id = parse_attribute_path(attribute_path)
+        if (
+            cluster_id not in ALL_CLUSTERS
+            or cluster_id not in ALL_ATTRIBUTES
+            or attribute_id not in ALL_ATTRIBUTES[cluster_id]
+        ):
+            # guard for unknown/custom clusters/attributes
+            return
+
         cluster_class: type[Clusters.Cluster] = ALL_CLUSTERS[cluster_id]
         if cluster_id in self.clusters:
             cluster_instance = self.clusters[cluster_id]

--- a/matter_server/client/models/node.py
+++ b/matter_server/client/models/node.py
@@ -188,7 +188,8 @@ class MatterEndpoint:
         ):
             # guard for unknown/custom clusters/attributes
             return
-
+        assert cluster_id is not None  # for mypy
+        assert attribute_id is not None  # for mypy
         cluster_class: type[Clusters.Cluster] = ALL_CLUSTERS[cluster_id]
         if cluster_id in self.clusters:
             cluster_instance = self.clusters[cluster_id]
@@ -197,8 +198,6 @@ class MatterEndpoint:
             self.clusters[cluster_id] = cluster_instance
 
         # unpack cluster attribute, using the descriptor
-        assert cluster_id is not None
-        assert attribute_id is not None
         attribute_class: type[Clusters.ClusterAttributeDescriptor] = ALL_ATTRIBUTES[
             cluster_id
         ][attribute_id]

--- a/matter_server/common/const.py
+++ b/matter_server/common/const.py
@@ -2,4 +2,4 @@
 
 # schema version is used to determine compatibility between server and client
 # bump schema if we add new features and/or make other (breaking) changes
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5

--- a/matter_server/common/helpers/json.py
+++ b/matter_server/common/helpers/json.py
@@ -7,7 +7,6 @@ from chip.clusters.Types import Nullable
 from chip.tlv import float32, uint
 import orjson
 
-
 JSON_ENCODE_EXCEPTIONS = (TypeError, ValueError)
 JSON_DECODE_EXCEPTIONS = (orjson.JSONDecodeError,)
 

--- a/matter_server/common/helpers/json.py
+++ b/matter_server/common/helpers/json.py
@@ -1,14 +1,12 @@
 """Helpers to work with (de)serializing of json."""
 
 from base64 import b64encode
-from dataclasses import is_dataclass
 from typing import Any
 
 from chip.clusters.Types import Nullable
 from chip.tlv import float32, uint
 import orjson
 
-from .util import dataclass_to_dict
 
 JSON_ENCODE_EXCEPTIONS = (TypeError, ValueError)
 JSON_DECODE_EXCEPTIONS = (orjson.JSONDecodeError,)
@@ -27,10 +25,6 @@ def json_encoder_default(obj: Any) -> Any:
         return float(obj)
     if isinstance(obj, uint):
         return int(obj)
-    if hasattr(obj, "as_dict"):
-        return obj.as_dict()
-    if is_dataclass(obj):
-        return dataclass_to_dict(obj)
     if isinstance(obj, Nullable):
         return None
     if isinstance(obj, bytes):
@@ -39,7 +33,6 @@ def json_encoder_default(obj: Any) -> Any:
         return str(obj)
     if type(obj) is type:  # pylint: disable=unidiomatic-typecheck
         return f"{obj.__module__}.{obj.__qualname__}"
-
     raise TypeError
 
 
@@ -47,9 +40,7 @@ def json_dumps(data: Any) -> str:
     """Dump json string."""
     return orjson.dumps(
         data,
-        option=orjson.OPT_NON_STR_KEYS
-        | orjson.OPT_INDENT_2
-        | orjson.OPT_PASSTHROUGH_DATACLASS,
+        option=orjson.OPT_NON_STR_KEYS | orjson.OPT_INDENT_2,
         default=json_encoder_default,
     ).decode("utf-8")
 

--- a/matter_server/common/helpers/util.py
+++ b/matter_server/common/helpers/util.py
@@ -16,6 +16,7 @@ from typing import (
     Any,
     TypeVar,
     Union,
+    cast,
     get_args,
     get_origin,
     get_type_hints,
@@ -94,8 +95,8 @@ def _get_descriptor_key(descriptor: ClusterObjectDescriptor, key: str | int) -> 
     """Return correct Cluster attribute key for a tag id."""
     if (isinstance(key, str) and key.isnumeric()) or isinstance(key, int):
         if field := descriptor.GetFieldByTag(int(key)):
-            return field.Label
-    return key
+            return cast(str, field.Label)
+    return cast(str, key)
 
 
 def parse_value(

--- a/matter_server/common/helpers/util.py
+++ b/matter_server/common/helpers/util.py
@@ -90,9 +90,9 @@ def parse_utc_timestamp(datetime_string: str) -> datetime:
     return datetime.fromisoformat(datetime_string.replace("Z", "+00:00"))
 
 
-def _get_descriptor_key(descriptor: ClusterObjectDescriptor, key: Any):
+def _get_descriptor_key(descriptor: ClusterObjectDescriptor, key: str | int) -> str:
     """Return correct Cluster attribute key for a tag id."""
-    if isinstance(key, str) and key.isnumeric():
+    if (isinstance(key, str) and key.isnumeric()) or isinstance(key, int):
         if field := descriptor.GetFieldByTag(int(key)):
             return field.Label
     return key

--- a/matter_server/common/helpers/util.py
+++ b/matter_server/common/helpers/util.py
@@ -46,20 +46,27 @@ def create_attribute_path_from_attribute(
     )
 
 
-def create_attribute_path(endpoint: int, cluster_id: int, attribute_id: int) -> str:
+def create_attribute_path(
+    endpoint: int | None, cluster_id: int | None, attribute_id: int | None
+) -> str:
     """
-    Create path/identifier for an Attribute.
+    Create path/identifier string for an Attribute.
 
-    Returns same output as `Attribute.AttributePath`
+    Returns same output as `Attribute.AttributePath` string representation.
     endpoint/cluster_id/attribute_id
     """
     return f"{endpoint}/{cluster_id}/{attribute_id}"
 
 
-def parse_attribute_path(attribute_path: str) -> tuple[int, int, int]:
-    """Parse AttributePath string into endpoint_id, cluster_id, attribute_id."""
+def parse_attribute_path(
+    attribute_path: str,
+) -> tuple[int | None, int | None, int | None]:
+    """Parse AttributePath string into tuple of endpoint_id, cluster_id, attribute_id."""
     endpoint_id_str, cluster_id_str, attribute_id_str = attribute_path.split("/")
-    return (int(endpoint_id_str), int(cluster_id_str), int(attribute_id_str))
+    endpoint_id = int(endpoint_id_str) if endpoint_id_str.isnumeric() else None
+    cluster_id = int(cluster_id_str) if cluster_id_str.isnumeric() else None
+    attribute_id = int(attribute_id_str) if attribute_id_str.isnumeric() else None
+    return (endpoint_id, cluster_id, attribute_id)
 
 
 def dataclass_to_dict(obj_in: DataclassInstance) -> dict:
@@ -80,7 +87,13 @@ def parse_utc_timestamp(datetime_string: str) -> datetime:
     return datetime.fromisoformat(datetime_string.replace("Z", "+00:00"))
 
 
-def parse_value(name: str, value: Any, value_type: Any, default: Any = MISSING) -> Any:
+def parse_value(
+    name: str,
+    value: Any,
+    value_type: Any,
+    default: Any = MISSING,
+    allow_none: bool = True,
+) -> Any:
     """Try to parse a value from raw (json) data and type annotations."""
     # pylint: disable=too-many-return-statements,too-many-branches
 
@@ -89,9 +102,15 @@ def parse_value(name: str, value: Any, value_type: Any, default: Any = MISSING) 
         value_type = get_type_hints(value_type, globals(), locals())
 
     if isinstance(value, dict):
-        # always prefer classes that have a from_dict
-        if hasattr(value_type, "from_dict"):
-            return value_type.from_dict(value)
+        if descriptor := getattr(value_type, "descriptor", None):
+            # handle matter TLV dicts where the keys are just tag identifiers
+            def _get_descriptor_key(key: Any):
+                if isinstance(key, str) and key.isnumeric():
+                    if field := descriptor.GetFieldByTag(int(key)):
+                        return field.Label
+                return key
+
+            value = {_get_descriptor_key(x): y for x, y in value.items()}
         # handle a parse error in the sdk which is returned as:
         # {'TLVValue': None, 'Reason': None} or {'TLVValue': None}
         if value.get("TLVValue", MISSING) is None:
@@ -102,6 +121,8 @@ def parse_value(name: str, value: Any, value_type: Any, default: Any = MISSING) 
     if value is None and not isinstance(default, type(MISSING)):
         return default
     if value is None and value_type is NoneType:
+        return None
+    if value is None and allow_none:
         return None
     if value is None and value_type is Nullable:
         return None
@@ -155,7 +176,7 @@ def parse_value(name: str, value: Any, value_type: Any, default: Any = MISSING) 
     if value_type is Any:
         return value
     # raise if value is None and the value is required according to annotations
-    if value is None and value_type is not NoneType:
+    if value is None and value_type is not NoneType and not allow_none:
         raise KeyError(f"`{name}` of type `{value_type}` is required.")
 
     try:
@@ -192,7 +213,9 @@ def parse_value(name: str, value: Any, value_type: Any, default: Any = MISSING) 
     ):
         return uint(value)
     if value_type is float32 and (
-        isinstance(value, float) or (isinstance(value, str) and value.isnumeric())
+        isinstance(value, float)
+        or isinstance(value, int)
+        or (isinstance(value, str) and value.isnumeric())
     ):
         return float32(value)
 

--- a/matter_server/common/models.py
+++ b/matter_server/common/models.py
@@ -76,8 +76,8 @@ class MatterNodeData:
     attributes: dict[str, Any] = field(default_factory=dict)
     # all attribute subscriptions we need to persist for this node,
     # a set of tuples in format (endpoint_id, cluster_id, attribute_id)
-    # where each value can also be a '*' for wildcard
-    attribute_subscriptions: set[tuple[int | str, int | str, int | str]] = field(
+    # where each value can also be a None for wildcard
+    attribute_subscriptions: set[tuple[int | None, int | None, int | None]] = field(
         default_factory=set
     )
     last_subscription_attempt: float = 0

--- a/matter_server/server/const.py
+++ b/matter_server/server/const.py
@@ -3,7 +3,7 @@ import pathlib
 from typing import Final
 
 # The minimum schema version (of a client) the server can support
-MIN_SCHEMA_VERSION = 2
+MIN_SCHEMA_VERSION = 5
 
 # the paa-root-certs path is hardcoded in the sdk at this time
 # and always uses the development subfolder
@@ -15,4 +15,4 @@ PAA_ROOT_CERTS_DIR: Final[pathlib.Path] = (
     .parent.resolve()
     .parent.resolve()
     .joinpath("credentials/development/paa-root-certs")
-)
+)§

--- a/matter_server/server/const.py
+++ b/matter_server/server/const.py
@@ -15,4 +15,4 @@ PAA_ROOT_CERTS_DIR: Final[pathlib.Path] = (
     .parent.resolve()
     .parent.resolve()
     .joinpath("credentials/development/paa-root-certs")
-)§
+)

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -394,6 +394,7 @@ class MatterDeviceController:
         endpoint_id, cluster_id, attribute_id = parse_attribute_path(attribute_path)
         async with node_lock:
             self.chip_controller.CheckIsActive()
+            assert self.server.loop is not None
             future = self.server.loop.create_future()
             device = self.chip_controller.GetConnectedDeviceSync(node_id)
             Attribute.Read(
@@ -414,6 +415,7 @@ class MatterDeviceController:
                 result.tlvAttributes
             )
             # update cached info in node attributes
+            assert self._nodes[node_id] is not None
             self._nodes[node_id].attributes.update(read_atributes)
             if len(read_atributes) > 1:
                 return read_atributes
@@ -615,6 +617,7 @@ class MatterDeviceController:
                 else random.randint(40, 70)
             )
             self.chip_controller.CheckIsActive()
+            assert self.server.loop is not None
             future = self.server.loop.create_future()
             device = self.chip_controller.GetConnectedDeviceSync(node_id)
             Attribute.Read(
@@ -881,7 +884,7 @@ class MatterDeviceController:
 
     @staticmethod
     def _parse_attributes_from_read_result(
-        raw_tlv_attributes: dict[int, dict[int, dict[int, Any]]] | None = None,
+        raw_tlv_attributes: dict[int, dict[int, dict[int, Any]]],
     ) -> dict[str, Any]:
         """Parse attributes from ReadResult's TLV Attributes."""
         result = {}

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -795,6 +795,7 @@ class MatterDeviceController:
         node.available = True
         # update attributes with current state from read request
         # NOTE: Make public method upstream for retrieving the attributeTLVCache
+        # pylint: disable=protected-access
         tlv_attributes = sub._readTransaction._cache.attributeTLVCache
         node.attributes.update(self._parse_attributes_from_read_result(tlv_attributes))
         node_logger.info("Subscription succeeded")

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -14,11 +14,7 @@ from typing import TYPE_CHECKING, Any, Callable, Iterable, TypeVar, cast
 from chip.ChipDeviceCtrl import CommissionableNode
 from chip.clusters import Attribute, Objects as Clusters
 from chip.clusters.Attribute import ValueDecodeFailure
-from chip.clusters.ClusterObjects import (
-    ALL_ATTRIBUTES,
-    ALL_CLUSTERS,
-    Cluster,
-)
+from chip.clusters.ClusterObjects import ALL_ATTRIBUTES, ALL_CLUSTERS, Cluster
 from chip.exceptions import ChipStackError
 
 from ..common.const import SCHEMA_VERSION

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -415,8 +415,9 @@ class MatterDeviceController:
                 result.tlvAttributes
             )
             # update cached info in node attributes
-            assert self._nodes[node_id] is not None
-            self._nodes[node_id].attributes.update(read_atributes)
+            self._nodes[node_id].attributes.update(  # type: ignore[union-attr]
+                read_atributes
+            )
             if len(read_atributes) > 1:
                 return read_atributes
             return read_atributes.get(attribute_path, None)

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -9,7 +9,7 @@ from functools import partial
 import logging
 import random
 import time
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Type, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Callable, Iterable, TypeVar, cast
 
 from chip.ChipDeviceCtrl import CommissionableNode
 from chip.clusters import Attribute, Objects as Clusters
@@ -18,7 +18,6 @@ from chip.clusters.ClusterObjects import (
     ALL_ATTRIBUTES,
     ALL_CLUSTERS,
     Cluster,
-    ClusterAttributeDescriptor,
 )
 from chip.exceptions import ChipStackError
 
@@ -30,7 +29,6 @@ from ..common.errors import (
     NodeNotResolving,
 )
 from ..common.helpers.api import api_command
-from ..common.helpers.json import json_dumps
 from ..common.helpers.util import (
     create_attribute_path,
     create_attribute_path_from_attribute,
@@ -55,11 +53,11 @@ LOGGER = logging.getLogger(__name__)
 MAX_POLL_INTERVAL = 600
 
 # a list of attributes we should always watch on all nodes
-DEFAULT_SUBSCRIBE_ATTRIBUTES: set[tuple[int | str, int | str, int | str]] = {
-    ("*", 0x001D, 0x00000000),  # all endpoints, descriptor cluster, deviceTypeList
-    ("*", 0x001D, 0x00000003),  # all endpoints, descriptor cluster, partsList
-    (0, 0x0028, "*"),  # endpoint 0, BasicInformation cluster, all attributes
-    ("*", 0x0039, "*"),  # BridgedDeviceBasicInformation
+DEFAULT_SUBSCRIBE_ATTRIBUTES: set[tuple[int | None, int | None, int | None]] = {
+    (None, 0x001D, 0x00000000),  # all endpoints, descriptor cluster, deviceTypeList
+    (None, 0x001D, 0x00000003),  # all endpoints, descriptor cluster, partsList
+    (0, 0x0028, None),  # endpoint 0, BasicInformation cluster, all attributes
+    (None, 0x0039, None),  # BridgedDeviceBasicInformation
 }
 
 
@@ -77,7 +75,7 @@ class MatterDeviceController:
         # we keep the last events in memory so we can include them in the diagnostics dump
         self.event_history: deque[Attribute.EventReadResult] = deque(maxlen=25)
         self._subscriptions: dict[int, Attribute.SubscriptionTransaction] = {}
-        self._attr_subscriptions: dict[int, list[tuple[Any, ...]] | str] = {}
+        self._attr_subscriptions: dict[int, list[Attribute.AttributePath]] = {}
         self._resub_debounce_timer: dict[int, asyncio.TimerHandle] = {}
         self._sub_retry_timer: dict[int, asyncio.TimerHandle] = {}
         self._nodes: dict[int, MatterNodeData | None] = {}
@@ -327,8 +325,9 @@ class MatterDeviceController:
             else datetime.utcnow(),
             last_interview=datetime.utcnow(),
             interview_version=SCHEMA_VERSION,
+            available=True,
             attributes=self._parse_attributes_from_read_result(
-                read_response.attributes
+                read_response.tlvAttributes
             ),
         )
 
@@ -336,7 +335,7 @@ class MatterDeviceController:
             node.attribute_subscriptions = existing_info.attribute_subscriptions
         # work out if the node is a bridge device by looking at the devicetype of endpoint 1
         if attr_data := node.attributes.get("1/29/0"):
-            node.is_bridge = any(x.deviceType == 14 for x in attr_data)
+            node.is_bridge = any(x[0] == 14 for x in attr_data)
 
         # save updated node data
         self._nodes[node_id] = node
@@ -391,24 +390,37 @@ class MatterDeviceController:
         node_id: int,
         attribute_path: str,
     ) -> Any:
-        """Read a single attribute on a node."""
+        """Read a single attribute (or Cluster) on a node."""
         if self.chip_controller is None:
             raise RuntimeError("Device Controller not initialized.")
         node_lock = self._get_node_lock(node_id)
         await self._resolve_node(node_id=node_id)
         endpoint_id, cluster_id, attribute_id = parse_attribute_path(attribute_path)
-        attribute: Type[ClusterAttributeDescriptor] = ALL_ATTRIBUTES[cluster_id][
-            attribute_id
-        ]
         async with node_lock:
-            result: Attribute.AsyncReadTransaction.ReadResponse = (
-                await self.chip_controller.Read(
-                    nodeid=node_id,
-                    attributes=[(endpoint_id, attribute)],
-                    fabricFiltered=False,
-                )
+            self.chip_controller.CheckIsActive()
+            future = self.server.loop.create_future()
+            device = self.chip_controller.GetConnectedDeviceSync(node_id)
+            Attribute.Read(
+                future=future,
+                eventLoop=self.server.loop,
+                device=device.deviceProxy,
+                devCtrl=self.chip_controller,
+                attributes=[
+                    Attribute.AttributePath(
+                        EndpointId=endpoint_id,
+                        ClusterId=cluster_id,
+                        AttributeId=attribute_id,
+                    )
+                ],
+            ).raise_on_error()
+            result: Attribute.AsyncReadTransaction.ReadResponse = await future
+            read_atributes = self._parse_attributes_from_read_result(
+                result.tlvAttributes
             )
-            read_atributes = self._parse_attributes_from_read_result(result.attributes)
+            # update cached info in node attributes
+            self._nodes[node_id].attributes.update(read_atributes)
+            if len(read_atributes) > 1:
+                return read_atributes
             return read_atributes.get(attribute_path, None)
 
     @api_command(APICommand.WRITE_ATTRIBUTE)
@@ -540,38 +552,26 @@ class MatterDeviceController:
         await self._resolve_node(node_id=node_id)
 
         # work out all (current) attribute subscriptions
-        attr_subscriptions: list[Any] = []
+        attr_subscriptions: list[Attribute.AttributePath] = []
         for (
             endpoint_id,
             cluster_id,
             attribute_id,
         ) in set.union(DEFAULT_SUBSCRIBE_ATTRIBUTES, node.attribute_subscriptions):
-            endpoint: int | None = None if endpoint_id == "*" else int(endpoint_id)
-            cluster: Type[Cluster] = ALL_CLUSTERS[cluster_id]
-            attribute: Type[ClusterAttributeDescriptor] | None = (
-                None
-                if attribute_id == "*"
-                else ALL_ATTRIBUTES[cluster_id][attribute_id]
+            attr_subscriptions.append(
+                Attribute.AttributePath(
+                    EndpointId=endpoint_id,
+                    ClusterId=cluster_id,
+                    AttributeId=attribute_id,
+                )
             )
-            if endpoint and attribute:
-                # Concrete path: specific endpoint, specific clusterattribute
-                attr_subscriptions.append((endpoint, attribute))
-            elif endpoint and cluster:
-                # Specific endpoint, Wildcard attribute id (specific cluster)
-                attr_subscriptions.append((endpoint, cluster))
-            elif attribute:
-                # Wildcard endpoint, specific attribute
-                attr_subscriptions.append(attribute)
-            elif cluster:
-                # Wildcard endpoint, specific cluster
-                attr_subscriptions.append(cluster)
 
         if len(attr_subscriptions) > 9:
             # strictly taken a matter device can only handle 9 individual subscriptions
             # (3 subscriptions of 3 paths per fabric)
             # although the device can probably handle more, we play it safe and opt for
             # wildcard as soon as we have more than 9 paths to watch for.
-            attr_subscriptions = "*"  # type: ignore[assignment]
+            attr_subscriptions = [Attribute.AttributePath()]  # wildcard
 
         # check if we already have an subscription for this node,
         # if so, we need to unsubscribe first because a device can only maintain
@@ -618,17 +618,32 @@ class MatterDeviceController:
                 if battery_powered
                 else random.randint(40, 70)
             )
-            sub: Attribute.SubscriptionTransaction = await self.chip_controller.Read(
-                nodeid=node_id,
+            self.chip_controller.CheckIsActive()
+            future = self.server.loop.create_future()
+            device = self.chip_controller.GetConnectedDeviceSync(node_id)
+            Attribute.Read(
+                future=future,
+                eventLoop=self.server.loop,
+                device=device.deviceProxy,
+                devCtrl=self.chip_controller,
                 attributes=attr_subscriptions,
                 # simply subscribe to urgent device events only (e.g. button press etc.)
                 # non urgent events are diagnostic reports etc. for which we have no usecase (yet).
-                events=[("*", 1)],
-                reportInterval=(interval_floor, interval_ceiling),
+                events=[
+                    Attribute.EventPath(
+                        EndpointId=None, Cluster=None, Event=None, Urgent=1
+                    )
+                ],
+                returnClusterObject=False,
+                subscriptionParameters=Attribute.SubscriptionParameters(
+                    interval_floor, interval_ceiling
+                ),
                 # Use fabricfiltered as False to detect changes made by other controllers
                 # and to be able to provide a list of all fabrics attached to the device
                 fabricFiltered=False,
-            )
+                autoResubscribe=True,
+            ).raise_on_error()
+            sub: Attribute.SubscriptionTransaction = await future
 
         def attribute_updated_callback(
             path: Attribute.TypedAttributePath,
@@ -644,7 +659,7 @@ class MatterDeviceController:
             attr_path = str(path.Path)
             old_value = node.attributes.get(attr_path)
 
-            node_logger.debug(
+            node_logger.info(
                 "Attribute updated: %s - old value: %s - new value: %s",
                 path,
                 old_value,
@@ -782,10 +797,11 @@ class MatterDeviceController:
         # if we reach this point, it means the node could be resolved
         # and the initial subscription succeeded, mark the node available.
         node.available = True
-        node_logger.info("Subscription succeeded")
         # update attributes with current state from read request
-        current_atributes = self._parse_attributes_from_read_result(sub.GetAttributes())
-        node.attributes.update(current_atributes)
+        # NOTE: Make public method upstream for retrieving the attributeTLVCache
+        tlv_attributes = sub._readTransaction._cache.attributeTLVCache
+        node.attributes.update(self._parse_attributes_from_read_result(tlv_attributes))
+        node_logger.info("Subscription succeeded")
         self.server.signal_event(EventType.NODE_UPDATED, node)
 
     def _get_next_node_id(self) -> int:
@@ -868,43 +884,21 @@ class MatterDeviceController:
 
     @staticmethod
     def _parse_attributes_from_read_result(
-        read_result: dict[int, dict[Type, dict[Type, Any]]]
+        raw_tlv_attributes: dict[int, dict[int, dict[int, Any]]] | None = None,
     ) -> dict[str, Any]:
-        """Parse attributes from ReadResult."""
+        """Parse attributes from ReadResult's TLV Attributes."""
         result = {}
-        for endpoint, cluster_dict in read_result.items():
-            # read result output is in format
-            # {endpoint: {ClusterClass: {AttributeClass: value}}}
-            for cluster_cls, attr_dict in cluster_dict.items():
-                for attr_cls, attr_value in attr_dict.items():
-                    if attr_cls == Attribute.DataVersion:
-                        continue
+        # prefer raw tlv attributes as it requires less parsing back and forth
+        for endpoint_id, clusters in raw_tlv_attributes.items():
+            for cluster_id, attribute in clusters.items():
+                for attribute_id, attr_value in attribute.items():
                     # we are only interested in the raw values and let the client
                     # match back from the id's to the correct cluster/attribute classes
                     # attributes are stored in form of AttributePath:
                     # ENDPOINT/CLUSTER_ID/ATTRIBUTE_ID
                     attribute_path = create_attribute_path(
-                        endpoint, cluster_cls.id, attr_cls.attribute_id
+                        endpoint_id, cluster_id, attribute_id
                     )
-                    # failsafe: ignore ValueDecodeErrors
-                    # these are set by the SDK if parsing the value failed miserably
-                    if isinstance(attr_value, ValueDecodeFailure):
-                        continue
-                    # failsafe: make sure the attribute is serializable
-                    # there is a chance we receive malformed data from the sdk
-                    # due to all magic parsing to/from TLV.
-                    # skip an attribute in that case to prevent serialization issues
-                    # of the whole node.
-                    try:
-                        json_dumps(attr_value)
-                    except TypeError as err:
-                        LOGGER.warning(
-                            "Unserializable data found - "
-                            "skip attribute %s - error details: %s",
-                            attribute_path,
-                            err,
-                        )
-                        continue
                     result[attribute_path] = attr_value
         return result
 


### PR DESCRIPTION
- Support reading custom Clusters and Attributes
- Skip overhead by using raw tlv values in the server
- Add custom models for Eve custom cluster (for energy plug readings)
- Refactor serialization; now that we use the raw values we can let orjson deal with serializing - this means speed improvements

We're now sending the raw tlv values from the read requests in the server to the client so we skip the overhead of having to go through the models. This allows us to see all values, so including the custom attributes for which there are no models defines in the SDK wrapper. Also, skipping the intermediate step gives us a speed bump.

**SCHEMA CHANGED TO VERSION 5**
Although there are no breaking changes in any of the public methods, the data schema is not compatible and has been bumped to version 5. Clients with older schema versions can not communicate with the server running schema 5 (or higher) making this a breaking change.





