### PR TITLE
Implement more aggressive retry logic for resolving and first interview

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ message = {
     "command": "device_command",
     "args": {
         "endpoint_id": 1,
-        "node_id": 1, 
+        "node_id": 1,
         "payload": payload,
         "cluster_id": command.cluster_id,
         "command_name": "On"

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -171,7 +171,7 @@ class MatterDeviceController:
         # perform full (first) interview of the device
         # we retry the interview max 3 times as it may fail in noisy
         # RF environments (in case of thread), mdns trouble or just flaky devices.
-        # retryuing both the mdns resolve and (first) interview, increases the chances
+        # retrying both the mdns resolve and (first) interview, increases the chances
         # of a successful device commission.
         retries = 3
         while retries:

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -3,17 +3,16 @@
 from __future__ import annotations
 
 import asyncio
-import logging
-import random
-import time
 from collections import deque
 from datetime import datetime
 from functools import partial
+import logging
+import random
+import time
 from typing import TYPE_CHECKING, Any, Callable, Iterable, TypeVar, cast
 
 from chip.ChipDeviceCtrl import CommissionableNode
-from chip.clusters import Attribute
-from chip.clusters import Objects as Clusters
+from chip.clusters import Attribute, Objects as Clusters
 from chip.clusters.Attribute import ValueDecodeFailure
 from chip.clusters.ClusterObjects import ALL_ATTRIBUTES, ALL_CLUSTERS, Cluster
 from chip.exceptions import ChipStackError
@@ -919,7 +918,9 @@ class MatterDeviceController:
                     result[attribute_path] = attr_value
         return result
 
-    async def _resolve_node(self, node_id: int, retries: int = 5, attempt=1) -> None:
+    async def _resolve_node(
+        self, node_id: int, retries: int = 5, attempt: int = 1
+    ) -> None:
         """Resolve a Node on the network."""
         if (node := self._nodes.get(node_id)) and node.available:
             # no need to resolve, the node is already available/connected


### PR DESCRIPTION
Strictly taken this should not be needed but we've seen that thread networks can suffer from interference and/or discovery failing for some devices. This increases the chances that the commissioning of a node succeeds by simply retrying the resolving with extended timeouts.