### PR TITLE
Update json dump helper to handle CommissionableNode structure

### DIFF
--- a/matter_server/common/helpers/json.py
+++ b/matter_server/common/helpers/json.py
@@ -4,6 +4,7 @@ from base64 import b64encode
 from typing import Any
 
 from chip.clusters.Types import Nullable
+from chip.ChipDeviceCtrl import CommissionableNode
 from chip.tlv import float32, uint
 import orjson
 
@@ -30,6 +31,24 @@ def json_encoder_default(obj: Any) -> Any:
         return b64encode(obj).decode("utf-8")
     if isinstance(obj, Exception):
         return str(obj)
+    if isinstance(obj, CommissionableNode):
+        return {
+            "addresses": obj.addresses, 
+            "commissioningMode": obj.commissioningMode,
+            "deviceName": obj.deviceName ,
+            "deviceType": obj.deviceType,
+            "hostName": obj.hostName ,
+            "instanceName": obj.instanceName ,
+            "longDiscriminator": obj.longDiscriminator ,
+            "mrpRetryIntervalActive": obj.mrpRetryIntervalActive ,
+            "mrpRetryIntervalIdle": obj.mrpRetryIntervalIdle ,
+            "pairingHint": obj.pairingHint ,
+            "pairingInstruction": obj.pairingInstruction ,
+            "port": obj.port,
+            "productId": obj.productId,
+            "supportsTcp": obj.supportsTcp,
+            "vendorId": obj.vendorId
+            }        
     if type(obj) is type:  # pylint: disable=unidiomatic-typecheck
         return f"{obj.__module__}.{obj.__qualname__}"
     raise TypeError


### PR DESCRIPTION
TypeError: Type is not JSON serializable: CommissionableNode

python3 --version Python 3.10.12

Suspected Reason:
json dumps handler cannot handle CommissionableNode structure

Steps to reproduce:

1) flash latest esp32 lighting-app example to ESP32 dev kit

2) commission esp32 lighting-app example using chip-tool
./chip-tool pairing ble-wifi 0x1 MYSSID MYPASS 20202021 3840

3) Once commissioning is successful as node 1, open a commissioning window:
./chip-tool pairing open-commissioning-window 1 1 300 1000 2365

4) run a discover from the python-matter-server
{"message_id": "1","command": "discover"}

