### PR TITLE
Prevent duplicate interviews

### DIFF
--- a/matter_server/common/helpers/util.py
+++ b/matter_server/common/helpers/util.py
@@ -1,4 +1,5 @@
 """Utils for Matter server (and client)."""
+
 from __future__ import annotations
 
 import base64
@@ -257,6 +258,7 @@ def dataclass_from_dict(cls: type[_T], dict_obj: dict, strict: bool = False) -> 
                 dict_obj.get(field.name),
                 type_hints[field.name],
                 field.default,
+                allow_none=not strict,
             )
             for field in dc_fields
             if field.init


### PR DESCRIPTION
Always try to instantiate a MatterNodeData object from the cache info and if that fails, fallback to a default object.
Let the interview logic sort out if a re interview is really needed