### PR TITLE
Remove (pointless) resolve lock

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -452,7 +452,6 @@ class MatterDeviceController:
             raise RuntimeError("Device Controller not initialized.")
         node_lock = self._get_node_lock(node_id)
         endpoint_id, cluster_id, attribute_id = parse_attribute_path(attribute_path)
-        LOGGER.getChild(f"[node {node_id}]")
         async with node_lock:
             assert self.server.loop is not None
             future = self.server.loop.create_future()


### PR DESCRIPTION
We still had a lock (just in case) for resolving nodes. In the meanwhile we learned that its not resolving but subsequent actions on a node that needs to be guarded/locked. With the latest refactor to do all node resolving in the "_resolve_node" helper function this lock was used when not needed. So for example when the server is attempting to resolve unreachable nodes, all (server wide) node actions would then be blocked.

Removing the lock fixes this useless waiting resulting in a massive speedup as well as bugfix for the unstable subscription (continuous resubscriptions)

I have stress tested to ensure that this lock is really no longer needed. I did not experience a segfault.
We do need to keep an eye on using the node_lock at all times because that can in fact induce a segfault due to thread unsafety.