### PR TITLE
Catch TimeoutError while retrieving certificates

### DIFF
--- a/matter_server/server/helpers/paa_certificates.py
+++ b/matter_server/server/helpers/paa_certificates.py
@@ -106,7 +106,7 @@ async def fetch_dcl_certificates(
                     )
                     LAST_CERT_IDS.add(paa["subjectKeyId"])
                     fetch_count += 1
-    except ClientError as err:
+    except (ClientError, TimeoutError) as err:
         LOGGER.warning(
             "Fetching latest certificates failed: error %s", err, exc_info=err
         )
@@ -142,7 +142,7 @@ async def fetch_git_certificates() -> int:
                 await write_paa_root_cert(certificate, cert)
                 LAST_CERT_IDS.add(cert)
                 fetch_count += 1
-    except ClientError as err:
+    except (ClientError, TimeoutError) as err:
         LOGGER.warning(
             "Fetching latest certificates failed: error %s", err, exc_info=err
         )


### PR DESCRIPTION
Some users had reported that their Matter server didn't start and [while inspecting their logs](https://github.com/home-assistant/core/issues/111251#issuecomment-1966840622) I noticed the fetching of certificates from Github was raising a TimeoutError we weren't catching.

Still, not retrieving the certificates can cause issues when trying to commission new nodes but a not starting Matter server isn't very nice either.

NOTE: It's not possible to load these certificates while running. They must be fetched before starting the devicecontroller.