### PR TITLE
Disable chip.Attribute logger

### DIFF
--- a/matter_server/server/__main__.py
+++ b/matter_server/server/__main__.py
@@ -73,6 +73,11 @@ def main() -> None:
     if not logging.getLogger().isEnabledFor(logging.DEBUG):
         logging.getLogger("chip").setLevel(logging.WARNING)
         logging.getLogger("PersistentStorage").setLevel(logging.WARNING)
+        # temporary disable the logger of chip.clusters.Attribute because it now logs
+        # an error on every custom attribute that couldn't be parsed which confuses people
+        # we can restore the default log level again when we patched the device controller
+        # to handle the raw attribute data to deal with custom clusters.
+        logging.getLogger("chip.clusters.Attribute").setLevel(logging.CRITICAL)
 
     # make sure storage path exists
     if not os.path.isdir(args.storage_path):


### PR DESCRIPTION
temporary disable the logger of chip.clusters.Attribute because it now logs an error on every custom attribute that couldn't be parsed which confuses people.

We can restore the default log level again when we patched the device controller to handle the raw attribute data to deal with custom clusters.