### PR TITLE
Allow to commission with code on network only

### DIFF
--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -112,7 +112,7 @@ class MatterClient:
         raise NodeNotExists(f"Node {node_id} does not exist or is not yet interviewed")
 
     async def commission_with_code(
-        self, code: str, network_only: bool
+        self, code: str, network_only: bool = False
     ) -> MatterNodeData:
         """
         Commission a device using QRCode or ManualPairingCode.

--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -115,9 +115,12 @@ class MatterClient:
         self, code: str, network_only: bool = False
     ) -> MatterNodeData:
         """
-        Commission a device using QRCode or ManualPairingCode.
+        Commission a device using a QR Code or Manual Pairing Code.
 
-        Returns basic MatterNodeData once complete.
+        :param code: The QR Code or Manual Pairing Code for device commissioning.
+        :param network_only: If True, restricts device discovery to network only.
+
+        :return: The NodeInfo of the commissioned device.
         """
         data = await self.send_command(
             APICommand.COMMISSION_WITH_CODE, code=code, network_only=network_only

--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -111,13 +111,17 @@ class MatterClient:
             return node
         raise NodeNotExists(f"Node {node_id} does not exist or is not yet interviewed")
 
-    async def commission_with_code(self, code: str) -> MatterNodeData:
+    async def commission_with_code(
+        self, code: str, network_only: bool
+    ) -> MatterNodeData:
         """
         Commission a device using QRCode or ManualPairingCode.
 
         Returns basic MatterNodeData once complete.
         """
-        data = await self.send_command(APICommand.COMMISSION_WITH_CODE, code=code)
+        data = await self.send_command(
+            APICommand.COMMISSION_WITH_CODE, code=code, network_only=network_only
+        )
         return dataclass_from_dict(MatterNodeData, data)
 
     async def commission_on_network(

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -150,9 +150,12 @@ class MatterDeviceController:
         self, code: str, network_only: bool = False
     ) -> MatterNodeData:
         """
-        Commission a device using QRCode or ManualPairingCode.
+        Commission a device using a QR Code or Manual Pairing Code.
 
-        Returns full NodeInfo once complete.
+        :param code: The QR Code or Manual Pairing Code for device commissioning.
+        :param network_only: If True, restricts device discovery to network only.
+
+        :return: The NodeInfo of the commissioned device.
         """
         if self.chip_controller is None:
             raise RuntimeError("Device Controller not initialized.")

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -145,7 +145,9 @@ class MatterDeviceController:
         raise NodeNotExists(f"Node {node_id} does not exist or is not yet interviewed")
 
     @api_command(APICommand.COMMISSION_WITH_CODE)
-    async def commission_with_code(self, code: str) -> MatterNodeData:
+    async def commission_with_code(
+        self, code: str, network_only: bool = False
+    ) -> MatterNodeData:
         """
         Commission a device using QRCode or ManualPairingCode.
 
@@ -166,6 +168,7 @@ class MatterDeviceController:
             self.chip_controller.CommissionWithCode,
             setupPayload=code,
             nodeid=node_id,
+            networkOnly=network_only,
         )
         if not success:
             raise NodeCommissionFailed(

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -1,5 +1,5 @@
 """Controller that Manages Matter devices."""
-# pylint: disable=C0302
+# pylint: disable=too-many-lines
 
 from __future__ import annotations
 

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -1,4 +1,5 @@
 """Controller that Manages Matter devices."""
+# pylint: disable=C0302
 
 from __future__ import annotations
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,12 +28,12 @@ dependencies = [
   "coloredlogs",
   "dacite",
   "orjson",
-  "home-assistant-chip-clusters==2023.10.2"
+  "home-assistant-chip-clusters==2023.12.0"
 ]
 
 [project.optional-dependencies]
 server = [
-  "home-assistant-chip-core==2023.10.2",
+  "home-assistant-chip-core==2023.12.0",
   "cryptography==41.0.7"
 ]
 test = [

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -184,7 +184,7 @@ async def test_server_start(
             {"code": "test_code"},
             strict=True,
         )
-    ) == {"code": "test_code"}
+    ) == {"code": "test_code", "network_only": False}
     assert (
         parse_arguments(
             server.command_handlers[APICommand.COMMISSION_ON_NETWORK].signature,


### PR DESCRIPTION
Add a parameter which instructs the SDK to search for the device only on the network. This is useful when using the manual pairing code, which does not contain a device specific discovery capabilties.

This is useful to prevent the SDK from searching via Bluetooth from the Android App (which provides a manual pairing code when using the non-App integrated Matter onboarding flow).