### PR TITLE
Fix Nullable values in write attributes procedure

### DIFF
--- a/matter_server/common/helpers/util.py
+++ b/matter_server/common/helpers/util.py
@@ -3,17 +3,16 @@
 from __future__ import annotations
 
 import base64
-import binascii
-import logging
-import platform
-import socket
 from base64 import b64decode
+import binascii
 from dataclasses import MISSING, asdict, fields, is_dataclass
 from datetime import datetime
 from enum import Enum
 from functools import cache
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as pkg_version
+from importlib.metadata import PackageNotFoundError, version as pkg_version
+import logging
+import platform
+import socket
 from types import NoneType, UnionType
 from typing import (
     TYPE_CHECKING,

--- a/matter_server/common/helpers/util.py
+++ b/matter_server/common/helpers/util.py
@@ -3,16 +3,17 @@
 from __future__ import annotations
 
 import base64
-from base64 import b64decode
 import binascii
+import logging
+import platform
+import socket
+from base64 import b64decode
 from dataclasses import MISSING, asdict, fields, is_dataclass
 from datetime import datetime
 from enum import Enum
 from functools import cache
-from importlib.metadata import PackageNotFoundError, version as pkg_version
-import logging
-import platform
-import socket
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as pkg_version
 from types import NoneType, UnionType
 from typing import (
     TYPE_CHECKING,
@@ -108,8 +109,13 @@ def parse_value(
     value_type: Any,
     default: Any = MISSING,
     allow_none: bool = True,
+    allow_sdk_types: bool = False,
 ) -> Any:
-    """Try to parse a value from raw (json) data and type annotations."""
+    """
+    Try to parse a value from raw (json) data and type annotations.
+
+    If allow_sdk_types is False, any SDK specific custom data types will be converted.
+    """
     # pylint: disable=too-many-return-statements,too-many-branches
 
     if isinstance(value_type, str):
@@ -131,9 +137,9 @@ def parse_value(
         return default
     if value is None and value_type is NoneType:
         return None
-    if value is None and allow_none:
-        return None
     if value is None and value_type is Nullable:
+        return Nullable() if allow_sdk_types else None
+    if value is None and allow_none:
         return None
     if is_dataclass(value_type) and isinstance(value, dict):
         return dataclass_from_dict(value_type, value)
@@ -220,12 +226,12 @@ def parse_value(
     if value_type is uint and (
         isinstance(value, int) or (isinstance(value, str) and value.isnumeric())
     ):
-        return uint(value)
+        return uint(value) if allow_sdk_types else int(value)
     if value_type is float32 and (
         isinstance(value, (float, int))
         or (isinstance(value, str) and value.isnumeric())
     ):
-        return float32(value)
+        return float32(value) if allow_sdk_types else float(value)
 
     # If we reach this point, we could not match the value with the type and we raise
     if not isinstance(value, value_type):
@@ -236,7 +242,9 @@ def parse_value(
     return value
 
 
-def dataclass_from_dict(cls: type[_T], dict_obj: dict, strict: bool = False) -> _T:
+def dataclass_from_dict(
+    cls: type[_T], dict_obj: dict, strict: bool = False, allow_sdk_types: bool = False
+) -> _T:
     """
     Create (instance of) a dataclass by providing a dict with values.
 
@@ -259,6 +267,7 @@ def dataclass_from_dict(cls: type[_T], dict_obj: dict, strict: bool = False) -> 
                 type_hints[field.name],
                 field.default,
                 allow_none=not strict,
+                allow_sdk_types=allow_sdk_types,
             )
             for field in dc_fields
             if field.init

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -37,6 +37,7 @@ from ..common.helpers.util import (
     dataclass_from_dict,
     dataclass_to_dict,
     parse_attribute_path,
+    parse_value,
 )
 from ..common.models import (
     APICommand,

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -556,7 +556,7 @@ class MatterDeviceController:
             raise NodeNotReady(f"Node {node_id} is not (yet) available.")
         cluster_cls: Cluster = ALL_CLUSTERS[cluster_id]
         command_cls = getattr(cluster_cls.Commands, command_name)
-        command = dataclass_from_dict(command_cls, payload)
+        command = dataclass_from_dict(command_cls, payload, allow_sdk_types=True)
         node_lock = self._get_node_lock(node_id)
         async with node_lock:
             return await self.chip_controller.SendCommand(

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -22,7 +22,7 @@ from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo, AsyncZerocon
 
 from matter_server.common.helpers.util import convert_ip_address
 from matter_server.common.models import CommissionableNodeData, CommissioningParameters
-from matter_server.server.helpers.attributes import parse_attributes_from_read_result, parse_nullable_for_write
+from matter_server.server.helpers.attributes import parse_attributes_from_read_result
 from matter_server.server.helpers.utils import ping_ip
 
 from ..common.errors import (
@@ -619,8 +619,16 @@ class MatterDeviceController:
         if (node := self._nodes.get(node_id)) is None or not node.available:
             raise NodeNotReady(f"Node {node_id} is not (yet) available.")
         endpoint_id, cluster_id, attribute_id = parse_attribute_path(attribute_path)
-        attribute = ALL_ATTRIBUTES[cluster_id][attribute_id]()
-        attribute.value = parse_nullable_for_write(value)
+        attribute = cast(
+            Clusters.ClusterAttributeDescriptor,
+            ALL_ATTRIBUTES[cluster_id][attribute_id](),
+        )
+        attribute.value = parse_value(
+            name=attribute.__qualname__,
+            value=value,
+            value_type=attribute.attribute_type.Type,
+            allow_sdk_types=True,
+        )
         return await self.chip_controller.WriteAttribute(
             nodeid=node_id,
             attributes=[(endpoint_id, attribute)],
@@ -1256,4 +1264,3 @@ class MatterDeviceController:
         node.available = False
         self.server.signal_event(EventType.NODE_UPDATED, node)
         LOGGER.info("Marked node %s as offline", node_id)
-

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -598,7 +598,7 @@ class MatterDeviceController:
             ALL_ATTRIBUTES[cluster_id][attribute_id](),
         )
         attribute.value = parse_value(
-            name=attribute.__qualname__,
+            name=attribute_path,
             value=value,
             value_type=attribute.attribute_type.Type,
             allow_sdk_types=True,

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -22,7 +22,7 @@ from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo, AsyncZerocon
 
 from matter_server.common.helpers.util import convert_ip_address
 from matter_server.common.models import CommissionableNodeData, CommissioningParameters
-from matter_server.server.helpers.attributes import parse_attributes_from_read_result
+from matter_server.server.helpers.attributes import parse_attributes_from_read_result, parse_nullable_for_write
 from matter_server.server.helpers.utils import ping_ip
 
 from ..common.errors import (
@@ -620,7 +620,7 @@ class MatterDeviceController:
             raise NodeNotReady(f"Node {node_id} is not (yet) available.")
         endpoint_id, cluster_id, attribute_id = parse_attribute_path(attribute_path)
         attribute = ALL_ATTRIBUTES[cluster_id][attribute_id]()
-        attribute.value = Clusters.NullValue if value is None else value
+        attribute.value = parse_nullable_for_write(value)
         return await self.chip_controller.WriteAttribute(
             nodeid=node_id,
             attributes=[(endpoint_id, attribute)],
@@ -1256,3 +1256,4 @@ class MatterDeviceController:
         node.available = False
         self.server.signal_event(EventType.NODE_UPDATED, node)
         LOGGER.info("Marked node %s as offline", node_id)
+

--- a/matter_server/server/helpers/attributes.py
+++ b/matter_server/server/helpers/attributes.py
@@ -1,8 +1,6 @@
 """Helpers to manage Cluster attributes."""
 
 from typing import Any
-from copy import deepcopy
-from chip.clusters import Objects as Clusters
 
 from ...common.helpers.util import create_attribute_path
 
@@ -25,18 +23,3 @@ def parse_attributes_from_read_result(
                 )
                 result[attribute_path] = attr_value
     return result
-
-def parse_nullable_for_write(payload):
-    """Parses the Python 'None' values to CHIP 'Nullable' type for writing attribute."""
-    outload = deepcopy(payload)
-
-    if isinstance(outload, dict):
-        for k, v in outload.items():
-            outload[k] = parse_nullable_for_write(outload[k])
-    elif isinstance(outload, list):
-        for i in range(0, len(outload)):
-            outload[i] = parse_nullable_for_write(outload[i])
-    else:
-        outload = Clusters.NullValue if outload is None else outload
-
-    return outload

--- a/matter_server/server/helpers/attributes.py
+++ b/matter_server/server/helpers/attributes.py
@@ -1,6 +1,8 @@
 """Helpers to manage Cluster attributes."""
 
 from typing import Any
+from copy import deepcopy
+from chip.clusters import Objects as Clusters
 
 from ...common.helpers.util import create_attribute_path
 
@@ -23,3 +25,18 @@ def parse_attributes_from_read_result(
                 )
                 result[attribute_path] = attr_value
     return result
+
+def parse_nullable_for_write(payload):
+    """Parses the Python 'None' values to CHIP 'Nullable' type for writing attribute."""
+    outload = deepcopy(payload)
+
+    if isinstance(outload, dict):
+        for k, v in outload.items():
+            outload[k] = parse_nullable_for_write(outload[k])
+    elif isinstance(outload, list):
+        for i in range(0, len(outload)):
+            outload[i] = parse_nullable_for_write(outload[i])
+    else:
+        outload = Clusters.NullValue if outload is None else outload
+
+    return outload


### PR DESCRIPTION
Writing attributes values with JSON data is allowed in Matter, for instance with the ACL cluster we can send this payload:
<details>
<summary>Expand</summary>

```
[
    {
        "fabricIndex":0,
        "privilege":5,
        "authMode":2,
        "subjects":[
            112233
        ],
        "targets":null
    },
    {
        "fabricIndex":0,
        "privilege":1,
        "authMode":2,
        "subjects":[
            4444,
            5555,
            6666
        ],
        "targets":null
    },
    {
        "fabricIndex":0,
        "privilege":3,
        "authMode":3,
        "subjects":[
            123,
            456
        ],
        "targets":[
            {
                "cluster":6,
                "endpoint":null,
                "deviceType":null
            },
            {
                "cluster":null,
                "endpoint":1,
                "deviceType":null
            },
            {
                "cluster":8,
                "endpoint":2,
                "deviceType":null
            }
        ]
    }
]
```

</details>

When Python parses this JSON, the `null` value is then converted to a Python `None`. This `None` is not allowed by the Matter SDK, at the opposite of the `Nullable` type which is defined in the SDK to handle this kind of situation.

This pull-request is there to fix this issue: the Python `None` is converted to a Matter `Null` value of type `Nullable`. 