### PR TITLE
Skip push to main branch check in test workflow push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ name: Test
 
 on:
   push:
-    branches: [main]
+    branches: ["!main"]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ name: Test
 
 on:
   push:
-    branches: ["!main"]
+    branches: [main]
   pull_request:
     branches: [main]
 
@@ -29,7 +29,7 @@ jobs:
           pip install -e .[server]
           pip install -e .[test]
       - name: Lint/test with pre-commit
-        run: pre-commit run --all-files
+        run: SKIP=no-commit-to-branch pre-commit run --all-files
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Our test workflow should ignore the pre-commit action for push to main if running from CI (but still run locally)