### PR TITLE
Extend sleep in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
       - name: Wait for PyPI
-        run: sleep 60
+        run: sleep 120
   build-and-push-container-image:
     name: Builds and pushes the Matter Server container to ghcr.io
     runs-on: ubuntu-latest


### PR DESCRIPTION
Turns out 60 seconds was still too short, extended it to 120 seconds.
Let's see next time if it succeeds.