### PR TITLE
Extend sleep in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
       - name: Wait for PyPI
-        run: sleep 120
+        run: sleep 300
   build-and-push-container-image:
     name: Builds and pushes the Matter Server container to ghcr.io
     runs-on: ubuntu-latest


### PR DESCRIPTION
The release action just failed again with a 120 seconds sleep (due to the released pypi package couldn't be found).
Extended it to 5 minutes now, let's see how that works out.