### PR TITLE
Add diagnostics for matter nodes

### DIFF
--- a/matter_server/client/models/node.py
+++ b/matter_server/client/models/node.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 import logging
 from typing import Any, TypeVar, cast
 
@@ -363,3 +364,41 @@ class MatterNode:
     def __repr__(self) -> str:
         """Return the representation."""
         return f"<MatterNode {self.node_id}>"
+
+
+class NodeType(Enum):
+    """Custom Enum with Matter node types, used for diagnostics."""
+
+    END_DEVICE = "end_device"
+    SLEEPY_END_DEVICE = "sleepy_end_device"
+    ROUTING_END_DEVICE = "routing_end_device"
+    BRIDGE = "bridge"
+    UNKNOWN = "unknown"
+
+
+class NetworkType(Enum):
+    """Custom Enum with Matter network types used for diagnostics.."""
+
+    THREAD = "thread"
+    WIFI = "wifi"
+    ETHERNET = "ethernet"
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class NodeDiagnostics:
+    """
+    Representation of a Node diagnostics message.
+
+    This a custom model intended to be (easily) consumed by Home Assistant
+    and constructed from various cluster attribute values.
+    """
+
+    node_id: int
+    network_type: NetworkType
+    node_type: NodeType
+    network_name: str | None  # WiFi SSID or Thread network name
+    ip_adresses: list[str]
+    mac_address: str | None
+    reachable: bool
+    active_fabrics: list[MatterFabricData]

--- a/matter_server/common/helpers/util.py
+++ b/matter_server/common/helpers/util.py
@@ -318,7 +318,4 @@ def convert_ip_address(hex_ip: str | bytes, ipv6: bool = False) -> str:
     if isinstance(hex_ip, str):
         # note that the bytes string can be optionally base64 encoded
         hex_ip = base64.b64decode(hex_ip)
-    if ipv6:
-        hex_str = "".join(f"{byte:02x}" for byte in hex_ip)
-        return ":".join(hex_str[i : i + 4] for i in range(0, len(hex_str), 4))
-    return socket.inet_ntoa(hex_ip)
+    return socket.inet_ntop(socket.AF_INET6 if ipv6 else socket.AF_INET, hex_ip)

--- a/matter_server/common/helpers/util.py
+++ b/matter_server/common/helpers/util.py
@@ -295,7 +295,7 @@ def chip_core_version() -> str:
 
 
 def convert_hex_string(hex_str: str | bytes) -> str:
-    """Convert hex string received from the sdk to a regular (unicode) string."""
+    """Convert (Base64 encoded) byte array received from the sdk to a regular (unicode) string."""
     if isinstance(hex_str, str):
         # note that the bytes string can be optionally base64 encoded
         # when we send it back and forth over our api
@@ -305,7 +305,7 @@ def convert_hex_string(hex_str: str | bytes) -> str:
 
 
 def convert_mac_address(hex_mac: str | bytes) -> str:
-    """Convert hexadecimal MAC received from the sdk to a regular mac-address string."""
+    """Convert (Base64 encoded) byte array MAC received from the sdk to a regular mac-address."""
     if isinstance(hex_mac, str):
         # note that the bytes string can be optionally base64 encoded
         hex_mac = base64.b64decode(hex_mac)
@@ -314,7 +314,7 @@ def convert_mac_address(hex_mac: str | bytes) -> str:
 
 
 def convert_ip_address(hex_ip: str | bytes, ipv6: bool = False) -> str:
-    """Convert hexadecimal IP received from the sdk to a regular IP string."""
+    """Convert (Base64 encoded) byte array IP received from the Matter SDK to a regular IP."""
     if isinstance(hex_ip, str):
         # note that the bytes string can be optionally base64 encoded
         hex_ip = base64.b64decode(hex_ip)

--- a/matter_server/common/models.py
+++ b/matter_server/common/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import Any, Callable, Type
+from typing import Any, Callable
 
 # Enums and constants
 
@@ -44,8 +44,6 @@ class APICommand(str, Enum):
     READ_ATTRIBUTE = "read_attribute"
     WRITE_ATTRIBUTE = "write_attribute"
     PING_NODE = "ping_node"
-    NODE_FABRICS = "node_fabrics"
-    NODE_DIAGNOSTICS = "node_diagnostics"
 
 
 EventCallBackType = Callable[[EventType, Any], None]
