### PR TITLE
Fix for leading zero mismatch in fabric check

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -1168,7 +1168,7 @@ class MatterDeviceController:
             return
         if service_type == MDNS_TYPE_OPERATIONAL_NODE:
             name = name.lower()
-            if not name.startswith(self.fabric_id_hex):
+            if self.fabric_id_hex not in name:
                 # filter out messages that are not for our fabric
                 return
             LOGGER.debug("Received %s MDNS event for %s", state_change, name)


### PR DESCRIPTION
Kind of a stupid mistake... The fabric hex can start with a leading zero