### PR TITLE
Filter Matter SDK logging in SDK

### DIFF
--- a/matter_server/server/__main__.py
+++ b/matter_server/server/__main__.py
@@ -83,6 +83,7 @@ parser.add_argument(
 
 args = parser.parse_args()
 
+
 def _setup_logging() -> None:
     custom_level_style = {
         **coloredlogs.DEFAULT_LEVEL_STYLES,

--- a/matter_server/server/__main__.py
+++ b/matter_server/server/__main__.py
@@ -5,8 +5,10 @@ import logging
 import os
 from pathlib import Path
 
-from aiorun import run
 import coloredlogs
+from aiorun import run
+
+from matter_server.server import stack
 
 from .server import MatterServer
 
@@ -58,8 +60,13 @@ parser.add_argument(
     "--log-level",
     type=str,
     default="info",
-    # pylint: disable=line-too-long
-    help="Provide logging level. Example --log-level debug, default=info, possible=(critical, error, warning, info, debug)",
+    help="Global logging level. Example --log-level debug, default=info, possible=(critical, error, warning, info, debug)",
+)
+parser.add_argument(
+    "--log-level-sdk",
+    type=str,
+    default="error",
+    help="Matter SDK logging level. Example --log-level-sdk detail, default=error, possible=(none, error, progress, detail, automation)",
 )
 parser.add_argument(
     "--log-file",
@@ -76,23 +83,38 @@ parser.add_argument(
 
 args = parser.parse_args()
 
+def _setup_logging() -> None:
+    custom_level_style = {
+        **coloredlogs.DEFAULT_LEVEL_STYLES,
+        "chip_automation": {"color": "green", "faint": True},
+        "chip_detail": {"color": "green", "faint": True},
+        "chip_progress": {},
+        "chip_error": {"color": "red"},
+    }
+    # Let coloredlogs handle all levels, we filter levels in the logging module
+    coloredlogs.install(level=logging.NOTSET, level_styles=custom_level_style)
 
-def main() -> None:
-    """Run main execution."""
-    # configure logging
     handlers = None
     if args.log_file:
         handlers = [logging.FileHandler(args.log_file)]
     logging.basicConfig(handlers=handlers, level=args.log_level.upper())
-    coloredlogs.install(level=args.log_level.upper())
+
+    stack.init_logging(args.log_level_sdk.upper())
+    logging.getLogger().setLevel(args.log_level.upper())
+
     if not logging.getLogger().isEnabledFor(logging.DEBUG):
-        logging.getLogger("chip").setLevel(logging.WARNING)
         logging.getLogger("PersistentStorage").setLevel(logging.WARNING)
         # Temporary disable the logger of chip.clusters.Attribute because it now logs
         # an error on every custom attribute that couldn't be parsed which confuses people.
         # We can restore the default log level again when we've patched the device controller
         # to handle the raw attribute data to deal with custom clusters.
         logging.getLogger("chip.clusters.Attribute").setLevel(logging.CRITICAL)
+
+
+def main() -> None:
+    """Run main execution."""
+
+    _setup_logging()
 
     # make sure storage path exists
     if not os.path.isdir(args.storage_path):

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -9,7 +9,8 @@ import logging
 from collections import deque
 from datetime import datetime
 from functools import partial
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Iterable, TypeVar, cast
+from typing import (TYPE_CHECKING, Any, Awaitable, Callable, Iterable, TypeVar,
+                    cast)
 
 from chip.ChipDeviceCtrl import DeviceProxyWrapper
 from chip.clusters import Attribute
@@ -18,35 +19,24 @@ from chip.clusters.Attribute import ValueDecodeFailure
 from chip.clusters.ClusterObjects import ALL_ATTRIBUTES, ALL_CLUSTERS, Cluster
 from chip.exceptions import ChipStackError
 from zeroconf import IPVersion, ServiceStateChange, Zeroconf
-from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo, AsyncZeroconf
+from zeroconf.asyncio import (AsyncServiceBrowser, AsyncServiceInfo,
+                              AsyncZeroconf)
 
 from matter_server.common.helpers.util import convert_ip_address
-from matter_server.common.models import CommissionableNodeData, CommissioningParameters
-from matter_server.server.helpers.attributes import parse_attributes_from_read_result
+from matter_server.common.models import (CommissionableNodeData,
+                                         CommissioningParameters)
+from matter_server.server.helpers.attributes import \
+    parse_attributes_from_read_result
 from matter_server.server.helpers.utils import ping_ip
 
-from ..common.errors import (
-    NodeCommissionFailed,
-    NodeInterviewFailed,
-    NodeNotExists,
-    NodeNotReady,
-    NodeNotResolving,
-)
+from ..common.errors import (NodeCommissionFailed, NodeInterviewFailed,
+                             NodeNotExists, NodeNotReady, NodeNotResolving)
 from ..common.helpers.api import api_command
-from ..common.helpers.util import (
-    create_attribute_path_from_attribute,
-    dataclass_from_dict,
-    dataclass_to_dict,
-    parse_attribute_path,
-    parse_value,
-)
-from ..common.models import (
-    APICommand,
-    EventType,
-    MatterNodeData,
-    MatterNodeEvent,
-    NodePingResult,
-)
+from ..common.helpers.util import (create_attribute_path_from_attribute,
+                                   dataclass_from_dict, dataclass_to_dict,
+                                   parse_attribute_path, parse_value)
+from ..common.models import (APICommand, EventType, MatterNodeData,
+                             MatterNodeEvent, NodePingResult)
 from .const import DATA_MODEL_SCHEMA_VERSION, PAA_ROOT_CERTS_DIR
 from .helpers.paa_certificates import fetch_certificates
 

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -9,8 +9,7 @@ import logging
 from collections import deque
 from datetime import datetime
 from functools import partial
-from typing import (TYPE_CHECKING, Any, Awaitable, Callable, Iterable, TypeVar,
-                    cast)
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Iterable, TypeVar, cast
 
 from chip.ChipDeviceCtrl import DeviceProxyWrapper
 from chip.clusters import Attribute
@@ -19,24 +18,35 @@ from chip.clusters.Attribute import ValueDecodeFailure
 from chip.clusters.ClusterObjects import ALL_ATTRIBUTES, ALL_CLUSTERS, Cluster
 from chip.exceptions import ChipStackError
 from zeroconf import IPVersion, ServiceStateChange, Zeroconf
-from zeroconf.asyncio import (AsyncServiceBrowser, AsyncServiceInfo,
-                              AsyncZeroconf)
+from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo, AsyncZeroconf
 
 from matter_server.common.helpers.util import convert_ip_address
-from matter_server.common.models import (CommissionableNodeData,
-                                         CommissioningParameters)
-from matter_server.server.helpers.attributes import \
-    parse_attributes_from_read_result
+from matter_server.common.models import CommissionableNodeData, CommissioningParameters
+from matter_server.server.helpers.attributes import parse_attributes_from_read_result
 from matter_server.server.helpers.utils import ping_ip
 
-from ..common.errors import (NodeCommissionFailed, NodeInterviewFailed,
-                             NodeNotExists, NodeNotReady, NodeNotResolving)
+from ..common.errors import (
+    NodeCommissionFailed,
+    NodeInterviewFailed,
+    NodeNotExists,
+    NodeNotReady,
+    NodeNotResolving,
+)
 from ..common.helpers.api import api_command
-from ..common.helpers.util import (create_attribute_path_from_attribute,
-                                   dataclass_from_dict, dataclass_to_dict,
-                                   parse_attribute_path, parse_value)
-from ..common.models import (APICommand, EventType, MatterNodeData,
-                             MatterNodeEvent, NodePingResult)
+from ..common.helpers.util import (
+    create_attribute_path_from_attribute,
+    dataclass_from_dict,
+    dataclass_to_dict,
+    parse_attribute_path,
+    parse_value,
+)
+from ..common.models import (
+    APICommand,
+    EventType,
+    MatterNodeData,
+    MatterNodeEvent,
+    NodePingResult,
+)
 from .const import DATA_MODEL_SCHEMA_VERSION, PAA_ROOT_CERTS_DIR
 from .helpers.paa_certificates import fetch_certificates
 

--- a/matter_server/server/stack.py
+++ b/matter_server/server/stack.py
@@ -7,8 +7,12 @@ from typing import TYPE_CHECKING
 import chip.logging
 import chip.native
 from chip.ChipStack import ChipStack
-from chip.logging import (ERROR_CATEGORY_DETAIL, ERROR_CATEGORY_ERROR,
-                          ERROR_CATEGORY_NONE, ERROR_CATEGORY_PROGRESS)
+from chip.logging import (
+    ERROR_CATEGORY_DETAIL,
+    ERROR_CATEGORY_ERROR,
+    ERROR_CATEGORY_NONE,
+    ERROR_CATEGORY_PROGRESS,
+)
 from chip.logging.library_handle import _GetLoggingLibraryHandle
 from chip.logging.types import LogRedirectCallback_t
 
@@ -24,12 +28,15 @@ CHIP_PROGRESS = logging.INFO - 1
 CHIP_DETAIL = logging.DEBUG - 1
 CHIP_AUTOMATION = logging.DEBUG - 2
 
-@LogRedirectCallback_t
-def _redirect_to_python_logging(category, module, message) -> None:
-    module = module.decode("utf-8")
-    message = message.decode("utf-8")
 
-    logger = logging.getLogger("chip.native.%s" % module)
+@LogRedirectCallback_t  # type: ignore[misc]
+def _redirect_to_python_logging(
+    category: int, raw_module: bytes, raw_message: bytes
+) -> None:
+    module = raw_module.decode("utf-8")
+    message = raw_message.decode("utf-8")
+
+    logger = logging.getLogger(f"chip.native.{module}")
 
     # All logs are expected to have some reasonable category. This treats
     # unknown/None as critical.
@@ -41,13 +48,13 @@ def _redirect_to_python_logging(category, module, message) -> None:
         level = CHIP_PROGRESS
     elif category == ERROR_CATEGORY_DETAIL:
         level = CHIP_DETAIL
-    elif category == 4: # TODO: Add automation level to upstream Python bindings
+    elif category == 4:  # TODO: Add automation level to upstream Python bindings
         level = CHIP_AUTOMATION
 
     logger.log(level, "%s", message)
 
 
-def init_logging(category: str):
+def init_logging(category: str) -> None:
     """Initialize Matter SDK logging. Filter by category."""
 
     _LOGGER.info("Initializing CHIP/Matter Logging...")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   "coloredlogs",
   "dacite",
   "orjson",
-  "home-assistant-chip-clusters==2024.1.0",
+  "home-assistant-chip-clusters==2024.2.0",
 ]
 description = "Python Matter WebSocket Server"
 license = {text = "Apache-2.0"}
@@ -34,7 +34,7 @@ version = "0.0.0"
 
 [project.optional-dependencies]
 server = [
-  "home-assistant-chip-core==2024.1.0",
+  "home-assistant-chip-core==2024.2.0",
   "cryptography==42.0.2",
   "zeroconf==0.131.0",
 ]


### PR DESCRIPTION
Use the Matter SDK's log filtering capability. This avoids unnecessary calls into the Python library. Also introduce custom Python logging levels for the SDK log entries to make them distinct. This helps to easier spot SDK messages and match them to the log category semantics used in the SDK.

Note that there are two log entries shown on stdout right when initializing the logging, specifically:
```
[1708008135.838346][77288:77288] CHIP:CTL: Setting attestation nonce to random value
[1708008135.838417][77288:77288] CHIP:CTL: Setting CSR nonce to random value
```

These are messages which are printed when the native library gets loaded the first time (constructors of globals). We can't install the Python redirect. So these messages are printed using the native libraries default logger, which prints directly to stdout.

This needs CHIP wheels 2024.2.0.