### PR TITLE
Print result of device removal

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -576,6 +576,8 @@ class MatterDeviceController:
         self.server.storage.save(immediate=True)
         LOGGER.info("Node ID %s successfully removed from Matter server.", node_id)
 
+        self.server.signal_event(EventType.NODE_REMOVED, node_id)
+
         assert node is not None
 
         attribute_path = create_attribute_path_from_attribute(
@@ -584,15 +586,25 @@ class MatterDeviceController:
         )
         fabric_index = node.attributes[attribute_path]
 
-        self.server.signal_event(EventType.NODE_REMOVED, node_id)
-
-        await self.chip_controller.SendCommand(
-            nodeid=node_id,
-            endpoint=0,
-            payload=Clusters.OperationalCredentials.Commands.RemoveFabric(
-                fabricIndex=fabric_index,
-            ),
+        result: Clusters.OperationalCredentials.Commands.NOCResponse = (
+            await self.chip_controller.SendCommand(
+                nodeid=node_id,
+                endpoint=0,
+                payload=Clusters.OperationalCredentials.Commands.RemoveFabric(
+                    fabricIndex=fabric_index,
+                ),
+            )
         )
+        if (
+            result.statusCode
+            == Clusters.OperationalCredentials.Enums.NodeOperationalCertStatusEnum.kOk
+        ):
+            LOGGER.info("Successfully removed Home Assistant fabric from device.")
+        else:
+            LOGGER.warning(
+                "Removing Home Assistant fabric from device failed with status code %d.",
+                result.statusCode,
+            )
 
     @api_command(APICommand.SUBSCRIBE_ATTRIBUTE)
     async def subscribe_attribute(

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -602,7 +602,7 @@ class MatterDeviceController:
             LOGGER.info("Successfully removed Home Assistant fabric from device.")
         else:
             LOGGER.warning(
-                "Removing Home Assistant fabric from device failed with status code %d.",
+                "Removing current fabric from device failed with status code %d.",
                 result.statusCode,
             )
 


### PR DESCRIPTION
Ideally, we like to remove the Home Assistant fabric from a device. We optimistically execute the command to remove the device.

Check the result of the device removal and print a message accordingly so users can tell if removing was successful.