### PR TITLE
Include (base) dashboard in the builtin-webserver

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ name: Publish releases
 on:
   release:
     types: [published]
+env:
+  PYTHON_VERSION: "3.10"
+  NODE_VERSION: "18.x"
 
 jobs:
   build-and-publish-pypi:
@@ -28,10 +31,14 @@ jobs:
               exit 1
             fi
           fi
-      - name: Set up Python 3.10
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@v5.0.0
         with:
-          python-version: "3.10"
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Set up Node ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
       - name: Install build
         run: >-
           pip install build tomli tomli-w
@@ -48,7 +55,13 @@ jobs:
 
           with open("pyproject.toml", "wb") as f:
             tomli_w.dump(pyproject, f)
-      - name: Build
+      - name: Build dashboard
+        run: |
+          cd dashboard
+          script/setup
+          script/build
+          cd ..
+      - name: Build python package
         run: >-
           python3 -m build
       - name: Publish release to PyPI
@@ -69,9 +82,9 @@ jobs:
       - name: Log in to the GitHub container registry
         uses: docker/login-action@v3.0.0
         with:
-            registry: ghcr.io
-            username: ${{ github.repository_owner }}
-            password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.1.0
       - name: Version number for tags
@@ -95,8 +108,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/python-matter-server:${{ steps.tags.outputs.major }},
             ghcr.io/${{ github.repository_owner }}/python-matter-server:stable
           push: true
-          build-args:
-            "PYTHON_MATTER_SERVER=${{ needs.build-and-publish-pypi.outputs.version }}"
+          build-args: "PYTHON_MATTER_SERVER=${{ needs.build-and-publish-pypi.outputs.version }}"
       - name: Build and Push pre-release
         uses: docker/build-push-action@v5.1.0
         if: github.event.release.prerelease == true
@@ -108,5 +120,4 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/python-matter-server:${{ steps.tags.outputs.patch }},
             ghcr.io/${{ github.repository_owner }}/python-matter-server:beta
           push: true
-          build-args:
-            "PYTHON_MATTER_SERVER=${{ needs.build-and-publish-pypi.outputs.version }}"
+          build-args: "PYTHON_MATTER_SERVER=${{ needs.build-and-publish-pypi.outputs.version }}"

