### PR TITLE
Log ChipStackError as well

### DIFF
--- a/matter_server/server/client_handler.py
+++ b/matter_server/server/client_handler.py
@@ -188,6 +188,7 @@ class WebsocketClientHandler:
                 result = await result
             self._send_message(SuccessResultMessage(msg.message_id, result))
         except ChipStackError as err:
+            self._logger.exception("SDK Error during handling message: %s", msg)
             self._send_message(
                 ErrorResultMessage(msg.message_id, SDKStackError.error_code, str(err))
             )


### PR DESCRIPTION
In case we encounter an unhandled ChipStackError during processing a websocket message, make sure we note that in our server logs as well.

Typically we should handle those errors and convert them to Python Matter server specific errors.