### PR TITLE
Fix for removal of orphaned node

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -642,7 +642,9 @@ class MatterDeviceController:
             0,
             Clusters.OperationalCredentials.Attributes.CurrentFabricIndex,
         )
-        fabric_index = node.attributes[attribute_path]
+        fabric_index = node.attributes.get(attribute_path)
+        if fabric_index is None:
+            return
         result: Clusters.OperationalCredentials.Commands.NOCResponse | None = None
         try:
             result = await self.chip_controller.SendCommand(


### PR DESCRIPTION
Handles bit of an edge case but still....
Allows removing of a node for which we have no attribute data at all.