### PR TITLE
Add async-timeout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 dependencies = [
   "aiohttp",
   "aiorun",
+  "async-timeout",
   "coloredlogs",
   "dacite",
   "orjson",


### PR DESCRIPTION
- Latest aiohttp now only includes async-timeout if running on Python 3.10 or lower.
- Include async-timeout explicitly for now until we bump minimum Python version. Python 3.11 has `asyncio.timeout`.