--- a/dashboard/src/entrypoint/main.ts
+++ b/dashboard/src/entrypoint/main.ts
@@ -10,7 +10,7 @@ async function main() {
     // Turn httpX url into wsX url and append "/ws"
     url = "ws" + new URL("./ws", location.href).toString().substring(4);
   } else {
-    // dvelopment server, ask for url to matter server
+    // development server, ask for url to matter server
     let storageUrl = localStorage.getItem("matterURL");
     if (!storageUrl) {
       storageUrl = prompt(

--- a/dashboard/src/entrypoint/main.ts
+++ b/dashboard/src/entrypoint/main.ts
@@ -3,16 +3,19 @@ import { MatterClient } from "../client/client";
 async function main() {
   import("../pages/matter-dashboard-app");
 
-  // Turn httpX url into wsX url and append "/ws"
-  let url = "ws" + new URL("./ws", location.href).toString().substring(4);
-
-  // Inside Home Assistant ingress, we will not prompt for the URL
-  if (!location.pathname.endsWith("/ingress")) {
+  let url = "";
+  // Detect if we're running in the (production) webserver included in the matter server or not.
+  if (location.href.includes(":5580")) {
+    // production server running inside the matter server
+    // Turn httpX url into wsX url and append "/ws"
+    url = "ws" + new URL("./ws", location.href).toString().substring(4);
+  } else {
+    // dvelopment server, ask for url to matter server
     let storageUrl = localStorage.getItem("matterURL");
     if (!storageUrl) {
       storageUrl = prompt(
-        "Enter Matter URL",
-        "ws://homeassistant.local:5580/ws"
+        "Enter Websocket URL to a running Matter Server",
+        "ws://localhost:5580/ws"
       );
       if (!storageUrl) {
         alert("Unable to connect without URL");

--- a/dashboard/src/pages/matter-dashboard.ts
+++ b/dashboard/src/pages/matter-dashboard.ts
@@ -28,14 +28,19 @@ class MatterDashboard extends LitElement {
 
   render() {
     const nodes = this.nodeEntries(this.nodes);
+    const isProductionServer = location.href.includes(":5580")
 
     return html`
       <div class="header">
         <div>Python Matter Server</div>
         <div class="actions">
+        ${isProductionServer
+        ? ""
+        : html`
           <md-icon-button @click=${this._disconnect}>
             <ha-svg-icon .path=${mdiLogout}></ha-svg-icon>
           </md-icon-button>
+          `}
         </div>
       </div>
       <div class="container">
@@ -50,20 +55,20 @@ class MatterDashboard extends LitElement {
           </md-list-item>
           <md-divider></md-divider>
           ${nodes.map(([id, node]) => {
-            return html`
+          return html`
               <md-list-item type="link" href=${`#node/${node.node_id}`}>
                 <span slot="start">${node.node_id}</span>
                 <div slot="headline">
                   ${node.vendorName} ${node.productName}
                   ${node.available
-                    ? ""
-                    : html`<span class="status">OFFLINE</span>`}
+              ? ""
+              : html`<span class="status">OFFLINE</span>`}
                 </div>
                 <div slot="supporting-text">${node.serialNumber}</div>
                 <ha-svg-icon slot="end" .path=${mdiChevronRight}></ha-svg-icon>
               </md-list-item>
             `;
-          })}
+        })}
         </md-list>
       </div>
       <div class="footer">

--- a/matter_server/server/server.py
+++ b/matter_server/server/server.py
@@ -116,9 +116,10 @@ class MatterServer:
 
         # Host dashboard if the prebuilt files are detected
         if DASHBOARD_DIR_EXISTS:
-            self.logger.debug("Detected dashboard files on %s", str(DASHBOARD_DIR))
-            for abs_dir, _, files in os.walk(str(DASHBOARD_DIR)):
-                rel_dir = abs_dir.replace(str(DASHBOARD_DIR), "")
+            dashboard_dir = str(DASHBOARD_DIR)
+            self.logger.debug("Detected dashboard files on %s", dashboard_dir)
+            for abs_dir, _, files in os.walk(dashboard_dir):
+                rel_dir = abs_dir.replace(dashboard_dir, "")
                 for filename in files:
                     filepath = os.path.join(abs_dir, filename)
                     handler = partial(self._serve_static, filepath)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ zip-safe = false
 matter_server = ["py.typed"]
 
 [tool.setuptools.packages.find]
-include = ["matter_server*"]
+include = ["matter_server*", "dashboard/dist/web*"]
 
 [tool.mypy]
 check_untyped_defs = true

--- a/tests/server/test_server.py
+++ b/tests/server/test_server.py
@@ -119,11 +119,11 @@ async def test_server_start(
     assert application.call_count == 1
     application_instance = application.return_value
     add_route = application_instance.router.add_route
-    assert add_route.call_count == 2
+    assert add_route.call_count >= 2
     assert add_route.call_args_list[0][0][0] == "GET"
     assert add_route.call_args_list[0][0][1] == "/ws"
     assert add_route.call_args_list[1][0][0] == "GET"
-    assert add_route.call_args_list[1][0][1] == "/"
+    assert add_route.call_args_list[1][0][1] == "/info"
     assert app_runner.call_count == 1
     assert app_runner.return_value.setup.call_count == 1
     assert multi_host_tcp_site.call_count == 1


### PR DESCRIPTION
- Build the dashboard in the release script
- Host the dashboard on the builtin webserver
- Detect the production server based on our default port

This is just the base dashboard as-is with no added functionality, that is to be extended in follow-up PR's.