### PR TITLE
Do multiple ping attempts when discovering a node

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -710,7 +710,7 @@ class MatterDeviceController:
         )
 
     @api_command(APICommand.PING_NODE)
-    async def ping_node(self, node_id: int) -> NodePingResult:
+    async def ping_node(self, node_id: int, attempts: int = 1) -> NodePingResult:
         """Ping node on the currently known IP-adress(es)."""
         result: NodePingResult = {}
         node = self._nodes.get(node_id)
@@ -741,7 +741,7 @@ class MatterDeviceController:
             else:
                 clean_ip = ip_address
                 node_logger.debug("Pinging address %s", clean_ip)
-            result[clean_ip] = await ping_ip(ip_address, timeout)
+            result[clean_ip] = await ping_ip(ip_address, timeout, attempts=attempts)
 
         ip_addresses = await self.get_node_ip_addresses(
             node_id, prefer_cache=False, scoped=True
@@ -1058,7 +1058,7 @@ class MatterDeviceController:
             # Ping the node to rule out stale mdns reports and to prevent that we
             # send an unreachable node to the sdk which is very slow with resolving it.
             # This will also precache the ip addresses of the node for later use.
-            ping_result = await self.ping_node(node_id)
+            ping_result = await self.ping_node(node_id, attempts=3)
             if not any(ping_result.values()):
                 LOGGER.warning(
                     "Skip set-up for node %s because it does not appear to be reachable...",

--- a/matter_server/server/helpers/utils.py
+++ b/matter_server/server/helpers/utils.py
@@ -8,7 +8,7 @@ import async_timeout
 PLATFORM_MAC = platform.system() == "Darwin"
 
 
-async def ping_ip(ip_address: str, timeout: int = 2) -> bool:
+async def ping_ip(ip_address: str, timeout: int = 2, attempts: int = 1) -> bool:
     """Ping given (IPv4 or IPv6) IP-address."""
     is_ipv6 = ":" in ip_address
     if is_ipv6 and PLATFORM_MAC:
@@ -18,13 +18,20 @@ async def ping_ip(ip_address: str, timeout: int = 2) -> bool:
         cmd = f"ping6 -c 1 -W {timeout} {ip_address}"
     else:
         cmd = f"ping -c 1 -W {timeout} {ip_address}"
-    try:
-        # we add an additional timeout here as safeguard and to account for the fact
-        # that macos does not seem to have timeout on ping6
-        async with async_timeout.timeout(timeout + 2):
-            return (await check_output(cmd))[0] == 0
-    except asyncio.TimeoutError:
-        return False
+    while attempts:
+        attempts -= 1
+        try:
+            # we add an additional timeout here as safeguard and to account for the fact
+            # that macos does not seem to have timeout on ping6
+            async with async_timeout.timeout(timeout + 2):
+                success = (await check_output(cmd))[0] == 0
+                if success or not attempts:
+                    return success
+        except asyncio.TimeoutError:
+            pass
+        # sleep between attempts
+        await asyncio.sleep(10)
+    return False
 
 
 async def check_output(shell_cmd: str) -> tuple[int | None, bytes]:


### PR DESCRIPTION
Some nodes are just super slow to respond or the network may be busy.
Do multiple ping attempts when we discover a node on mdns.