### PR TITLE
Delay marking a node as unavailable

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -980,8 +980,8 @@ class MatterDeviceController:
             )
             resubscription_attempt = self._last_subscription_attempt[node_id] + 1
             self._last_subscription_attempt[node_id] = resubscription_attempt
-            # mark node as unavailable and signal consumers
-            # we debounce it a bit so we only mark the node unavailable
+            # Mark node as unavailable and signal consumers.
+            # We debounce it a bit so we only mark the node unavailable
             # after some resubscription attempts and we shutdown the subscription
             # if the resubscription interval exceeds 30 minutes (TTL of mdns)
             # the node will be auto picked up by mdns if its alive again

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -983,8 +983,8 @@ class MatterDeviceController:
             # Mark node as unavailable and signal consumers.
             # We debounce it a bit so we only mark the node unavailable
             # after some resubscription attempts and we shutdown the subscription
-            # if the resubscription interval exceeds 30 minutes (TTL of mdns)
-            # the node will be auto picked up by mdns if its alive again
+            # if the resubscription interval exceeds 30 minutes (TTL of mdns).
+            # The node will be auto picked up by mdns if it's alive again.
             if (
                 node.available
                 and resubscription_attempt >= NODE_RESUBSCRIBE_ATTEMPTS_UNAVAILABLE


### PR DESCRIPTION
After our recent change with the proactive node detection using our own mdns discovery we also changed how/when we mark a node as unavailable/offline if its not responding. we lowered the treshold in favor of re-detecting it over mdns.

We however get multiple reports that people now see their nodes go unavailable a lot more often.
Now we can go argue that they should fix their networks/devices so they do not miss the subscription intervals but real world is that dropouts may happen and bad devices do exist ;-)

I have investigated other platforms like Apple Home and Google home and they're all a huge bit more forgiving than us, basically "hiding" the node unavailability for a while by debouncing it. This PR extends our tresholds as well to follow that pattern but it still logs these events so people are still aware that something is going on in their network (and hopefully fix it).

The outcome is that devices won't be marked unavailable in HA as fast as before, basically reproducing the behavior of other platforms.

