### PR TITLE
Shutdown Certificate Authority Manager before the stack

### DIFF
--- a/matter_server/server/stack.py
+++ b/matter_server/server/stack.py
@@ -70,4 +70,5 @@ class MatterStack:
         """Stop/Shutdown Matter Stack."""
         self.logger.info("Shutting down the Matter stack...")
         # NOTE that this will abruptly end the python process!
+        self.certificate_authority_manager.Shutdown()
         self._chip_stack.Shutdown()


### PR DESCRIPTION
When shutting down the Certificate Authority Manager, the underlying code needs the chip stack to properly free up all resources. Manually shutdown the Certificate Authority Manager to avoid exception later during shutdown.

This avoids stack traces as follows:
```
Exception ignored in: <function CertificateAuthorityManager.__del__ at 0x7d523bd51260>
Traceback (most recent call last):
  File "/home/sag/projects/project-chip/python-matter-server/venv/lib/python3.11/site-packages/chip/CertificateAuthority.py", line 306, in __del__
    self.Shutdown()
  File "/home/sag/projects/project-chip/python-matter-server/venv/lib/python3.11/site-packages/chip/CertificateAuthority.py", line 296, in Shutdown
    ca.Shutdown()
  File "/home/sag/projects/project-chip/python-matter-server/venv/lib/python3.11/site-packages/chip/CertificateAuthority.py", line 163, in Shutdown
    self._chipStack.Call(
  File "/home/sag/projects/project-chip/python-matter-server/venv/lib/python3.11/site-packages/chip/ChipStack.py", line 362, in Call
    self.completeEvent.clear()
    ^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'clear'
```