@@ -109,72 +107,7 @@ class ServerDiagnostics:
     events: list[dict]
 
 
-class NodeType(Enum):
-    """Enum with Matter node types."""
-
-    END_DEVICE = "end_device"
-    SLEEPY_END_DEVICE = "sleepy_end_device"
-    ROUTING_END_DEVICE = "routing_end_device"
-    BRIDGE = "bridge"
-    UNKNOWN = "unknown"
-
-    @classmethod
-    def from_matter_routing_role(cls: Type, role: int) -> NodeType:
-        """Parse NetworkType from Matter RoutingRole integer."""
-        if role in (5, 6):
-            return NodeType.ROUTING_END_DEVICE
-        if role == 2:
-            return NodeType.SLEEPY_END_DEVICE
-        if role == 3:
-            return NodeType.END_DEVICE
-        return NodeType.UNKNOWN
-
-
-class NetworkType(Enum):
-    """Enum with Matter network types."""
-
-    THREAD = "thread"
-    WIFI = "wifi"
-    ETHERNET = "ethernet"
-    UNKNOWN = "unknown"
-
-    @classmethod
-    def from_matter_interface_type(cls: Type, interface: int) -> NetworkType:
-        """Parse NetworkType from Matter InterfaceType integer."""
-        if interface == 1:
-            return NetworkType.WIFI
-        if interface == 2:
-            return NetworkType.ETHERNET
-        if interface == 4:
-            return NetworkType.THREAD
-        return NetworkType.UNKNOWN
-
-
 NodePingResult = dict[str, bool]
-
-
-@dataclass
-class ActiveFabric:
-    """Representation of a ActiveFabric message."""
-
-    fabric_index: int
-    vendor_id: int
-    fabric_id: int
-    name: str
-
-
-@dataclass
-class NodeDiagnostics:
-    """Representation of a Node diagnostics message."""
-
-    node_id: int
-    network_type: NetworkType
-    node_type: NodeType
-    network_name: str | None  # WiFi SSID or Thread network name
-    ip_adresses: list[str]
-    mac_address: str | None
-    reachable: bool
-    active_fabrics: list[ActiveFabric]
 
 
 # API message models

--- a/matter_server/common/models.py
+++ b/matter_server/common/models.py
@@ -140,7 +140,7 @@ class NetworkType(Enum):
 
     @classmethod
     def from_matter_interface_type(cls: Type, interface: int) -> NetworkType:
-        """Parse NetworkType  from Matter InterfaceType integer."""
+        """Parse NetworkType from Matter InterfaceType integer."""
         if interface == 1:
             return NetworkType.WIFI
         if interface == 2:

--- a/matter_server/common/models.py
+++ b/matter_server/common/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import Any, Callable
+from typing import Any, Callable, Type
 
 # Enums and constants
 
@@ -43,6 +43,9 @@ class APICommand(str, Enum):
     SUBSCRIBE_ATTRIBUTE = "subscribe_attribute"
     READ_ATTRIBUTE = "read_attribute"
     WRITE_ATTRIBUTE = "write_attribute"
+    PING_NODE = "ping_node"
+    NODE_FABRICS = "node_fabrics"
+    NODE_DIAGNOSTICS = "node_diagnostics"
 
 
 EventCallBackType = Callable[[EventType, Any], None]
@@ -104,6 +107,74 @@ class ServerDiagnostics:
     info: ServerInfoMessage
     nodes: list[MatterNodeData]
     events: list[dict]
