### PR TITLE
Add pagination for vendors query

### DIFF
--- a/matter_server/server/vendor_info.py
+++ b/matter_server/server/vendor_info.py
@@ -48,7 +48,7 @@ class VendorInfo:
         vendors: dict[int, VendorInfoModel] = {}
         try:
             async with ClientSession(raise_for_status=True) as session:
-                page_token = ""
+                page_token: str | None = ""
                 while page_token is not None:
                     async with session.get(
                         f"{PRODUCTION_URL}/dcl/vendorinfo/vendors",

--- a/matter_server/server/vendor_info.py
+++ b/matter_server/server/vendor_info.py
@@ -52,7 +52,7 @@ class VendorInfo:
                 while page_token is not None:
                     async with session.get(
                         f"{PRODUCTION_URL}/dcl/vendorinfo/vendors",
-                        params={"pagination.key": page_token}
+                        params={"pagination.key": page_token},
                     ) as response:
                         data = await response.json()
                         for vendorinfo in data["vendorInfo"]:
@@ -60,8 +60,12 @@ class VendorInfo:
                                 vendor_id=vendorinfo["vendorID"],
                                 vendor_name=vendorinfo["vendorName"],
                                 company_legal_name=vendorinfo["companyLegalName"],
-                                company_preferred_name=vendorinfo["companyPreferredName"],
-                                vendor_landing_page_url=vendorinfo["vendorLandingPageURL"],
+                                company_preferred_name=vendorinfo[
+                                    "companyPreferredName"
+                                ],
+                                vendor_landing_page_url=vendorinfo[
+                                    "vendorLandingPageURL"
+                                ],
                                 creator=vendorinfo["creator"],
                             )
                     page_token = data.get("pagination", {}).get("next_key", None)


### PR DESCRIPTION
this api defaults to a limit of 100 vendors. adds a loop to fetch all the pages

docs: https://on.dcl.csa-iot.org/#/Query/VendorInfoAll

logs after update
```
2024-01-05 02:28:11 3bf053e85e29 matter_server.server.vendor_info[1] INFO Loading vendor info from storage.
2024-01-05 02:28:11 3bf053e85e29 matter_server.server.vendor_info[1] INFO Loaded 0 vendors from storage.
2024-01-05 02:28:11 3bf053e85e29 matter_server.server.vendor_info[1] INFO Fetching the latest vendor info from DCL.
2024-01-05 02:28:12 3bf053e85e29 matter_server.server.vendor_info[1] INFO Fetched 142 vendors from DCL.
2024-01-05 02:28:12 3bf053e85e29 matter_server.server.vendor_info[1] INFO Saving vendor info to storage.
```