### PR TITLE
Do not override the timeout of the operational node discovery

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -932,14 +932,14 @@ class MatterDeviceController:
             # the sdk crashes when multiple resolves happen at the same time
             # guard simultane resolves with a lock.
             async with node_lock, self._resolve_lock:
-                LOGGER.debug("Attempting to resolve node %s...", node_id)
+                LOGGER.debug(
+                    "Attempting to resolve node %s... (attempt %s of %s)",
+                    node_id,
+                    attempt,
+                    retries,
+                )
                 await self._call_sdk(
-                    self.chip_controller.GetConnectedDeviceSync,
-                    allowPASE=False,
-                    # For the first attempts we use the SDK's default timeout.
-                    # Once we keep retrying we try the final attempt(s)
-                    # with an extended timeout.
-                    timeoutMs=30000 if attempt >= 3 else None,
+                    self.chip_controller.ResolveNode,
                     nodeid=node_id,
                 )
         except (ChipStackError, TimeoutError) as err:


### PR DESCRIPTION
In another attempt of trying to fix the segfaulting sdk, remove the custom timeout on the "GetConnectedDeviceSync" as that seems to induce the issue (at least on my basic testing). Further research is needed to understand why this is happening but its very low level at the C++ side of things.