### PR TITLE
Optimize commission and (re)subscription flows

### DIFF
--- a/matter_server/common/models.py
+++ b/matter_server/common/models.py
@@ -80,7 +80,6 @@ class MatterNodeData:
     attribute_subscriptions: set[tuple[int | None, int | None, int | None]] = field(
         default_factory=set
     )
-    last_subscription_attempt: float = 0
 
 
 @dataclass

--- a/matter_server/server/__main__.py
+++ b/matter_server/server/__main__.py
@@ -72,6 +72,7 @@ def main() -> None:
     coloredlogs.install(level=args.log_level.upper())
     if not logging.getLogger().isEnabledFor(logging.DEBUG):
         logging.getLogger("chip").setLevel(logging.WARNING)
+        logging.getLogger("PersistentStorage").setLevel(logging.WARNING)
 
     # make sure storage path exists
     if not os.path.isdir(args.storage_path):

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -153,9 +153,6 @@ class MatterDeviceController:
         if self.chip_controller is None:
             raise RuntimeError("Device Controller not initialized.")
 
-        # perform a quick delta sync of certificates to make sure
-        # we have the latest paa root certs
-        await fetch_certificates()
         node_id = self._get_next_node_id()
 
         success = await self._call_sdk(
@@ -210,12 +207,6 @@ class MatterDeviceController:
         """
         if self.chip_controller is None:
             raise RuntimeError("Device Controller not initialized.")
-
-        # perform a quick delta sync of certificates to make sure
-        # we have the latest paa root certs
-        # NOTE: Its not very clear if the newly fetched certificates can be used without
-        # restarting the device controller
-        await fetch_certificates()
 
         node_id = self._get_next_node_id()
 

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -468,6 +468,7 @@ class MatterDeviceController:
             DATA_KEY_NODES,
             subkey=str(node_id),
         )
+        self.server.storage.save(immediate=True)
 
         assert node is not None
 

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -444,7 +444,6 @@ class MatterDeviceController:
         await self._resolve_node(node_id=node_id)
         endpoint_id, cluster_id, attribute_id = parse_attribute_path(attribute_path)
         async with node_lock:
-            self.chip_controller.CheckIsActive()
             assert self.server.loop is not None
             future = self.server.loop.create_future()
             device = await self._resolve_node(node_id)
@@ -715,7 +714,6 @@ class MatterDeviceController:
         assert self.chip_controller is not None
         node_logger.debug("Setting up attributes and events subscription.")
         self._last_subscription_attempt[node_id] = 0
-        self.chip_controller.CheckIsActive()
         assert self.server.loop is not None
         future = self.server.loop.create_future()
         device = await self._resolve_node(node_id)

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -708,7 +708,7 @@ class MatterDeviceController:
         interval_ceiling: int = 60,
         event_subscriptions: list[Attribute.EventPath] | None = None,
     ) -> Attribute.SubscriptionTransaction:
-        """Setup a single Node AttributePath(s) subscription."""
+        """Handle Setup of a single Node AttributePath(s) subscription."""
         node_id = node.node_id
         node_logger = LOGGER.getChild(f"[node {node_id}]")
         assert self.chip_controller is not None

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -810,9 +810,7 @@ class MatterDeviceController:
 
     def _get_next_node_id(self) -> int:
         """Return next node_id."""
-        next_node_id = cast(int, self.server.storage.get(DATA_KEY_LAST_NODE_ID, 0)) + 1
-        self.server.storage.set(DATA_KEY_LAST_NODE_ID, next_node_id, force=True)
-        return next_node_id
+        return cast(int, self.server.storage.get(DATA_KEY_LAST_NODE_ID, 0)) + 1
 
     async def _call_sdk(self, func: Callable[..., _T], *args: Any, **kwargs: Any) -> _T:
         """Call function on the SDK in executor and return result."""

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -347,10 +347,10 @@ class MatterDeviceController:
         if self.chip_controller is None:
             raise RuntimeError("Device Controller not initialized.")
 
-        LOGGER.info("Interviewing node: %s", node_id)
         try:
             await self._resolve_node(node_id=node_id)
             async with self._get_node_lock(node_id):
+                LOGGER.info("Interviewing node: %s", node_id)
                 read_response: Attribute.AsyncReadTransaction.ReadResponse = (
                     await self.chip_controller.Read(
                         nodeid=node_id,

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -939,7 +939,7 @@ class MatterDeviceController:
             reschedule()
 
     async def _resolve_node(
-        self, node_id: int, retries: int = 5, attempt: int = 1
+        self, node_id: int, retries: int = 2, attempt: int = 1
     ) -> None:
         """Resolve a Node on the network."""
         if (node := self._nodes.get(node_id)) and node.available:

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -946,14 +946,13 @@ class MatterDeviceController:
             # no need to resolve, the node is already available/connected
             return
 
-        node_lock = self._get_node_lock(node_id)
         log_level = logging.DEBUG if attempt == 1 else logging.INFO
         if self.chip_controller is None:
             raise RuntimeError("Device Controller not initialized.")
         try:
             # the sdk crashes when multiple resolves happen at the same time
             # guard simultane resolves with a lock.
-            async with node_lock, self._resolve_lock:
+            async with self._resolve_lock:
                 LOGGER.log(
                     log_level,
                     "Attempting to resolve node %s... (attempt %s of %s)",

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -708,31 +708,29 @@ class MatterDeviceController:
         """Setup a single Node AttributePath(s) subscription."""
         node_id = node.node_id
         node_logger = LOGGER.getChild(f"[node {node_id}]")
-        node_lock = self._get_node_lock(node_id)
         assert self.chip_controller is not None
-        async with node_lock:
-            node_logger.debug("Setting up attributes and events subscription.")
-            self.chip_controller.CheckIsActive()
-            assert self.server.loop is not None
-            future = self.server.loop.create_future()
-            device = self.chip_controller.GetConnectedDeviceSync(node_id)
-            Attribute.Read(
-                future=future,
-                eventLoop=self.server.loop,
-                device=device.deviceProxy,
-                devCtrl=self.chip_controller,
-                attributes=attr_subscriptions,
-                events=event_subscriptions,
-                returnClusterObject=False,
-                subscriptionParameters=Attribute.SubscriptionParameters(
-                    interval_floor, interval_ceiling
-                ),
-                # Use fabricfiltered as False to detect changes made by other controllers
-                # and to be able to provide a list of all fabrics attached to the device
-                fabricFiltered=False,
-                autoResubscribe=True,
-            ).raise_on_error()
-            sub: Attribute.SubscriptionTransaction = await future
+        node_logger.debug("Setting up attributes and events subscription.")
+        self.chip_controller.CheckIsActive()
+        assert self.server.loop is not None
+        future = self.server.loop.create_future()
+        device = self.chip_controller.GetConnectedDeviceSync(node_id)
+        Attribute.Read(
+            future=future,
+            eventLoop=self.server.loop,
+            device=device.deviceProxy,
+            devCtrl=self.chip_controller,
+            attributes=attr_subscriptions,
+            events=event_subscriptions,
+            returnClusterObject=False,
+            subscriptionParameters=Attribute.SubscriptionParameters(
+                interval_floor, interval_ceiling
+            ),
+            # Use fabricfiltered as False to detect changes made by other controllers
+            # and to be able to provide a list of all fabrics attached to the device
+            fabricFiltered=False,
+            autoResubscribe=True,
+        ).raise_on_error()
+        sub: Attribute.SubscriptionTransaction = await future
 
         def attribute_updated_callback(
             path: Attribute.TypedAttributePath,

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -456,6 +456,10 @@ class MatterDeviceController:
                 f"Node {node_id} does not exist or has not been interviewed."
             )
 
+        # shutdown any existing subscriptions
+        if attr_sub := self._subscriptions.pop(node_id, None):
+            await self._call_sdk(attr_sub.Shutdown)
+
         # pop any existing interview/subscription reschedule timer
         self._sub_retry_timer.pop(node_id, None)
 

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -627,9 +627,7 @@ class MatterDeviceController:
             # at the exact same time, also causing congestion.
             interval_floor = 0
             interval_ceiling = (
-                random.randint(3500, 3600)
-                if battery_powered
-                else random.randint(40, 70)
+                random.randint(60, 300) if battery_powered else random.randint(20, 60)
             )
             self.chip_controller.CheckIsActive()
             assert self.server.loop is not None


### PR DESCRIPTION
A bunch of (small) optimizations in the commissioning and (re)subscription flows again based on some investigation with various devices. 

- Remove fetching certificates before commissioning (as it only slows down and doesn't do anything)
- Ignore failed commissioned nodes at startup
- Cancel subscription at node removal
- Speed up resolve
- Split up node attribute subscriptions into 2 subscriptions
- Lower the ceiling once again
- Adjust logging of PersistentStorage module of sdk because it was too chatty

