### PR TITLE
Ensure that the dashboard build is included in the py wheel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,10 +57,8 @@ jobs:
             tomli_w.dump(pyproject, f)
       - name: Build dashboard
         run: |
-          cd dashboard
-          script/setup
-          script/build
-          cd ..
+          dashboard/script/setup
+          dashboard/script/build
       - name: Build python package
         run: >-
           python3 -m build

--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,6 @@ venv39/
 
 # ruff
 .ruff_cache/
+
+# prebuilt dashboard files
+matter_server/dashboard/

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -30,4 +30,5 @@ The production build is generated when you run
 script/build
 ```
 
-The folder `dist/web` will contain the build that can be served by any web browser.
+The production build is generated into the matter_server folder, to be picked up by
+the webserver of the python matter server.

--- a/dashboard/script/build
+++ b/dashboard/script/build
@@ -6,6 +6,8 @@ set -e
 cd "$(dirname "$0")/.."
 
 rm -rf dist
+rm -rf ../matter_server/dashboard
 NODE_ENV=production npm exec -- tsc
 NODE_ENV=production npm exec -- rollup -c
 cp -r public/* dist/web
+mv dist/web ../matter_server/dashboard

--- a/matter_server/server/server.py
+++ b/matter_server/server/server.py
@@ -34,7 +34,7 @@ from .stack import MatterStack
 from .storage import StorageController
 from .vendor_info import VendorInfo
 
-DASHBOARD_DIR = Path(__file__).parent.joinpath("../../dashboard/dist/web/").resolve()
+DASHBOARD_DIR = Path(__file__).parent.joinpath("../dashboard/").resolve()
 DASHBOARD_DIR_EXISTS = DASHBOARD_DIR.exists()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,10 +67,10 @@ platforms = ["any"]
 zip-safe = false
 
 [tool.setuptools.package-data]
-matter_server = ["py.typed"]
+matter_server = ["py.typed", "dashboard/**"]
 
 [tool.setuptools.packages.find]
-include = ["matter_server*", "dashboard/dist/web*"]
+include = ["matter_server*"]
 
 [tool.mypy]
 check_untyped_defs = true


### PR DESCRIPTION
After publishing 5.7.0 beta 0 I found out that the (prebuilt) dashboard wasn't included in the python wheel.
Modified the build script a bit to build the frontend into a dashboard subfolder of the matter_server, which will then recursively be picked up by setuptools. 