### PR TITLE
Speedup diagnostics

### DIFF
--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -260,9 +260,6 @@ class MatterClient:
             # ignore invalid/non-operational interfaces
             if not network_interface.isOperational:
                 continue
-            # ignore invalid/non-operational interfaces
-            if not network_interface.isOperational:
-                continue
             if (
                 network_interface.type
                 == Clusters.GeneralDiagnostics.Enums.InterfaceTypeEnum.kThread

--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -10,12 +10,11 @@ import uuid
 from aiohttp import ClientSession
 from chip.clusters import Objects as Clusters
 
-from matter_server.common.errors import ERROR_MAP, MatterError, NodeNotExists
+from matter_server.common.errors import ERROR_MAP, NodeNotExists
 
 from ..common.helpers.util import (
-    convert_hex_string,
+    convert_ip_address,
     convert_mac_address,
-    create_attribute_path_from_attribute,
     dataclass_from_dict,
     dataclass_to_dict,
 )
@@ -50,7 +49,7 @@ if TYPE_CHECKING:
 
 SUB_WILDCARD: Final = "*"
 
-# pylint: disable=too-many-public-methods
+# pylint: disable=too-many-public-methods,too-many-locals,too-many-branches
 
 
 class MatterClient:
@@ -206,17 +205,6 @@ class MatterClient:
         """
 
         node = self.get_node(node_id)
-        if node.available:
-            # try to refresh the OperationalCredentials.Fabric attribute
-            # so we have the most accurate information
-            attr_path = create_attribute_path_from_attribute(
-                0, Clusters.OperationalCredentials.Attributes.Fabrics
-            )
-            try:
-                await self.refresh_attribute(node_id, attr_path)
-            except MatterError as err:
-                self.logger.exception(err)
-
         fabrics: list[
             Clusters.OperationalCredentials.Structs.FabricDescriptorStruct
         ] = node.get_attribute_value(
@@ -260,16 +248,18 @@ class MatterClient:
     async def node_diagnostics(self, node_id: int) -> NodeDiagnostics:
         """Gather diagnostics for the given node."""
         node = self.get_node(node_id)
-        # ping the node (will also refresh NetworkInterfaces data)
-        ping_result = await self.ping_node(node_id)
         # grab some details from the first (operational) network interface
         network_type = NetworkType.UNKNOWN
         mac_address = None
         attribute = Clusters.GeneralDiagnostics.Attributes.NetworkInterfaces
         network_interface: Clusters.GeneralDiagnostics.Structs.NetworkInterface
+        ip_addresses: list[str] = []
         for network_interface in node.get_attribute_value(
             0, cluster=None, attribute=attribute
         ):
+            # ignore invalid/non-operational interfaces
+            if not network_interface.isOperational:
+                continue
             # ignore invalid/non-operational interfaces
             if not network_interface.isOperational:
                 continue
@@ -292,38 +282,44 @@ class MatterClient:
                 # unknown interface: ignore
                 continue
             mac_address = convert_mac_address(network_interface.hardwareAddress)
+            # enumerate ipv4 and ipv6 addresses
+            for ipv4_address_hex in network_interface.IPv4Addresses:
+                ipv4_address = convert_ip_address(ipv4_address_hex)
+                ip_addresses.append(ipv4_address)
+            for ipv6_address_hex in network_interface.IPv6Addresses:
+                ipv6_address = convert_ip_address(ipv6_address_hex, True)
+                ip_addresses.append(ipv6_address)
             break
         # get thread/wifi specific info
         node_type = NodeType.UNKNOWN
         network_name = None
         if network_type == NetworkType.THREAD:
-            cluster: Clusters.ThreadNetworkDiagnostics = node.get_cluster(
+            thread_cluster: Clusters.ThreadNetworkDiagnostics = node.get_cluster(
                 0, Clusters.ThreadNetworkDiagnostics
             )
-            network_name = convert_hex_string(cluster.networkName)
+            network_name = thread_cluster.networkName
             # parse routing role to (diagnostics) node type
             if (
-                cluster.routingRole
+                thread_cluster.routingRole
                 == Clusters.ThreadNetworkDiagnostics.Enums.RoutingRoleEnum.kSleepyEndDevice
             ):
                 node_type = NodeType.SLEEPY_END_DEVICE
-            if cluster.routingRole in (
+            if thread_cluster.routingRole in (
                 Clusters.ThreadNetworkDiagnostics.Enums.RoutingRoleEnum.kLeader,
                 Clusters.ThreadNetworkDiagnostics.Enums.RoutingRoleEnum.kRouter,
             ):
                 node_type = NodeType.ROUTING_END_DEVICE
             elif (
-                cluster.routingRole
+                thread_cluster.routingRole
                 == Clusters.ThreadNetworkDiagnostics.Enums.RoutingRoleEnum.kEndDevice
             ):
                 node_type = NodeType.END_DEVICE
         elif network_type == NetworkType.WIFI:
-            attr_value: bytes = node.get_attribute_value(
-                0,
-                cluster=None,
-                attribute=Clusters.WiFiNetworkDiagnostics.Attributes.Bssid,
+            wifi_cluster: Clusters.WiFiNetworkDiagnostics = node.get_cluster(
+                0, Clusters.WiFiNetworkDiagnostics
             )
-            network_name = convert_hex_string(attr_value)
+            if wifi_cluster and wifi_cluster.bssid:
+                network_name = wifi_cluster.bssid
             node_type = NodeType.END_DEVICE
         # override node type if node is a bridge
         if node.node_data.is_bridge:
@@ -335,9 +331,9 @@ class MatterClient:
             network_type=network_type,
             node_type=node_type,
             network_name=network_name,
-            ip_adresses=list(ping_result),
+            ip_adresses=ip_addresses,
             mac_address=mac_address,
-            reachable=any(ping_result.values()),
+            available=node.available,
             active_fabrics=active_fabrics,
         )
 

--- a/matter_server/client/models/node.py
+++ b/matter_server/client/models/node.py
@@ -400,5 +400,5 @@ class NodeDiagnostics:
     network_name: str | None  # WiFi SSID or Thread network name
     ip_adresses: list[str]
     mac_address: str | None
-    reachable: bool
+    available: bool
     active_fabrics: list[MatterFabricData]

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -66,7 +66,7 @@ ROUTING_ROLE_ATTRIBUTE_PATH = create_attribute_path_from_attribute(
     0, Clusters.ThreadNetworkDiagnostics.Attributes.RoutingRole
 )
 
-BASE_SUBSCRIBE_ATTRIBUTES: tuple[Attribute.AttributePath, Attribute.AttributePath] = (
+BASE_SUBSCRIBE_ATTRIBUTES: tuple[Attribute.AttributePath, ...] = (
     # all endpoints, BasicInformation cluster
     Attribute.AttributePath(
         EndpointId=None, ClusterId=Clusters.BasicInformation.id, Attribute=None
@@ -76,6 +76,15 @@ BASE_SUBSCRIBE_ATTRIBUTES: tuple[Attribute.AttributePath, Attribute.AttributePat
         EndpointId=None,
         ClusterId=Clusters.BridgedDeviceBasicInformation.id,
         Attribute=None,
+    ),
+    # networkinterfaces attribute on general diagnostics cluster,
+    # so we have the most accurate IP addresses for ping/diagnostics
+    Attribute.AttributePath(
+        EndpointId=0, Attribute=Clusters.GeneralDiagnostics.Attributes.NetworkInterfaces
+    ),
+    # active fabrics attribute - to speedup node diagnostics
+    Attribute.AttributePath(
+        EndpointId=0, Attribute=Clusters.OperationalCredentials.Attributes.Fabrics
     ),
 )
 
@@ -680,6 +689,7 @@ class MatterDeviceController:
             raise NodeNotExists(
                 f"Node {node_id} does not exist or is not yet interviewed"
             )
+
         if node.available:
             # try to refresh the GeneralDiagnostics.NetworkInterface attribute
             # so we have the most accurate information before pinging

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -690,14 +690,6 @@ class MatterDeviceController:
                 f"Node {node_id} does not exist or is not yet interviewed"
             )
 
-        if node.available:
-            # try to refresh the GeneralDiagnostics.NetworkInterface attribute
-            # so we have the most accurate information before pinging
-            try:
-                await self.read_attribute(node_id, attr_path)
-            except (NodeNotResolving, ChipStackError) as err:
-                LOGGER.exception(err)
-
         battery_powered = (
             node.attributes.get(ROUTING_ROLE_ATTRIBUTE_PATH, 0)
             == Clusters.ThreadNetworkDiagnostics.Enums.RoutingRoleEnum.kSleepyEndDevice


### PR DESCRIPTION
After playing a bit with the diagnostics fetching while implementing it in the frontend, I quickly came to the conclusion that it was not working as intended, especially the retrieval of the values and ping slows it down badly, especially for thread devices. So some changes;

- Add IP addresses and fabrics to watched attributes (so we do not have to fetch them)
- Remove ping from diagnostics 
- Use available bool on diagnostics model
- no duplicate conversion needed for network name