### PR TITLE
Use lock to avoid concurrent save tasks

### DIFF
--- a/matter_server/server/storage.py
+++ b/matter_server/server/storage.py
@@ -23,6 +23,7 @@ class StorageController:
         self.server = server
         self._data: Dict[str, Any] = {}
         self._timer_handle: asyncio.TimerHandle | None = None
+        self._save_lock: asyncio.Lock = asyncio.Lock()
 
     @property
     def filename(self) -> str:
@@ -156,4 +157,5 @@ class StorageController:
                 _file.write(json_dumps(self._data))
             LOGGER.debug("Saved data to persistent storage")
 
-        await self.server.loop.run_in_executor(None, do_save)
+        async with self._save_lock:
+            await self.server.loop.run_in_executor(None, do_save)


### PR DESCRIPTION
When two save tasks are scheduled, they might race and cause exceptions as follows:

```
2024-01-04 11:33:06 core-matter-server asyncio[245] ERROR Task exception was never retrieved
future: <Task finished name='Task-192' coro=<StorageController.async_save() done, defined at /usr/local/lib/python3.11/site-packages/matter_server/server/storage.py:143> exception=FileNotFoundError(2, 'No such file or directory')>
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/matter_server/server/storage.py", line 159, in async_save
    await self.server.loop.run_in_executor(None, do_save)
  File "/usr/local/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/matter_server/server/storage.py", line 153, in do_save
    os.rename(self.filename, filename_backup)
FileNotFoundError: [Errno 2] No such file or directory: '/data/11772491842912284087.json' -> '/data/11772491842912284087.json.backup'
```

Use a lock to avoid multiple save being executed in parallel.