### PR TITLE
Scope link-local IPv6 addresses received from WebSocket

### DIFF
--- a/matter_server/server/__main__.py
+++ b/matter_server/server/__main__.py
@@ -58,6 +58,12 @@ parser.add_argument(
     default=None,
     help="Log file to write to (optional).",
 )
+parser.add_argument(
+    "--primary-interface",
+    type=str,
+    default=None,
+    help="Primary network interface for link-local addresses (optional).",
+)
 
 args = parser.parse_args()
 
@@ -85,7 +91,8 @@ def main() -> None:
 
     # Init server
     server = MatterServer(
-        args.storage_path, int(args.vendorid), int(args.fabricid), int(args.port)
+        args.storage_path, int(args.vendorid), int(args.fabricid), int(args.port),
+        args.primary_interface
     )
 
     async def handle_stop(loop: asyncio.AbstractEventLoop) -> None:

--- a/matter_server/server/__main__.py
+++ b/matter_server/server/__main__.py
@@ -91,8 +91,11 @@ def main() -> None:
 
     # Init server
     server = MatterServer(
-        args.storage_path, int(args.vendorid), int(args.fabricid), int(args.port),
-        args.primary_interface
+        args.storage_path,
+        int(args.vendorid),
+        int(args.fabricid),
+        int(args.port),
+        args.primary_interface,
     )
 
     async def handle_stop(loop: asyncio.AbstractEventLoop) -> None:

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -259,6 +259,8 @@ class MatterDeviceController:
             raise RuntimeError("Device Controller not initialized.")
 
         node_id = self._get_next_node_id()
+        if ip_addr is not None:
+            ip_addr = self.server.scope_ipv6_lla(ip_addr)
 
         attempts = 0
         # we retry commissioning a few times as we've seen devices in the wild
@@ -281,9 +283,8 @@ class MatterDeviceController:
                     filter=filter,
                 )
             else:
-                ip_addr = self.server.scope_ipv6_lla(ip_addr)
                 LOGGER.info(
-                    "Starting Matter commissioning with IP using Node ID %s via IP address %s  (attempt %s/%s).",
+                    "Starting Matter commissioning using Node ID %s and IP %s (attempt %s/%s).",
                     node_id,
                     ip_addr,
                     attempts,

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -281,10 +281,11 @@ class MatterDeviceController:
                     filter=filter,
                 )
             else:
-                # Ip-adress provided, use CommissionIP method
+                ip_addr = self.server.scope_ipv6_lla(ip_addr)
                 LOGGER.info(
-                    "Starting Matter commissioning with IP using Node ID %s (attempt %s/%s).",
+                    "Starting Matter commissioning with IP using Node ID %s via IP address %s  (attempt %s/%s).",
                     node_id,
+                    ip_addr,
                     attempts,
                     MAX_COMMISSION_RETRIES,
                 )

--- a/matter_server/server/server.py
+++ b/matter_server/server/server.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 import ipaddress
 import logging
-from typing import Any, Callable, Set
+from typing import Any, Callable, Set, cast
 import weakref
 
 from aiohttp import web
@@ -177,8 +177,10 @@ class MatterServer:
         device is connected on the primary interface.
         """
         ip_addr_parsed = ipaddress.ip_address(ip_addr)
-        if not ip_addr_parsed.is_link_local:
+        if not ip_addr_parsed.is_link_local or ip_addr_parsed.version != 6:
             return ip_addr
+
+        ip_addr_parsed = cast(ipaddress.IPv6Address, ip_addr_parsed)
 
         if ip_addr_parsed.scope_id is not None:
             # This type of IPv6 manipulation is not supported by the ipaddress lib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,12 +28,12 @@ dependencies = [
   "coloredlogs",
   "dacite",
   "orjson",
-  "home-assistant-chip-clusters==2023.12.0"
+  "home-assistant-chip-clusters==2024.1.0"
 ]
 
 [project.optional-dependencies]
 server = [
-  "home-assistant-chip-core==2023.12.0",
+  "home-assistant-chip-core==2024.1.0",
   "cryptography==41.0.7"
 ]
 test = [

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -99,7 +99,7 @@ def fetch_certificates_fixture() -> Generator[MagicMock, None, None]:
 @pytest.fixture(name="server")
 async def server_fixture() -> AsyncGenerator[MatterServer, None]:
     """Yield a server."""
-    server = MatterServer("test_storage_path", 1234, 5678, 5580)
+    server = MatterServer("test_storage_path", 1234, 5678, 5580, None)
     await server.start()
     yield server
     await server.stop()


### PR DESCRIPTION
Scope link-local IPv6 addresses received from WebSocket

When receiving link-local IPv6 addresses, remove the scope by default
as the scope id is typically from a remote machine (e.g. from the Android
phone).

If the Matter server got started with a primary interface set, scope the
link-local address to that interface instead.

This fixes commissioning issue for WiFi devices when using the Android
in-app commissioning flow which sends the IP address of the device
to be commissioned alongside.

Related-to: #463