### PR TITLE
Fix open commissioning window tuple bug

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -258,7 +258,7 @@ class MatterDeviceController:
         iteration: int = 1000,
         option: int = 1,
         discriminator: int | None = None,
-    ) -> tuple[int, str]:
+    ) -> tuple[int, str, str]:
         """Open a commissioning window to commission a device present on this controller to another.
 
         Returns code to use as discriminator.
@@ -269,7 +269,7 @@ class MatterDeviceController:
         if discriminator is None:
             discriminator = 3840  # TODO generate random one
 
-        pin, code = await self._call_sdk(
+        result = await self._call_sdk(
             self.chip_controller.OpenCommissioningWindow,
             nodeid=node_id,
             timeout=timeout,
@@ -277,7 +277,7 @@ class MatterDeviceController:
             discriminator=discriminator,
             option=option,
         )
-        return pin, code
+        return result
 
     @api_command(APICommand.DISCOVER)
     async def discover_commissionable_nodes(

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -269,7 +269,7 @@ class MatterDeviceController:
         if discriminator is None:
             discriminator = 3840  # TODO generate random one
 
-        result = await self._call_sdk(
+        return await self._call_sdk(
             self.chip_controller.OpenCommissioningWindow,
             nodeid=node_id,
             timeout=timeout,
@@ -277,7 +277,6 @@ class MatterDeviceController:
             discriminator=discriminator,
             option=option,
         )
-        return result
 
     @api_command(APICommand.DISCOVER)
     async def discover_commissionable_nodes(

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -11,7 +11,7 @@ import random
 import time
 from typing import TYPE_CHECKING, Any, Callable, Iterable, TypeVar, cast
 
-from chip.ChipDeviceCtrl import CommissionableNode
+from chip.ChipDeviceCtrl import CommissionableNode, CommissioningParameters
 from chip.clusters import Attribute, Objects as Clusters
 from chip.clusters.Attribute import ValueDecodeFailure
 from chip.clusters.ClusterObjects import ALL_ATTRIBUTES, ALL_CLUSTERS, Cluster
@@ -258,7 +258,7 @@ class MatterDeviceController:
         iteration: int = 1000,
         option: int = 1,
         discriminator: int | None = None,
-    ) -> tuple[int, str, str]:
+    ) -> CommissioningParameters:
         """Open a commissioning window to commission a device present on this controller to another.
 
         Returns code to use as discriminator.


### PR DESCRIPTION
TypeError: cannot unpack non-iterable CommissioningParameters object

python3 --version Python 3.10.12

Suspected Reason:
open_commissioning_window in device_controller.py calls _call_sdk(self.chip_controller.OpenCommissioningWindow) which returns 3 values not 2 (pin, code, qrcode) 

Steps to reproduce:

1) flash latest esp32 lighting-app example to ESP32 dev kit
2) set the wifi credentials on the python-matter-server
   {"message_id": "1","command": "set_wifi_credentials","args": {"ssid": "MYSSID","credentials": "MYPASS"}}
3) commission with code (for esp32 lighting-app)
   { "message_id": "2","command": "commission_with_code","args": {"code": "34970112332"}}
   
4) Once commissioning is successful as node 1, try to open a commissioning window:
   {"message_id": "5", "command": "open_commissioning_window", "args": { "node_id": 1 } }

5) python-matter-server log shows:

2023-12-04 10:26:07 dell chip.DMG[1907289] INFO Received Command Response Status for Endpoint=0 Cluster=0x0000_003C Command=0x0000_0000 Status=0x0
2023-12-04 10:26:07 dell chip.CTL[1907289] INFO Successfully opened pairing window on the device
2023-12-04 10:26:07 dell chip.CTL[1907289] INFO Manual pairing code: [36050732280]
2023-12-04 10:26:07 dell chip.CTL[1907289] INFO SetupQRCode: [MT:00000CQM00CI-T2I410]
2023-12-04 10:26:07 dell chip.ZCL[1907289] INFO SetupManualCode = 36050732280
2023-12-04 10:26:07 dell chip.ZCL[1907289] INFO SetupQRCode = MT:00000CQM00CI-T2I410
Open Commissioning Window complete setting nodeid 1 pincode to 52898907
2023-12-04 10:26:07 dell chip.DMG[1907289] DEBUG ICR moving to [AwaitingDe]
2023-12-04 10:26:07 dell matter_server.server.client_handler[1907289] ERROR [139898164929936] Error handling message: CommandMessage(message_id='5', command='open_commissioning_window', args={'node_id': 1})
Traceback (most recent call last):
  File "/home/ivob/Projects/python-matter-server/matter_server/server/client_handler.py", line 188, in _run_handler
    result = await result
  File "/home/ivob/Projects/python-matter-server/matter_server/server/device_controller.py", line 272, in open_commissioning_window
    pin, code = await self._call_sdk(
TypeError: cannot unpack non-iterable CommissioningParameters object


Fix:

change return type to handle 3 items in tuple async def open_commissioning_window -> tuple[int, str, str]