### PR TITLE
Fix json serialization for discovery api

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -16,6 +16,7 @@ from chip.ChipDeviceCtrl import (
     CommissioningParameters,
     DeviceProxyWrapper,
 )
+from chip.discovery import CommissionableNode as CommissionableNodeData
 from chip.clusters import Attribute, Objects as Clusters
 from chip.clusters.Attribute import ValueDecodeFailure
 from chip.clusters.ClusterObjects import ALL_ATTRIBUTES, ALL_CLUSTERS, Cluster
@@ -383,7 +384,7 @@ class MatterDeviceController:
     @api_command(APICommand.DISCOVER)
     async def discover_commissionable_nodes(
         self,
-    ) -> CommissionableNode | list[CommissionableNode] | None:
+    ) -> CommissionableNodeData | list[CommissionableNodeData] | None:
         """Discover Commissionable Nodes (discovered on BLE or mDNS)."""
         if self.chip_controller is None:
             raise RuntimeError("Device Controller not initialized.")
@@ -391,7 +392,16 @@ class MatterDeviceController:
         result = await self._call_sdk(
             self.chip_controller.DiscoverCommissionableNodes,
         )
-        return result
+
+        def convert(cn: CommissionableNode) -> CommissionableNodeData:
+            cnd = CommissionableNodeData()
+            for field in CommissionableNodeData.__dataclass_fields__:
+                setattr(cnd, field, getattr(cn, field))
+            return cnd
+
+        if isinstance(result, list):
+            return [convert(c) for c in result]
+        return convert(result)
 
     @api_command(APICommand.INTERVIEW_NODE)
     async def interview_node(self, node_id: int) -> None:

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -16,10 +16,10 @@ from chip.ChipDeviceCtrl import (
     CommissioningParameters,
     DeviceProxyWrapper,
 )
-from chip.discovery import CommissionableNode as CommissionableNodeData
 from chip.clusters import Attribute, Objects as Clusters
 from chip.clusters.Attribute import ValueDecodeFailure
 from chip.clusters.ClusterObjects import ALL_ATTRIBUTES, ALL_CLUSTERS, Cluster
+from chip.discovery import CommissionableNode as CommissionableNodeData
 from chip.exceptions import ChipStackError
 
 from matter_server.server.helpers.attributes import parse_attributes_from_read_result

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -395,6 +395,7 @@ class MatterDeviceController:
 
         def convert(cn: CommissionableNode) -> CommissionableNodeData:
             cnd = CommissionableNodeData()
+            # pylint: disable=no-member
             for field in CommissionableNodeData.__dataclass_fields__:
                 setattr(cnd, field, getattr(cn, field))
             return cnd


### PR DESCRIPTION
alternative to #448 

validated locally:

```json
{
  "message_id": "c9627ca8-b91d-4f76-98de-91d4f34cd495",
  "result": [
    {
      "instanceName": "<redacted>",
      "hostName": "<redacted>",
      "port": <redacted>,
      "longDiscriminator": <redacted>,
      "vendorId": 4874,
      "productId": 89,
      "commissioningMode": 2,
      "deviceType": 263,
      "deviceName": "Eve Motion",
      "pairingInstruction": "",
      "pairingHint": <redacted>,
      "mrpRetryIntervalIdle": 3300,
      "mrpRetryIntervalActive": 1100,
      "supportsTcp": false,
      "addresses": [
        "<redacted>"
      ],
      "rotatingId": "<redacted>"
    }
  ]
}
```