### PR TITLE
Change log level of deprecated subscribe attribute

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -671,7 +671,7 @@ class MatterDeviceController:
         The given attribute path(s) will be added to the list of attributes that
         are watched for the given node. This is persistent over restarts.
         """
-        LOGGER.warning(
+        LOGGER.debug(
             "The subscribe_attribute command has been deprecated and will be removed from"
             " a future version. You no longer need to call this to subscribe to attribute changes."
         )


### PR DESCRIPTION
Temporary change the log level of this deprecated command warning because otherwise people running HA will think something is wrong. Change it back once we released a HA version that is modified to no longer send this command.