### PR TITLE
A few small fixes to the share (open commissioning window) feature

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -414,7 +414,7 @@ class MatterDeviceController:
             return self._known_commissioning_params[node_id]
 
         if discriminator is None:
-            discriminator = randint(1000, 4096)  # noqa: S311
+            discriminator = randint(0, 4095)  # noqa: S311
 
         sdk_result = await self._call_sdk(
             self.chip_controller.OpenCommissioningWindow,

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -405,6 +405,9 @@ class MatterDeviceController:
         if self.chip_controller is None:
             raise RuntimeError("Device Controller not initialized.")
 
+        if (node := self._nodes.get(node_id)) is None or not node.available:
+            raise NodeNotReady(f"Node {node_id} is not (yet) available.")
+
         if node_id in self._known_commissioning_params:
             # node has already been put into commissioning mode,
             # return previous parameters

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -9,6 +9,7 @@ from collections import deque
 from datetime import datetime
 from functools import partial
 import logging
+from random import randint
 import time
 from typing import TYPE_CHECKING, Any, Callable, Iterable, TypeVar, cast
 
@@ -410,7 +411,7 @@ class MatterDeviceController:
             return self._known_commissioning_params[node_id]
 
         if discriminator is None:
-            discriminator = 3840  # TODO generate random one
+            discriminator = randint(1000, 4096)  # noqa: S311
 
         sdk_result = await self._call_sdk(
             self.chip_controller.OpenCommissioningWindow,


### PR DESCRIPTION
If a device has been put into commissioning mode and you issue the command again (e.g. by pressing the button in the HA interface) the device will throw a (rather cryptic) message because its already in commissioning mode.
Fix this by returning the previous parameters (and clear them once the timeout expires)

Closes https://github.com/home-assistant/core/issues/109936

Another improvement is creating a random discriminator instead of a hardcoded one.

Also, add a check if the node is actually available (so a case session is active) before attempting to open the commissioning window, which should prevent #558 
