### PR TITLE
Disable PASE for operational node discovery

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -935,7 +935,7 @@ class MatterDeviceController:
                 LOGGER.debug("Attempting to resolve node %s...", node_id)
                 await self._call_sdk(
                     self.chip_controller.GetConnectedDeviceSync,
-                    allowPASE=True,
+                    allowPASE=False,
                     # For the first attempts we use the SDK's default timeout.
                     # Once we keep retrying we try the final attempt(s)
                     # with an extended timeout.

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -935,10 +935,10 @@ class MatterDeviceController:
                 LOGGER.debug("Attempting to resolve node %s...", node_id)
                 await self._call_sdk(
                     self.chip_controller.GetConnectedDeviceSync,
-                    # By default we do not allow PASE and we use the SDK's default timeout.
-                    # Once we keep retrying we try the final attempt(s) with PASE and
+                    allowPASE=True,
+                    # For the first attempts we use the SDK's default timeout.
+                    # Once we keep retrying we try the final attempt(s)
                     # with an extended timeout.
-                    allowPASE=attempt >= 4,
                     timeoutMs=30000 if attempt >= 3 else None,
                     nodeid=node_id,
                 )


### PR DESCRIPTION
our resolve_node helper is only used for operational node discovery so it makes no sense to even try a PASE session (as that is only used for commissionable nodes).

Some users have reported a crashing matter server - this seems to be true only for those who have unreachable devices, hence our retry logic kicks in. This may be the cause (or at least it does not hurt to try)