### PR TITLE
A few small improvements to the linter config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,8 @@ ignore = [
   "FIX002", # Just annoying, not really useful
   "PLR2004", # Just annoying, not really useful
   "PD011", # Just annoying, not really useful
+  "TCH001", # Just annoying, not really useful
+  "TCH003", # Just annoying, not really useful
   "S101", # assert is often used to satisfy type checking
   "TD002", # Just annoying, not really useful
   "TD003", # Just annoying, not really useful

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,7 @@ ignore = [
   "D203", # Conflicts with other rules
   "D213", # Conflicts with other rules
   "D417", # False positives in some occasions
+  "EM102", # Just annoying, not really useful
   "FIX002", # Just annoying, not really useful
   "PLR2004", # Just annoying, not really useful
   "PD011", # Just annoying, not really useful


### PR DESCRIPTION
Address a few small improvements to the linter config, as discussed in #548

- Disable Ruff TCH001 and TCH003 (requirement to move imports into type checking block)
- Disable ruff rule EM102 (disallow f strings in log)