+
+
+class NodeType(Enum):
+    """Enum with Matter node types."""
+
+    END_DEVICE = "end_device"
+    SLEEPY_END_DEVICE = "sleepy_end_device"
+    ROUTING_END_DEVICE = "routing_end_device"
+    BRIDGE = "bridge"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def from_matter_routing_role(cls: Type, role: int) -> NodeType:
+        """Parse NetworkType from Matter RoutingRole integer."""
+        if role in (5, 6):
+            return NodeType.ROUTING_END_DEVICE
+        if role == 2:
+            return NodeType.SLEEPY_END_DEVICE
+        if role == 3:
+            return NodeType.END_DEVICE
+        return NodeType.UNKNOWN
+
+
+class NetworkType(Enum):
+    """Enum with Matter network types."""
+
+    THREAD = "thread"
+    WIFI = "wifi"
+    ETHERNET = "ethernet"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def from_matter_interface_type(cls: Type, interface: int) -> NetworkType:
+        """Parse NetworkType  from Matter InterfaceType integer."""
+        if interface == 1:
+            return NetworkType.WIFI
+        if interface == 2:
+            return NetworkType.ETHERNET
+        if interface == 4:
+            return NetworkType.THREAD
+        return NetworkType.UNKNOWN
+
+
+NodePingResult = dict[str, bool]
+
+
+@dataclass
+class ActiveFabric:
+    """Representation of a ActiveFabric message."""
+
+    fabric_index: int
+    vendor_id: int
+    fabric_id: int
+    name: str
+
+
+@dataclass
+class NodeDiagnostics:
+    """Representation of a Node diagnostics message."""
+
+    node_id: int
+    network_type: NetworkType
+    node_type: NodeType
+    network_name: str | None  # WiFi SSID or Thread network name
+    ip_adresses: list[str]
+    mac_address: str | None
+    reachable: bool
+    active_fabrics: list[ActiveFabric]
 
 
 # API message models

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -701,15 +701,15 @@ class MatterDeviceController:
             """Ping IP and add to result."""
             result[ip_address] = await ping_ip(ip_address)
 
