### PR TITLE
Detect deadlock on node subscription setup

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -1117,7 +1117,7 @@ class MatterDeviceController:
                 except TimeoutError:
                     LOGGER.error(
                         "POSSIBLE DEADLOCK DETECTED - REPORT TO HOME ASSISTANT DEVELOPERS: "
-                        "Setting up subscriptions for node %s did not succeed after 30 minutes. ",
+                        "Setting up subscriptions for node %s did not succeed after 30 minutes.",
                         node_id,
                     )
                 except (NodeNotResolving, ChipStackError) as err:

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -1112,12 +1112,12 @@ class MatterDeviceController:
                         return
                 # setup subscriptions for the node
                 try:
-                    async with async_timeout.timeout(1800):
+                    async with async_timeout.timeout(15 * 60 * 60):
                         await self._subscribe_node(node_id)
                 except TimeoutError:
-                    LOGGER.error(
-                        "POSSIBLE DEADLOCK DETECTED - REPORT TO HOME ASSISTANT DEVELOPERS: "
-                        "Setting up subscriptions for node %s did not succeed after 30 minutes.",
+                    LOGGER.warning(
+                        "Setting up subscriptions for node %s did not "
+                        "succeed after 15 minutes!",
                         node_id,
                     )
                 except (NodeNotResolving, ChipStackError) as err:


### PR DESCRIPTION
So we've seen a few logs that worry us as the node subscription was started but then never completed. No stacktrace/error, no timeout, no success. Seems that it just deadlocks.

This was however in all cases Nanoleaf devices, that are known to be unstable and reset often.
What if the device resets just while setting up subscriptions?
It's worth investigating and at least protect against. This adds a timeout to setting up the subscription and logs a warning if the timeout expired.