5) python-matter-server log shows:
023-12-04 12:00:57 dell matter_server.server.client_handler[2017833] DEBUG [140135655073504] Received CommandMessage(message_id='1', command='discover', args=None)
2023-12-04 12:00:57 dell matter_server.server.client_handler[2017833] DEBUG [140135655073504] Handling command discover
2023-12-04 12:00:57 dell chip.DL[2017833] INFO Avahi browse: cache new
2023-12-04 12:00:57 dell chip.DL[2017833] INFO Avahi browse: cache new
2023-12-04 12:00:57 dell chip.DL[2017833] INFO Avahi browse: cache exhausted
2023-12-04 12:00:58 dell chip.DL[2017833] INFO Avahi browse: all for now
2023-12-04 12:00:58 dell chip.DL[2017833] INFO Avahi resolve found
2023-12-04 12:00:58 dell chip.DIS[2017833] DEBUG Discovered node:
2023-12-04 12:00:58 dell chip.DIS[2017833] DEBUG        Hostname: 58BF2593B9A8
2023-12-04 12:00:58 dell chip.DIS[2017833] DEBUG        IP Address #1: 192.168.1.41
2023-12-04 12:00:58 dell chip.DIS[2017833] DEBUG        Port: 5540
2023-12-04 12:00:58 dell chip.DIS[2017833] DEBUG        Mrp Interval idle: not present
2023-12-04 12:00:58 dell chip.DIS[2017833] DEBUG        Mrp Interval active: not present
2023-12-04 12:00:58 dell chip.DIS[2017833] DEBUG        TCP Supported: 1
2023-12-04 12:00:58 dell chip.DIS[2017833] DEBUG        Vendor ID: 65521
2023-12-04 12:00:58 dell chip.DIS[2017833] DEBUG        Product ID: 32768
2023-12-04 12:00:58 dell chip.DIS[2017833] DEBUG        Long Discriminator: 2365
2023-12-04 12:00:58 dell chip.DIS[2017833] DEBUG        Pairing Hint: 36
2023-12-04 12:00:58 dell chip.DIS[2017833] DEBUG        Instance Name: 35D42B385A32DC31
2023-12-04 12:00:58 dell chip.DIS[2017833] DEBUG        Commissioning Mode: 2
2023-12-04 12:00:58 dell chip.CTL[2017833] ERROR Unknown filter type; all matches will fail
2023-12-04 12:00:58 dell chip.DL[2017833] INFO Avahi resolve found
2023-12-04 12:00:58 dell chip.DIS[2017833] DEBUG Discovered node:
2023-12-04 12:00:58 dell chip.DIS[2017833] DEBUG        Hostname: 58BF2593B9A8
2023-12-04 12:00:58 dell chip.DIS[2017833] DEBUG        IP Address #1: 192.168.1.41
2023-12-04 12:00:58 dell chip.DIS[2017833] DEBUG        Port: 5540
2023-12-04 12:00:58 dell chip.DIS[2017833] DEBUG        Mrp Interval idle: not present
2023-12-04 12:00:58 dell chip.DIS[2017833] DEBUG        Mrp Interval active: not present
2023-12-04 12:00:58 dell chip.DIS[2017833] DEBUG        TCP Supported: 1
2023-12-04 12:00:58 dell chip.DIS[2017833] DEBUG        Vendor ID: 65521
2023-12-04 12:00:58 dell chip.DIS[2017833] DEBUG        Product ID: 32768
2023-12-04 12:00:58 dell chip.DIS[2017833] DEBUG        Long Discriminator: 2365
2023-12-04 12:00:58 dell chip.DIS[2017833] DEBUG        Pairing Hint: 36
2023-12-04 12:00:58 dell chip.DIS[2017833] DEBUG        Instance Name: 35D42B385A32DC31
2023-12-04 12:00:58 dell chip.DIS[2017833] DEBUG        Commissioning Mode: 2
2023-12-04 12:00:58 dell chip.CTL[2017833] ERROR Unknown filter type; all matches will fail
2023-12-04 12:00:59 dell chip.DL[2017833] INFO Avahi browse: cache new
2023-12-04 12:00:59 dell chip.DL[2017833] INFO Avahi browse: cache new
2023-12-04 12:00:59 dell chip.DL[2017833] INFO Avahi browse: cache exhausted
2023-12-04 12:01:00 dell chip.DL[2017833] INFO Avahi browse: all for now
2023-12-04 12:01:00 dell chip.DL[2017833] INFO Avahi resolve found
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG Discovered node:
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Hostname: 58BF2593B9A8
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        IP Address #1: 192.168.1.41
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Port: 5540
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Mrp Interval idle: not present
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Mrp Interval active: not present
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        TCP Supported: 1
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Vendor ID: 65521
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Product ID: 32768
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Long Discriminator: 2365
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Pairing Hint: 36
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Instance Name: 35D42B385A32DC31
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Commissioning Mode: 2
2023-12-04 12:01:00 dell chip.CTL[2017833] ERROR Unknown filter type; all matches will fail
2023-12-04 12:01:00 dell chip.DL[2017833] INFO Avahi resolve found
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG Discovered node:
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Hostname: 58BF2593B9A8
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        IP Address #1: 192.168.1.41
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Port: 5540
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Mrp Interval idle: not present
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Mrp Interval active: not present
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        TCP Supported: 1
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Vendor ID: 65521
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Product ID: 32768
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Long Discriminator: 2365
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Pairing Hint: 36
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Instance Name: 35D42B385A32DC31
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Commissioning Mode: 2
2023-12-04 12:01:00 dell chip.CTL[2017833] ERROR Unknown filter type; all matches will fail
2023-12-04 12:01:00 dell chip.DL[2017833] INFO Avahi resolve found
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG Discovered node:
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Hostname: 58BF2593B9A8
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        IP Address #1: 192.168.1.41
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Port: 5540
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Mrp Interval idle: not present
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Mrp Interval active: not present
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        TCP Supported: 1
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Vendor ID: 65521
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Product ID: 32768
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Long Discriminator: 2365
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Pairing Hint: 36
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Instance Name: 35D42B385A32DC31
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Commissioning Mode: 2
2023-12-04 12:01:00 dell chip.CTL[2017833] ERROR Unknown filter type; all matches will fail
2023-12-04 12:01:00 dell chip.DL[2017833] INFO Avahi resolve found
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG Discovered node:
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Hostname: 58BF2593B9A8
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        IP Address #1: 192.168.1.41
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Port: 5540
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Mrp Interval idle: not present
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Mrp Interval active: not present
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        TCP Supported: 1
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Vendor ID: 65521
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Product ID: 32768
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Long Discriminator: 2365
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Pairing Hint: 36
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Instance Name: 35D42B385A32DC31
2023-12-04 12:01:00 dell chip.DIS[2017833] DEBUG        Commissioning Mode: 2
2023-12-04 12:01:00 dell chip.CTL[2017833] ERROR Unknown filter type; all matches will fail
2023-12-04 12:01:02 dell chip.DIS[2017833] INFO Commissionable Node 0
2023-12-04 12:01:02 dell matter_server.server.client_handler[2017833] ERROR [140135655073504] Error handling message: CommandMessage(message_id='1', command='discover', args=None)
TypeError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/ivob/Projects/python-matter-server/matter_server/server/client_handler.py", line 189, in _run_handler
    self._send_message(SuccessResultMessage(msg.message_id, result))
  File "/home/ivob/Projects/python-matter-server/matter_server/server/client_handler.py", line 221, in _send_message
    _message = json_dumps(message)
  File "/home/ivob/Projects/python-matter-server/matter_server/common/helpers/json.py", line 40, in json_dumps
    return orjson.dumps(
TypeError: Type is not JSON serializable: CommissionableNode
