### PR TITLE
A collection of small (stability) fixes and tweaks

### DIFF
--- a/matter_server/server/__main__.py
+++ b/matter_server/server/__main__.py
@@ -96,9 +96,7 @@ args = parser.parse_args()
 
 
 def _setup_logging() -> None:
-    log_fmt = (
-        "%(asctime)s.%(msecs)03d %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
-    )
+    log_fmt = "%(asctime)s (%(threadName)s) %(levelname)s [%(name)s] %(message)s"
     custom_level_style = {
         **coloredlogs.DEFAULT_LEVEL_STYLES,
         "chip_automation": {"color": "green", "faint": True},

--- a/matter_server/server/__main__.py
+++ b/matter_server/server/__main__.py
@@ -5,6 +5,8 @@ import asyncio
 import logging
 import os
 from pathlib import Path
+import sys
+import threading
 
 from aiorun import run
 import coloredlogs
@@ -115,6 +117,20 @@ def _setup_logging() -> None:
         # (temporary) raise the log level of zeroconf as its a logs an annoying
         # warning at startup while trying to bind to a loopback IPv6 interface
         logging.getLogger("zeroconf").setLevel(logging.ERROR)
+
+    # register global uncaught exception loggers
+    sys.excepthook = lambda *args: logging.getLogger(None).exception(
+        "Uncaught exception",
+        exc_info=args,
+    )
+    threading.excepthook = lambda args: logging.getLogger(None).exception(
+        "Uncaught thread exception",
+        exc_info=(  # type: ignore[arg-type]
+            args.exc_type,
+            args.exc_value,
+            args.exc_traceback,
+        ),
+    )
 
 
 def main() -> None:

--- a/matter_server/server/__main__.py
+++ b/matter_server/server/__main__.py
@@ -2,11 +2,14 @@
 
 import argparse
 import asyncio
+from contextlib import suppress
 import logging
+from logging.handlers import RotatingFileHandler
 import os
 from pathlib import Path
 import sys
 import threading
+from typing import Final
 
 from aiorun import run
 import coloredlogs
@@ -21,6 +24,11 @@ DEFAULT_PORT = 5580
 # Default to None to bind to all addresses on both IPv4 and IPv6
 DEFAULT_LISTEN_ADDRESS = None
 DEFAULT_STORAGE_PATH = os.path.join(Path.home(), ".matter_server")
+
+FORMAT_DATE: Final = "%Y-%m-%d"
+FORMAT_TIME: Final = "%H:%M:%S"
+FORMAT_DATETIME: Final = f"{FORMAT_DATE} {FORMAT_TIME}"
+MAX_LOG_FILESIZE = 1000000 * 10  # 10 MB
 
 # Get parsed passed in arguments.
 parser = argparse.ArgumentParser(
@@ -88,6 +96,9 @@ args = parser.parse_args()
 
 
 def _setup_logging() -> None:
+    log_fmt = (
+        "%(asctime)s.%(msecs)03d %(levelname)s (%(threadName)s) [%(name)s] %(message)s"
+    )
     custom_level_style = {
         **coloredlogs.DEFAULT_LEVEL_STYLES,
         "chip_automation": {"color": "green", "faint": True},
@@ -96,34 +107,50 @@ def _setup_logging() -> None:
         "chip_error": {"color": "red"},
     }
     # Let coloredlogs handle all levels, we filter levels in the logging module
-    coloredlogs.install(level=logging.NOTSET, level_styles=custom_level_style)
+    coloredlogs.install(
+        level=logging.NOTSET, level_styles=custom_level_style, fmt=log_fmt
+    )
 
-    handlers = None
+    # Capture warnings.warn(...) and friends messages in logs.
+    # The standard destination for them is stderr, which may end up unnoticed.
+    # This way they're where other messages are, and can be filtered as usual.
+    logging.captureWarnings(True)
+
+    logging.basicConfig(level=args.log_level.upper())
+    logger = logging.getLogger()
+
+    # setup file handler
     if args.log_file:
-        handlers = [logging.FileHandler(args.log_file)]
-    logging.basicConfig(handlers=handlers, level=args.log_level.upper())
+        log_filename = os.path.join(args.log_file)
+        file_handler = RotatingFileHandler(
+            log_filename, maxBytes=MAX_LOG_FILESIZE, backupCount=1
+        )
+        # rotate log at each start
+        with suppress(OSError):
+            file_handler.doRollover()
+        file_handler.setFormatter(logging.Formatter(log_fmt, datefmt=FORMAT_DATETIME))
+        logger.addHandler(file_handler)
 
     stack.init_logging(args.log_level_sdk.upper())
-    logging.getLogger().setLevel(args.log_level.upper())
+    logger.setLevel(args.log_level.upper())
 
-    if not logging.getLogger().isEnabledFor(logging.DEBUG):
+    if not logger.isEnabledFor(logging.DEBUG):
         logging.getLogger("PersistentStorage").setLevel(logging.WARNING)
         # Temporary disable the logger of chip.clusters.Attribute because it now logs
         # an error on every custom attribute that couldn't be parsed which confuses people.
         # We can restore the default log level again when we've patched the device controller
         # to handle the raw attribute data to deal with custom clusters.
         logging.getLogger("chip.clusters.Attribute").setLevel(logging.CRITICAL)
-    if not logging.getLogger().isEnabledFor(logging.DEBUG):
         # (temporary) raise the log level of zeroconf as its a logs an annoying
         # warning at startup while trying to bind to a loopback IPv6 interface
         logging.getLogger("zeroconf").setLevel(logging.ERROR)
 
     # register global uncaught exception loggers
-    sys.excepthook = lambda *args: logging.getLogger(None).exception(
+    sys.excepthook = lambda *args: logger.exception(
         "Uncaught exception",
         exc_info=args,
     )
-    threading.excepthook = lambda args: logging.getLogger(None).exception(
+    threading.excepthook = lambda args: logger.exception(
         "Uncaught thread exception",
         exc_info=(  # type: ignore[arg-type]
             args.exc_type,
@@ -136,11 +163,11 @@ def _setup_logging() -> None:
 def main() -> None:
     """Run main execution."""
 
-    _setup_logging()
-
     # make sure storage path exists
     if not os.path.isdir(args.storage_path):
         os.mkdir(args.storage_path)
+
+    _setup_logging()
 
     # Init server
     server = MatterServer(

--- a/matter_server/server/__main__.py
+++ b/matter_server/server/__main__.py
@@ -182,7 +182,7 @@ def main() -> None:
         await server.stop()
 
     # run the server
-    run(server.start(), shutdown_callback=handle_stop, executor_workers=32)
+    run(server.start(), shutdown_callback=handle_stop)
 
 
 if __name__ == "__main__":

--- a/matter_server/server/__main__.py
+++ b/matter_server/server/__main__.py
@@ -157,7 +157,7 @@ def main() -> None:
         await server.stop()
 
     # run the server
-    run(server.start(), shutdown_callback=handle_stop)
+    run(server.start(), shutdown_callback=handle_stop, executor_workers=32)
 
 
 if __name__ == "__main__":

--- a/matter_server/server/client_handler.py
+++ b/matter_server/server/client_handler.py
@@ -193,12 +193,24 @@ class WebsocketClientHandler:
                 result = await result
             self._send_message(SuccessResultMessage(msg.message_id, result))
         except ChipStackError as err:
-            self._logger.exception("SDK Error during handling message: %s", msg)
+            self._logger.error(
+                "SDK Error during handling message: %s: %s",
+                msg.command,
+                str(err),
+                # only print the full stacktrace if debug logging is enabled
+                exc_info=err if self._logger.isEnabledFor(logging.DEBUG) else None,
+            )
             self._send_message(
                 ErrorResultMessage(msg.message_id, SDKStackError.error_code, str(err))
             )
-        except Exception as err:  # pylint: disable=broad-except
-            self._logger.exception("Error handling message: %s", msg)
+        except Exception as err:  # pylint: disable=broad-except  # noqa: BLE001
+            self._logger.error(
+                "SDK Error during handling message: %s: %s",
+                msg.command,
+                str(err),
+                # only print the full stacktrace if debug logging is enabled
+                exc_info=err if self._logger.isEnabledFor(logging.DEBUG) else None,
+            )
             error_code = getattr(err, "error_code", MatterError.error_code)
             self._send_message(ErrorResultMessage(msg.message_id, error_code, str(err)))
 

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -807,7 +807,7 @@ class MatterDeviceController:
         # if so, we need to unsubscribe
         if prev_sub := self._subscriptions.get(node_id, None):
             async with node_lock:
-                node_logger.debug("Unsubscribing from existing subscription.")
+                node_logger.info("Unsubscribing from existing subscription.")
                 await self._call_sdk(prev_sub.Shutdown)
                 del self._subscriptions[node_id]
 
@@ -1039,8 +1039,12 @@ class MatterDeviceController:
             raise NodeNotExists(f"Node {node_id} does not exist.")
         if node_id in self._nodes_in_setup:
             # prevent duplicate setup actions
+            LOGGER.warning(
+                "Ignoring node setup for node %s as its already being setup.", node_id
+            )
             return
         self._nodes_in_setup.add(node_id)
+        LOGGER.info("Setting-up node %s...", node_id)
         # pre-cache ip-addresses
         await self.get_node_ip_addresses(node_id)
         # we use a lock for the node setup process to process nodes sequentially
@@ -1062,7 +1066,6 @@ class MatterDeviceController:
                         # NOTE: the node will be picked up by mdns discovery automatically
                         # when it comes available again.
                         return
-
                 # setup subscriptions for the node
                 try:
                     await self._subscribe_node(node_id)

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -69,6 +69,9 @@ MAX_NODE_SUBSCRIPTION_CEILING_BATTERY_POWERED = 1800
 MAX_COMMISSION_RETRIES = 3
 NODE_RESUBSCRIBE_ATTEMPTS_UNAVAILABLE = 3
 NODE_RESUBSCRIBE_TIMEOUT_OFFLINE = 30 * 60 * 1000
+NODE_PING_TIMEOUT = 10
+NODE_PING_TIMEOUT_BATTERY_POWERED = 60
+NODE_MDNS_BACKOFF = 60
 
 MDNS_TYPE_OPERATIONAL_NODE = "_matter._tcp.local."
 MDNS_TYPE_COMMISSIONABLE_NODE = "_matterc._udp.local."
@@ -724,7 +727,11 @@ class MatterDeviceController:
 
         async def _do_ping(ip_address: str) -> None:
             """Ping IP and add to result."""
-            timeout = 60 if battery_powered else 10
+            timeout = (
+                NODE_PING_TIMEOUT_BATTERY_POWERED
+                if battery_powered
+                else NODE_PING_TIMEOUT
+            )
             if "%" in ip_address:
                 # ip address contains an interface index
                 clean_ip, interface_idx = ip_address.split("%", 1)
@@ -1189,7 +1196,7 @@ class MatterDeviceController:
         # and we have other logic in place to determine node aliveness
         now = time.time()
         last_seen = self._node_last_seen.get(node_id, 0)
-        if node.available and now - last_seen < 60:
+        if node.available and now - last_seen < NODE_MDNS_BACKOFF:
             return
         self._node_last_seen[node_id] = now
 

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -800,16 +800,14 @@ class MatterDeviceController:
             )
 
         node_logger = LOGGER.getChild(f"[node {node_id}]")
-        node_lock = self._get_node_lock(node_id)
         node = self._nodes[node_id]
 
         # check if we already have setup subscriptions for this node,
         # if so, we need to unsubscribe
         if prev_sub := self._subscriptions.get(node_id, None):
-            async with node_lock:
-                node_logger.info("Unsubscribing from existing subscription.")
-                await self._call_sdk(prev_sub.Shutdown)
-                del self._subscriptions[node_id]
+            node_logger.info("Unsubscribing from existing subscription.")
+            await self._call_sdk(prev_sub.Shutdown)
+            del self._subscriptions[node_id]
 
         # determine if node is battery powered sleeping device
         # Endpoint 0, ThreadNetworkDiagnostics Cluster, routingRole attribute
@@ -827,7 +825,6 @@ class MatterDeviceController:
             transaction: Attribute.SubscriptionTransaction,
         ) -> None:
             self._mdns_last_seen[node_id] = time.time()
-            assert loop is not None
             new_value = transaction.GetAttribute(path)
             # failsafe: ignore ValueDecodeErrors
             # these are set by the SDK if parsing the value failed miserably

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -1187,9 +1187,11 @@ class MatterDeviceController:
         # mdns events for matter devices arrive in bursts of (duplicate) messages
         # so we debounce this as we only use the mdns messages for operational node discovery
         # and we have other logic in place to determine node aliveness
+        now = time.time()
         last_seen = self._node_last_seen.get(node_id, 0)
-        if node.available and time.time() - last_seen < MAX_NODE_SUBSCRIPTION_CEILING:
+        if node.available and now - last_seen < 60:
             return
+        self._node_last_seen[node_id] = now
 
         # we treat UPDATE state changes as ADD if the node is marked as
         # unavailable to ensure we catch a node being operational

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -710,7 +710,7 @@ class MatterDeviceController:
             raise NodeNotExists(
                 f"Node {node_id} does not exist or is not yet interviewed"
             )
-        node_logger = LOGGER.getChild(f"[node {node_id}]")
+        node_logger = LOGGER.getChild(f"node_{node_id}")
 
         battery_powered = (
             node.attributes.get(ROUTING_ROLE_ATTRIBUTE_PATH, 0)
@@ -768,7 +768,7 @@ class MatterDeviceController:
             raise NodeNotExists(
                 f"Node {node_id} does not exist or is not yet interviewed"
             )
-        node_logger = LOGGER.getChild(f"[node {node_id}]")
+        node_logger = LOGGER.getChild(f"node_{node_id}")
         # query mdns for all IP's
         # ensure both fabric id and node id have 16 characters (prefix with zero's)
         mdns_name = f"{self.compressed_fabric_id:0{16}X}-{node_id:0{16}X}.{MDNS_TYPE_OPERATIONAL_NODE}"
@@ -801,7 +801,7 @@ class MatterDeviceController:
                 f"Node {node_id} does not exist or has not been interviewed."
             )
 
-        node_logger = LOGGER.getChild(f"[node {node_id}]")
+        node_logger = LOGGER.getChild(f"node_{node_id}")
         node = self._nodes[node_id]
 
         # check if we already have setup subscriptions for this node,

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -972,27 +972,24 @@ class MatterDeviceController:
         self._last_subscription_attempt[node_id] = 0
         future = loop.create_future()
         device = await self._resolve_node(node_id)
-        async with node_lock:
-            Attribute.Read(
-                future=future,
-                eventLoop=loop,
-                device=device.deviceProxy,
-                devCtrl=self.chip_controller,
-                attributes=[Attribute.AttributePath()],  # wildcard
-                events=[
-                    Attribute.EventPath(
-                        EndpointId=None, Cluster=None, Event=None, Urgent=1
-                    )
-                ],
-                returnClusterObject=False,
-                subscriptionParameters=Attribute.SubscriptionParameters(
-                    interval_floor, interval_ceiling
-                ),
-                # Use fabricfiltered as False to detect changes made by other controllers
-                # and to be able to provide a list of all fabrics attached to the device
-                fabricFiltered=False,
-                autoResubscribe=True,
-            ).raise_on_error()
+        Attribute.Read(
+            future=future,
+            eventLoop=loop,
+            device=device.deviceProxy,
+            devCtrl=self.chip_controller,
+            attributes=[Attribute.AttributePath()],  # wildcard
+            events=[
+                Attribute.EventPath(EndpointId=None, Cluster=None, Event=None, Urgent=1)
+            ],
+            returnClusterObject=False,
+            subscriptionParameters=Attribute.SubscriptionParameters(
+                interval_floor, interval_ceiling
+            ),
+            # Use fabricfiltered as False to detect changes made by other controllers
+            # and to be able to provide a list of all fabrics attached to the device
+            fabricFiltered=False,
+            autoResubscribe=True,
+        ).raise_on_error()
         sub: Attribute.SubscriptionTransaction = await future
 
         sub.SetAttributeUpdateCallback(attribute_updated_callback)

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -1080,7 +1080,8 @@ class MatterDeviceController:
         self, node_id: int, retries: int = 2, attempt: int = 1
     ) -> DeviceProxyWrapper:
         """Resolve a Node on the network."""
-        log_level = logging.DEBUG if attempt == 1 else logging.INFO
+        # log_level = logging.DEBUG if attempt == 1 else logging.INFO
+        log_level = logging.INFO  # TEMP !
         if self.chip_controller is None:
             raise RuntimeError("Device Controller not initialized.")
         try:

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -1048,9 +1048,9 @@ class MatterDeviceController:
             return
         self._nodes_in_setup.add(node_id)
         try:
-            # ping the node to out stale mdns reports and to prevent that we
-            # send an unreachable node to the sdk which is very slow with resolving it
-            # this will also precache the ip addresses of the node for later use.
+            # Ping the node to rule out stale mdns reports and to prevent that we
+            # send an unreachable node to the sdk which is very slow with resolving it.
+            # This will also precache the ip addresses of the node for later use.
             ping_result = await self.ping_node(node_id)
             if not any(ping_result.values()):
                 LOGGER.warning(

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -62,7 +62,7 @@ DATA_KEY_NODES = "nodes"
 DATA_KEY_LAST_NODE_ID = "last_node_id"
 
 LOGGER = logging.getLogger(__name__)
-MIN_NODE_SUBSCRIPTION_CEILING = 60
+MIN_NODE_SUBSCRIPTION_CEILING = 30
 MAX_NODE_SUBSCRIPTION_CEILING = 300
 MIN_NODE_SUBSCRIPTION_CEILING_BATTERY_POWERED = 300
 MAX_NODE_SUBSCRIPTION_CEILING_BATTERY_POWERED = 1800
@@ -1185,7 +1185,7 @@ class MatterDeviceController:
         now = time.time()
         last_seen = self._mdns_last_seen.get(node_id, 0)
         self._mdns_last_seen[node_id] = now
-        if now - last_seen < MIN_NODE_SUBSCRIPTION_CEILING:
+        if now - last_seen < 30:
             return
 
         # we treat UPDATE state changes as ADD if the node is marked as

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -969,25 +969,30 @@ class MatterDeviceController:
         self._last_subscription_attempt[node_id] = 0
         future = loop.create_future()
         device = await self._resolve_node(node_id)
-        Attribute.Read(
-            future=future,
-            eventLoop=loop,
-            device=device.deviceProxy,
-            devCtrl=self.chip_controller,
-            attributes=[Attribute.AttributePath()],  # wildcard
-            events=[
-                Attribute.EventPath(EndpointId=None, Cluster=None, Event=None, Urgent=1)
-            ],
-            returnClusterObject=False,
-            subscriptionParameters=Attribute.SubscriptionParameters(
-                interval_floor, interval_ceiling
-            ),
-            # Use fabricfiltered as False to detect changes made by other controllers
-            # and to be able to provide a list of all fabrics attached to the device
-            fabricFiltered=False,
-            autoResubscribe=True,
-        ).raise_on_error()
-        sub: Attribute.SubscriptionTransaction = await future
+        try:
+            Attribute.Read(
+                future=future,
+                eventLoop=loop,
+                device=device.deviceProxy,
+                devCtrl=self.chip_controller,
+                attributes=[Attribute.AttributePath()],  # wildcard
+                events=[
+                    Attribute.EventPath(
+                        EndpointId=None, Cluster=None, Event=None, Urgent=1
+                    )
+                ],
+                returnClusterObject=False,
+                subscriptionParameters=Attribute.SubscriptionParameters(
+                    interval_floor, interval_ceiling
+                ),
+                # Use fabricfiltered as False to detect changes made by other controllers
+                # and to be able to provide a list of all fabrics attached to the device
+                fabricFiltered=False,
+                autoResubscribe=True,
+            ).raise_on_error()
+            sub: Attribute.SubscriptionTransaction = await future
+        except Exception as err:  # pylint: disable=broad-except
+            node_logger.exception("Error setting up subscription", exc_info=err)
 
         sub.SetAttributeUpdateCallback(attribute_updated_callback)
         sub.SetEventUpdateCallback(event_callback)


### PR DESCRIPTION
After testing the 5.7.0 beta we collected a few tweaks to stabilize and enhance the server, especially for larger devices.
One important fix was to limit access to the SDK to a single thread with a single thread executorpool (already merged in separate PR). We also discovered that we were not catching unhandled exceptions.

This branch had a number of iterations while testing on users but in the end this is what's left;

- Enhance the logging config with some common tweaks such as showing the thread.
- Catch all unhandled exceptions in threads and asyncio tasks.
- Only print full stacktraces for exceptions if debug logging is enabled, otherwise just log a pretty-fied version.
- A few small tweaks to the mdns discovery and subscription ceilings

