### PR TITLE
Fix model for CommissioningParameters in client

### DIFF
--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -22,6 +22,7 @@ from ..common.helpers.util import (
 from ..common.models import (
     APICommand,
     CommandMessage,
+    CommissioningParameters,
     ErrorResultMessage,
     EventMessage,
     EventType,
@@ -179,14 +180,14 @@ class MatterClient:
         iteration: int = 1000,
         option: int = 1,
         discriminator: Optional[int] = None,
-    ) -> tuple[int, str]:
+    ) -> CommissioningParameters:
         """
         Open a commissioning window to commission a device present on this controller to another.
 
         Returns code to use as discriminator.
         """
-        return cast(
-            tuple[int, str],
+        return dataclass_from_dict(
+            CommissioningParameters,
             await self.send_command(
                 APICommand.OPEN_COMMISSIONING_WINDOW,
                 node_id=node_id,

--- a/matter_server/common/models.py
+++ b/matter_server/common/models.py
@@ -172,3 +172,16 @@ MessageType = (
     | ErrorResultMessage
     | ServerInfoMessage
 )
+
+
+@dataclass
+class CommissioningParameters:
+    """
+    Object that is returned on the 'open_commisisoning_window' command.
+
+    NOTE: This is just a copy of the dataclass specified in chip.ChipDeviceCtrl
+    """
+
+    setupPinCode: int  # pylint: disable=invalid-name
+    setupManualCode: str  # pylint: disable=invalid-name
+    setupQRCode: str  # pylint: disable=invalid-name

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -11,11 +11,7 @@ import logging
 import random
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Iterable, TypeVar, cast
 
-from chip.ChipDeviceCtrl import (
-    CommissionableNode,
-    CommissioningParameters,
-    DeviceProxyWrapper,
-)
+from chip.ChipDeviceCtrl import CommissionableNode, DeviceProxyWrapper
 from chip.clusters import Attribute, Objects as Clusters
 from chip.clusters.Attribute import ValueDecodeFailure
 from chip.clusters.ClusterObjects import ALL_ATTRIBUTES, ALL_CLUSTERS, Cluster
@@ -23,6 +19,7 @@ from chip.discovery import CommissionableNode as CommissionableNodeData
 from chip.exceptions import ChipStackError
 
 from matter_server.common.helpers.util import convert_ip_address
+from matter_server.common.models import CommissioningParameters
 from matter_server.server.helpers.attributes import parse_attributes_from_read_result
 from matter_server.server.helpers.utils import ping_ip
 


### PR DESCRIPTION
The server returns a CommissioningParameters object on the "open_commissioning_window" which is a dataclass specified in the chip devicecontroller.

The typing on our python client side was still a tuple, so wrong.

Copied the CommissioningParameters dataclass to our shared models for the client.