### PR TITLE
Add IP address support for commission_on_network

### DIFF
--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -120,7 +120,7 @@ class MatterClient:
         data = await self.send_command(APICommand.COMMISSION_WITH_CODE, code=code)
         return dataclass_from_dict(MatterNodeData, data)
 
-    async def commission_on_network(self, setup_pin_code: int) -> MatterNodeData:
+    async def commission_on_network(self, setup_pin_code: int, ip_addr: str | None = None) -> MatterNodeData:
         """
         Do the routine for OnNetworkCommissioning.
 
@@ -130,7 +130,8 @@ class MatterClient:
         Returns basic MatterNodeData once complete.
         """
         data = await self.send_command(
-            APICommand.COMMISSION_ON_NETWORK, setup_pin_code=setup_pin_code
+            APICommand.COMMISSION_ON_NETWORK, setup_pin_code=setup_pin_code,
+            ip_addr=ip_addr,
         )
         return dataclass_from_dict(MatterNodeData, data)
 

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -203,6 +203,7 @@ class MatterDeviceController:
         setup_pin_code: int,
         filter_type: int = 0,
         filter: Any = None,  # pylint: disable=redefined-builtin
+        ip_addr: str | None = None,
     ) -> MatterNodeData:
         """
         Do the routine for OnNetworkCommissioning, with a filter for mDNS discovery.
@@ -226,20 +227,36 @@ class MatterDeviceController:
 
         node_id = self._get_next_node_id()
 
-        LOGGER.info(
-            "Starting Matter commissioning on network using Node ID %s.", node_id
-        )
-        success = await self._call_sdk(
-            self.chip_controller.CommissionOnNetwork,
-            nodeId=node_id,
-            setupPinCode=setup_pin_code,
-            filterType=filter_type,
-            filter=filter,
-        )
-        if not success:
-            raise NodeCommissionFailed(
-                f"Commission on network failed for node {node_id}"
+        if ip_addr is None:
+            LOGGER.info(
+                "Starting Matter commissioning on network using Node ID %s.", node_id
             )
+            success = await self._call_sdk(
+                self.chip_controller.CommissionOnNetwork,
+                nodeId=node_id,
+                setupPinCode=setup_pin_code,
+                filterType=filter_type,
+                filter=filter,
+            )
+            if not success:
+                raise NodeCommissionFailed(
+                    f"Commission on network failed for node {node_id}"
+                )
+        else:
+            LOGGER.info(
+                "Starting Matter commissioning with IP using Node ID %s.", node_id
+            )
+            success = await self._call_sdk(
+                self.chip_controller.CommissionIP,
+                nodeid=node_id,
+                setupPinCode=setup_pin_code,
+                ipaddr=ip_addr,
+            )
+            if not success:
+                raise NodeCommissionFailed(
+                    f"Commission using IP failed for node {node_id}"
+                )
+
         LOGGER.info("Matter commissioning of Node ID %s successful.", node_id)
 
         # full interview of the device

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -195,6 +195,19 @@ async def test_server_start(
     ) == {"setup_pin_code": 1234, "filter_type": 0, "filter": None}
     assert (
         parse_arguments(
+            server.command_handlers[APICommand.COMMISSION_ON_NETWORK].signature,
+            server.command_handlers[APICommand.COMMISSION_ON_NETWORK].type_hints,
+            {"setup_pin_code": 1234, "ip_addr": "fd82:c9e9:5cb7:1:2c5c:ed99:ecf:4460"},
+            strict=True,
+        )
+    ) == {
+        "setup_pin_code": 1234,
+        "filter_type": 0,
+        "filter": None,
+        "ip_addr": "fd82:c9e9:5cb7:1:2c5c:ed99:ecf:4460",
+    }
+    assert (
+        parse_arguments(
             server.command_handlers[APICommand.SET_WIFI_CREDENTIALS].signature,
             server.command_handlers[APICommand.SET_WIFI_CREDENTIALS].type_hints,
             {"ssid": "test_ssid", "credentials": "test_credentials"},


### PR DESCRIPTION
When using the Android Matter commissioning flow from the Home Assistant App (via CommissioningRequest), we get the passcode only, no QR code or manual pairing code (see CommissioningRequestMetadata documentation). This means there is no discriminator. In other words, the server will try to find a commissionable device, and use the pincode against the first one found.

It seems that sometimes another device is announced to be commissionable at the same time, which obvisouly has another passcode, hence the commission fails quite quickly. The App shows "Something went wrong".

This seems to be particularly common when using Thread: The Thread border router forwards and caches DNS-SD/mDNS service information about commissionable Thread devices with its SRP server service. The cache is up to 2h long. So when a communication breakdown happens after a particular device went into commission mode, this commissionable service entry lingers in the network for quite some time.

Now if the OTBR sends this entry before the new/valid entry, the Matter Server tries to commission a device which is no longer responding.

The CommissioningRequestMetadata have a way to get the device's IP address. This change extends commission_on_network WS endpoint to also take an IP address. The SDK CommissionIP service is used to commission the device.

Note: CommissionIP is marked deprecated currently. This is mainly to prevent implementation which would ask users for IP addresses, which is not the intended way to implement commissioning. However, for this particular usecase the API seems very sensible and works as intended.

Fixes: #463