### PR TITLE
Delay building of the container after publishing to PyPi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,8 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
+      - name: Wait for PyPI
+        run: sleep 60
   build-and-push-container-image:
     name: Builds and pushes the Matter Server container to ghcr.io
     runs-on: ubuntu-latest


### PR DESCRIPTION
The release action fails 6 out of 10 times due to a race condition.
The new version is published to PyPI but then the container build action requires that same PyPI package and often fails to resolve it because its not yet visible in the indexer.

This puts a 1 minute sleep between the 2 actions to hopefully resolve this.