-        # the network interfaces attribute contains a list of network interfaces
-        # for regular nodes this is just a single interface but we iterate them all anyway
-        # create a list of tasks so we can do multiple pings simultanuous
-        # NOTE: upgrade this to TaskGroup once we bump to our minimal python version
+        # The network interfaces attribute contains a list of network interfaces.
+        # For regular nodes this is just a single interface but we iterate them all anyway.
+        # Create a list of tasks so we can do multiple pings simultanuous.
+        # NOTE: Upgrade this to a TaskGroup once we bump our minimal python version.
         attr_data = cast(list[dict[str, Any]], node.attributes.get(attr_path))
         tasks: list[Awaitable] = []
         for network_interface_data in attr_data:
             network_interface: Clusters.GeneralDiagnostics.Structs.NetworkInterface = (
-                parse_value(  # noqa: E501 # pylint: disable=line-too-long
+                parse_value(
                     "network_interface",
                     network_interface_data,
                     Clusters.GeneralDiagnostics.Structs.NetworkInterface,

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -64,6 +64,10 @@ LOGGER = logging.getLogger(__name__)
 MAX_POLL_INTERVAL = 600
 MAX_COMMISSION_RETRIES = 3
 
+ROUTING_ROLE_ATTRIBUTE_PATH = create_attribute_path_from_attribute(
+    0, Clusters.ThreadNetworkDiagnostics.Attributes.RoutingRole
+)
+
 BASE_SUBSCRIBE_ATTRIBUTES: tuple[Attribute.AttributePath, Attribute.AttributePath] = (
     # all endpoints, BasicInformation cluster
     Attribute.AttributePath(
@@ -691,7 +695,7 @@ class MatterDeviceController:
                 LOGGER.exception(err)
 
         battery_powered = (
-            node.attributes.get("0/53/1", 0)
+            node.attributes.get(ROUTING_ROLE_ATTRIBUTE_PATH, 0)
             == Clusters.ThreadNetworkDiagnostics.Enums.RoutingRoleEnum.kSleepyEndDevice
         )
 
@@ -799,7 +803,7 @@ class MatterDeviceController:
         # determine if node is battery powered sleeping device
         # Endpoint 0, ThreadNetworkDiagnostics Cluster, routingRole attribute
         battery_powered = (
-            node.attributes.get("0/53/1", 0)
+            node.attributes.get(ROUTING_ROLE_ATTRIBUTE_PATH, 0)
             == Clusters.ThreadNetworkDiagnostics.Enums.RoutingRoleEnum.kSleepyEndDevice
         )
 

--- a/matter_server/server/helpers/utils.py
+++ b/matter_server/server/helpers/utils.py
@@ -28,16 +28,16 @@ def convert_ip_address(hex_ip: str | bytes, ipv6: bool = False) -> str:
     return socket.inet_ntoa(hex_ip)
 
 
-async def ping_ip(ip_address: str) -> bool:
+async def ping_ip(ip_address: str, timeout: int = 2) -> bool:
     """Ping given (IPv4 or IPv6) IP-address."""
     is_ipv6 = ":" in ip_address
     if is_ipv6 and PLATFORM_MAC:
         # macos does not have support for -W (timeout) on ping6 ?!
         cmd = f"ping6 -c 1 {ip_address}"
     elif is_ipv6:
-        cmd = f"ping6 -c 1 -W 2 {ip_address}"
+        cmd = f"ping6 -c 1 -W {timeout} {ip_address}"
     else:
-        cmd = f"ping -c 1 -W 2 {ip_address}"
+        cmd = f"ping -c 1 -W {timeout} {ip_address}"
     return (await check_output(cmd))[0] == 0
 
 

--- a/matter_server/server/helpers/utils.py
+++ b/matter_server/server/helpers/utils.py
@@ -1,0 +1,52 @@
+"""Utils for Matter server."""
+
+import asyncio
+import base64
+import platform
+import socket
+
+PLATFORM_MAC = platform.system() == "Darwin"
+
+
+def convert_mac_address(hex_mac: str | bytes) -> str:
+    """Convert hexadecimal MAC received from the sdk to a regular mac-address string."""
+    if isinstance(hex_mac, str):
+        # note that the bytes string can be optionally base64 encoded
+        hex_mac = base64.b64decode(hex_mac)
+
+    return ":".join("{:02x}".format(byte) for byte in hex_mac)  # pylint: disable=C0209
+
+
+def convert_ip_address(hex_ip: str | bytes, ipv6: bool = False) -> str:
+    """Convert hexadecimal IP received from the sdk to a regular IP string."""
+    if isinstance(hex_ip, str):
+        # note that the bytes string can be optionally base64 encoded
+        hex_ip = base64.b64decode(hex_ip)
+    if ipv6:
+        hex_str = "".join(f"{byte:02x}" for byte in hex_ip)
+        return ":".join(hex_str[i : i + 4] for i in range(0, len(hex_str), 4))
+    return socket.inet_ntoa(hex_ip)
+
+
+async def ping_ip(ip_address: str) -> bool:
+    """Ping given (IPv4 or IPv6) IP-address."""
+    is_ipv6 = ":" in ip_address
+    if is_ipv6 and PLATFORM_MAC:
+        # macos does not have support for -W (timeout) on ping6 ?!
+        cmd = f"ping6 -c 1 {ip_address}"
+    elif is_ipv6:
+        cmd = f"ping6 -c 1 -W 2 {ip_address}"
+    else:
+        cmd = f"ping -c 1 -W 2 {ip_address}"
+    return (await check_output(cmd))[0] == 0
+
+
+async def check_output(shell_cmd: str) -> tuple[int | None, bytes]:
+    """Run shell subprocess and return output."""
+    proc = await asyncio.create_subprocess_shell(
+        shell_cmd,
+        stderr=asyncio.subprocess.STDOUT,
+        stdout=asyncio.subprocess.PIPE,
+    )
+    stdout, _ = await proc.communicate()
+    return (proc.returncode, stdout)

--- a/matter_server/server/helpers/utils.py
+++ b/matter_server/server/helpers/utils.py
@@ -1,31 +1,9 @@
 """Utils for Matter server."""
 
 import asyncio
-import base64
 import platform
-import socket
 
 PLATFORM_MAC = platform.system() == "Darwin"
-
-
-def convert_mac_address(hex_mac: str | bytes) -> str:
-    """Convert hexadecimal MAC received from the sdk to a regular mac-address string."""
-    if isinstance(hex_mac, str):
-        # note that the bytes string can be optionally base64 encoded
-        hex_mac = base64.b64decode(hex_mac)
-
-    return ":".join("{:02x}".format(byte) for byte in hex_mac)  # pylint: disable=C0209
-
-
-def convert_ip_address(hex_ip: str | bytes, ipv6: bool = False) -> str:
-    """Convert hexadecimal IP received from the sdk to a regular IP string."""
-    if isinstance(hex_ip, str):
-        # note that the bytes string can be optionally base64 encoded
-        hex_ip = base64.b64decode(hex_ip)
-    if ipv6:
-        hex_str = "".join(f"{byte:02x}" for byte in hex_ip)
-        return ":".join(hex_str[i : i + 4] for i in range(0, len(hex_str), 4))
-    return socket.inet_ntoa(hex_ip)
 
 
 async def ping_ip(ip_address: str, timeout: int = 2) -> bool:

--- a/matter_server/server/vendor_info.py
+++ b/matter_server/server/vendor_info.py
@@ -18,12 +18,35 @@ PRODUCTION_URL = "https://on.dcl.csa-iot.org"
 DATA_KEY_VENDOR_INFO = "vendor_info"
 
 
+TEST_VENDOR = VendorInfoModel(
+    vendor_id=65521,
+    vendor_name="Test",
+    company_legal_name="Test",
+    company_preferred_name="Test",
+    vendor_landing_page_url="https://csa-iot.org",
+    creator="",
+)
+NABUCASA_VENDOR = VendorInfoModel(
+    vendor_id=4939,
+    vendor_name="Nabu Casa",
+    company_legal_name="Nabu Casa Inc.",
+    company_preferred_name="Nabu Casa",
+    vendor_landing_page_url="https://nabucasa.com/",
+    creator="",
+)
+
+
 class VendorInfo:
     """Fetches vendor info from the CSA and handles api calls to get it."""
 
     def __init__(self, server: MatterServer):
         """Initialize the vendor info."""
-        self._data: dict[int, VendorInfoModel] = {}
+        self._data: dict[int, VendorInfoModel] = {
+            # add test vendor ID
+            TEST_VENDOR.vendor_id: TEST_VENDOR,
+            # add nabucasa vendor while we're not yet certified
+            NABUCASA_VENDOR.vendor_id: NABUCASA_VENDOR,
+        }
         self._server = server
 
     async def start(self) -> None:

--- a/tests/common/test_utils.py
+++ b/tests/common/test_utils.py
@@ -1,10 +1,6 @@
 """Test the util functions."""
 
-from matter_server.server.helpers.utils import (
-    convert_ip_address,
-    convert_mac_address,
-    ping_ip,
-)
+from matter_server.common.helpers.util import convert_ip_address, convert_mac_address
 
 
 def test_convert_functions() -> None:
@@ -17,15 +13,3 @@ def test_convert_functions() -> None:
     assert convert_mac_address("ji4yiD/r91c=") == "8e:2e:32:88:3f:eb:f7:57"
 
     b"\xfe\x80\x00\x00\x00\x00\x00\x00\x04P\x1dB]@\x8eE"
-
-
-async def test_ping() -> None:
-    """Test ping ip util."""
-    # test valid ipv4
-    assert await ping_ip("127.0.0.1") is True
-    # test invalid ipv4
-    assert await ping_ip("192.5.2.7") is False
-    # test valid ipv6
-    assert await ping_ip("::1") is True
-    # test invalid ipv6
-    assert await ping_ip("232::344::33") is False

--- a/tests/server/test_utils.py
+++ b/tests/server/test_utils.py
@@ -1,0 +1,31 @@
+"""Test the util functions."""
+
+from matter_server.server.helpers.utils import (
+    convert_ip_address,
+    convert_mac_address,
+    ping_ip,
+)
+
+
+def test_convert_functions() -> None:
+    """Test convert_ip_address and convert_mac_address util."""
+    assert convert_ip_address("wKgBNA==") == "192.168.1.52"
+    assert (
+        convert_ip_address("KgARtxIxhABW70T//kmvxg==", True)
+        == "2a00:11b7:1231:8400:56ef:44ff:fe49:afc6"
+    )
+    assert convert_mac_address("ji4yiD/r91c=") == "8e:2e:32:88:3f:eb:f7:57"
+
+    b"\xfe\x80\x00\x00\x00\x00\x00\x00\x04P\x1dB]@\x8eE"
+
+
+async def test_ping() -> None:
+    """Test ping ip util."""
+    # test valid ipv4
+    assert await ping_ip("127.0.0.1") is True
+    # test invalid ipv4
+    assert await ping_ip("192.5.2.7") is False
+    # test valid ipv6
+    assert await ping_ip("::1") is True
+    # test invalid ipv6
+    assert await ping_ip("232::344::33") is False


### PR DESCRIPTION
Add models and functions to get (and refresh) diagnostic details for Matter nodes:

- Add ping_node command to the server to refresh and ping all ip addresses of a node and return them in a human readable format.
- Adjust matter_fabrics helper in the client to refresh the data
- Add node_diagnostics helper in the client to return a collection of node diagnostics in a human readable format, already prepared in a custom format that is more ready suitable for HA (like string enums that can be used as translation keys)

