### PR TITLE
Update to Matter SDK wheels 2024.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         libuv1 \
-        openssl \
         zlib1g \
         libjson-c5 \
         libnl-3-200 \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -10,7 +10,6 @@ RUN \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         libuv1 \
-        openssl \
         zlib1g \
         libjson-c5 \
         libnl-3-200 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   "coloredlogs",
   "dacite",
   "orjson",
-  "home-assistant-chip-clusters==2024.2.0",
+  "home-assistant-chip-clusters==2024.2.1",
 ]
 description = "Python Matter WebSocket Server"
 license = {text = "Apache-2.0"}
@@ -34,7 +34,7 @@ version = "0.0.0"
 
 [project.optional-dependencies]
 server = [
-  "home-assistant-chip-core==2024.2.0",
+  "home-assistant-chip-core==2024.2.1",
   "cryptography==42.0.5",
   "zeroconf==0.131.0",
 ]


### PR DESCRIPTION
With Matter SDK wheels 2024.2.1 OpenSSL is no longer required as statically linked BoringSSL is used.

This also gets rid of the mDNS failed to join multicast group errors on startup.