### PR TITLE
Guard node resolving with a lock

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -107,7 +107,7 @@ class MatterDeviceController:
         self.thread_credentials_set: bool = False
         self.compressed_fabric_id: int | None = None
         self._node_lock: dict[int, asyncio.Lock] = {}
-        self._resolve_lock: asyncio.Lock = asyncio.Lock()
+        self._resolve_lock = asyncio.Lock()
 
     async def initialize(self) -> None:
         """Async initialize of controller."""


### PR DESCRIPTION
It's still not entirely clear but it looks like multiple resolves at the same time is not very safe and one action may even be discarded if another attempt comes in. So for example if the server is busy trying to resolve an offline node it may cause commissioning to fail. So for safety reasons put a lock on the resolving. It makes init of nodes somewhat slower but its safer.