### PR TITLE
Bump schema version to 6

### DIFF
--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -122,8 +122,16 @@ class MatterClient:
 
         :return: The NodeInfo of the commissioned device.
         """
+        if self.server_info and self.server_info.schema_version < 6 and network_only:
+            self.logger.warning(
+                "Server schema version does not support network_only commisisoning, "
+                "the parameter will be ignored."
+            )
+
         data = await self.send_command(
-            APICommand.COMMISSION_WITH_CODE, code=code, network_only=network_only
+            APICommand.COMMISSION_WITH_CODE,
+            code=code,
+            network_only=network_only,
         )
         return dataclass_from_dict(MatterNodeData, data)
 

--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -122,14 +122,9 @@ class MatterClient:
 
         :return: The NodeInfo of the commissioned device.
         """
-        if self.server_info and self.server_info.schema_version < 6 and network_only:
-            self.logger.warning(
-                "Server schema version does not support network_only commisisoning, "
-                "the parameter will be ignored."
-            )
-
         data = await self.send_command(
             APICommand.COMMISSION_WITH_CODE,
+            require_schema=6 if network_only else None,
             code=code,
             network_only=network_only,
         )

--- a/matter_server/common/const.py
+++ b/matter_server/common/const.py
@@ -2,4 +2,4 @@
 
 # schema version is used to determine compatibility between server and client
 # bump schema if we add new features and/or make other (breaking) changes
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6


### PR DESCRIPTION
- Bump schema to version 6
- Require schema version 6 if trying to use the new network_only param

The schema is backwards compatible so not a breaking change