### PR TITLE
Use our own global models for CommissionableNodeData and Commissionin…

### DIFF
--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -22,6 +22,7 @@ from ..common.helpers.util import (
 from ..common.models import (
     APICommand,
     CommandMessage,
+    CommissionableNodeData,
     CommissioningParameters,
     ErrorResultMessage,
     EventMessage,
@@ -197,6 +198,15 @@ class MatterClient:
                 discriminator=discriminator,
             ),
         )
+
+    async def discover_commissionable_nodes(
+        self,
+    ) -> list[CommissionableNodeData]:
+        """Discover Commissionable Nodes (discovered on BLE or mDNS)."""
+        return [
+            dataclass_from_dict(CommissionableNodeData, x)
+            for x in await self.send_command(APICommand.DISCOVER, require_schema=7)
+        ]
 
     async def get_matter_fabrics(self, node_id: int) -> list[MatterFabricData]:
         """

--- a/matter_server/common/const.py
+++ b/matter_server/common/const.py
@@ -2,4 +2,4 @@
 
 # schema version is used to determine compatibility between server and client
 # bump schema if we add new features and/or make other (breaking) changes
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7

--- a/matter_server/common/models.py
+++ b/matter_server/common/models.py
@@ -175,13 +175,31 @@ MessageType = (
 
 
 @dataclass
+class CommissionableNodeData:
+    """Object that is returned on the 'discover_commissionable_nodes' command."""
+
+    instance_name: str | None = None
+    host_name: str | None = None
+    port: int | None = None
+    long_discriminator: int | None = None
+    vendor_id: int | None = None
+    product_id: int | None = None
+    commissioning_mode: int | None = None
+    device_type: int | None = None
+    device_name: str | None = None
+    pairing_instruction: str | None = None
+    pairing_hint: int | None = None
+    mrp_retry_interval_idle: int | None = None
+    mrp_retry_interval_active: int | None = None
+    supports_tcp: bool | None = None
+    addresses: list[str] | None = None
+    rotating_id: str | None = None
+
+
+@dataclass
 class CommissioningParameters:
-    """
-    Object that is returned on the 'open_commisisoning_window' command.
+    """Object that is returned on the 'open_commisisoning_window' command."""
 
-    NOTE: This is just a copy of the dataclass specified in chip.ChipDeviceCtrl
-    """
-
-    setupPinCode: int  # pylint: disable=invalid-name
-    setupManualCode: str  # pylint: disable=invalid-name
-    setupQRCode: str  # pylint: disable=invalid-name
+    setup_pin_code: int
+    setup_manual_code: str
+    setup_qr_code: str

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -407,7 +407,7 @@ class MatterDeviceController:
     @api_command(APICommand.DISCOVER)
     async def discover_commissionable_nodes(
         self,
-    ) -> list[CommissionableNodeData] | None:
+    ) -> list[CommissionableNodeData]:
         """Discover Commissionable Nodes (discovered on BLE or mDNS)."""
         if self.chip_controller is None:
             raise RuntimeError("Device Controller not initialized.")


### PR DESCRIPTION
Use our own global models for CommissionableNodeData and CommissioningParameters instead of the (non camelcase) ones from the SDK

These were not yet used so this is not a breaking change but I've bumped the schema anyways.