### PR TITLE
Immediately store last used node id

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -843,7 +843,9 @@ class MatterDeviceController:
 
     def _get_next_node_id(self) -> int:
         """Return next node_id."""
-        return cast(int, self.server.storage.get(DATA_KEY_LAST_NODE_ID, 0)) + 1
+        next_node_id = cast(int, self.server.storage.get(DATA_KEY_LAST_NODE_ID, 0)) + 1
+        self.server.storage.set(DATA_KEY_LAST_NODE_ID, next_node_id, force=True)
+        return next_node_id
 
     async def _call_sdk(self, func: Callable[..., _T], *args: Any, **kwargs: Any) -> _T:
         """Call function on the SDK in executor and return result."""


### PR DESCRIPTION
Fix regression where the last used NodeID is not stored so causing a collission and effectively preventing multiple commission actions. Store the Node ID we tried at all times. Other logic will make sure that we only start interviewing existing nodes.

Fixes #482 
