### PR TITLE
Disable chip.native.DL logger for now

### DIFF
--- a/matter_server/server/__main__.py
+++ b/matter_server/server/__main__.py
@@ -1,4 +1,5 @@
 """Script entry point to run the Matter Server."""
+
 import argparse
 import asyncio
 import logging
@@ -110,6 +111,10 @@ def _setup_logging() -> None:
         # We can restore the default log level again when we've patched the device controller
         # to handle the raw attribute data to deal with custom clusters.
         logging.getLogger("chip.clusters.Attribute").setLevel(logging.CRITICAL)
+        # Temporary disable the logger of chip.native.DL because it now logs
+        # a whole list of errors when its trying to bind to internal interfaces on
+        # the HA supervisor set-up.
+        logging.getLogger("chip.native.DL").setLevel(logging.CRITICAL)
 
 
 def main() -> None:


### PR DESCRIPTION
Temporary disable the logger of chip.native.DL because it now logs a whole list of errors when its trying to bind to internal interfaces on the HA supervisor set-up.

```
2024-02-27 16:49:00 core-matter-server chip.native.DL[223] CHIP_ERROR MDNS failed to join multicast group on veth3cdf62f for address type IPv4: src/inet/UDPEndPointImplSockets.cpp:777: Inet Error 0x00000110: Address not found
2024-02-27 16:49:00 core-matter-server chip.native.DL[223] CHIP_ERROR MDNS failed to join multicast group on vethe5c361f for address type IPv4: src/inet/UDPEndPointImplSockets.cpp:777: Inet Error 0x00000110: Address not found
2024-02-27 16:49:00 core-matter-server chip.native.DL[223] CHIP_ERROR MDNS failed to join multicast group on vethc8dbc91 for address type IPv4: src/inet/UDPEndPointImplSockets.cpp:777: Inet Error 0x00000110: Address not found
2024-02-27 16:49:00 core-matter-server chip.native.DL[223] CHIP_ERROR MDNS failed to join multicast group on veth624a4d1 for address type IPv4: src/inet/UDPEndPointImplSockets.cpp:777: Inet Error 0x00000110: Address not found
2024-02-27 16:49:00 core-matter-server chip.native.DL[223] CHIP_ERROR MDNS failed to join multicast group on veth1ff504c for address type IPv4: src/inet/UDPEndPointImplSockets.cpp:777: Inet Error 0x00000110: Address not found
2024-02-27 16:49:00 core-matter-server chip.native.DL[223] CHIP_ERROR MDNS failed to join multicast group on vethdcab12e for address type IPv4: src/inet/UDPEndPointImplSockets.cpp:777: Inet Error 0x00000110: Address not found

```