### PR TITLE
Allow writing null to attributes (fixes #434)

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -434,7 +434,7 @@ class MatterDeviceController:
             raise RuntimeError("Device Controller not initialized.")
         endpoint_id, cluster_id, attribute_id = parse_attribute_path(attribute_path)
         attribute = ALL_ATTRIBUTES[cluster_id][attribute_id]()
-        attribute.value = value
+        attribute.value = Clusters.NullValue if value is None else value
         return await self.chip_controller.WriteAttribute(
             nodeid=node_id,
             attributes=[(endpoint_id, attribute)],


### PR DESCRIPTION
Some attributes accept a null value (e.g. the `OnLevel` attribute of the `LevelControl` cluster) and so the server should handle this value correctly.

I've tested this locally with a real dimmer switch and it worked as expected.