### PR TITLE
Several improvements to resolving and (re)subscribing to nodes

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -1288,8 +1288,9 @@ class MatterDeviceController:
             last_seen = self._node_last_seen.get(node_id, 0)
             if now - last_seen < FALLBACK_NODE_SCANNER_INTERVAL:
                 continue
-            if await self.ping_node(node_id, attempts=3, allow_cached_ips=False):
+            if await self.ping_node(node_id, attempts=3, allow_cached_ips=True):
                 LOGGER.info("Node %s discovered using fallback ping", node_id)
+                self._node_last_seen[node_id] = now
                 await self._setup_node(node_id)
 
         def reschedule_self() -> None:

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -682,14 +682,12 @@ class MatterDeviceController:
             return
         result: Clusters.OperationalCredentials.Commands.NOCResponse | None = None
         try:
-            result = await self._call_sdk(
-                self.chip_controller.SendCommand(
-                    nodeid=node_id,
-                    endpoint=0,
-                    payload=Clusters.OperationalCredentials.Commands.RemoveFabric(
-                        fabricIndex=fabric_index,
-                    ),
-                )
+            result = await self.chip_controller.SendCommand(
+                nodeid=node_id,
+                endpoint=0,
+                payload=Clusters.OperationalCredentials.Commands.RemoveFabric(
+                    fabricIndex=fabric_index,
+                ),
             )
         except ChipStackError as err:
             LOGGER.warning(

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -1295,6 +1295,8 @@ class MatterDeviceController:
 
     def _write_node_state(self, node_id: int, force: bool = False) -> None:
         """Schedule the write of the current node state to persistent storage."""
+        if node_id not in self._nodes:
+            return  # guard
         node = self._nodes[node_id]
         self.server.storage.set(
             DATA_KEY_NODES,

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -503,15 +503,14 @@ class MatterDeviceController:
             raise RuntimeError("Device Controller not initialized.")
 
         try:
-            if not (node := self._nodes.get(node_id)) or not node.available:
-                LOGGER.info("Interviewing node: %s", node_id)
-                read_response: Attribute.AsyncReadTransaction.ReadResponse = (
-                    await self.chip_controller.Read(
-                        nodeid=node_id,
-                        attributes="*",
-                        fabricFiltered=False,
-                    )
+            LOGGER.info("Interviewing node: %s", node_id)
+            read_response: Attribute.AsyncReadTransaction.ReadResponse = (
+                await self.chip_controller.Read(
+                    nodeid=node_id,
+                    attributes="*",
+                    fabricFiltered=False,
                 )
+            )
         except ChipStackError as err:
             raise NodeInterviewFailed(f"Failed to interview node {node_id}") from err
 

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -14,7 +14,6 @@ from random import randint
 import time
 from typing import TYPE_CHECKING, Any, Callable, Iterable, TypeVar, cast
 
-import async_timeout
 from chip.ChipDeviceCtrl import DeviceProxyWrapper
 from chip.clusters import Attribute, Objects as Clusters
 from chip.clusters.Attribute import ValueDecodeFailure
@@ -1112,14 +1111,7 @@ class MatterDeviceController:
                         return
                 # setup subscriptions for the node
                 try:
-                    async with async_timeout.timeout(15 * 60):
-                        await self._subscribe_node(node_id)
-                except TimeoutError:
-                    LOGGER.warning(
-                        "Setting up subscriptions for node %s did not "
-                        "succeed after 15 minutes!",
-                        node_id,
-                    )
+                    await self._subscribe_node(node_id)
                 except (NodeNotResolving, ChipStackError) as err:
                     LOGGER.warning(
                         "Unable to subscribe to Node %s: %s",

--- a/matter_server/server/helpers/utils.py
+++ b/matter_server/server/helpers/utils.py
@@ -1,6 +1,7 @@
 """Utils for Matter server."""
 
 import asyncio
+from contextlib import suppress
 import platform
 
 import async_timeout
@@ -44,7 +45,8 @@ async def check_output(shell_cmd: str) -> tuple[int | None, bytes]:
     try:
         stdout, _ = await proc.communicate()
     except asyncio.CancelledError:
-        proc.terminate()
-        await proc.communicate()
+        with suppress(ProcessLookupError):
+            proc.terminate()
+            await proc.communicate()
         raise
     return (proc.returncode, stdout)

--- a/matter_server/server/server.py
+++ b/matter_server/server/server.py
@@ -133,7 +133,7 @@ class MatterServer:
             )
         self.loop = asyncio.get_running_loop()
         self.loop.set_exception_handler(_global_loop_exception_handler)
-        self.loop.set_debug(os.environ.get("PYTHONDEBUG") == "1")
+        self.loop.set_debug(os.environ.get("PYTHONDEBUG", "") != "")
         await self.device_controller.initialize()
         await self.storage.start()
         await self.device_controller.start()

--- a/matter_server/server/server.py
+++ b/matter_server/server/server.py
@@ -9,7 +9,7 @@ import logging
 import os
 from pathlib import Path
 import traceback
-from typing import Any, Callable, Set, cast
+from typing import TYPE_CHECKING, Any, Callable, Set, cast
 import weakref
 
 from aiohttp import web
@@ -133,6 +133,7 @@ class MatterServer:
             )
         self.loop = asyncio.get_running_loop()
         self.loop.set_exception_handler(_global_loop_exception_handler)
+        self.loop.set_debug(os.environ.get("PYTHONDEBUG") == "1")
         await self.device_controller.initialize()
         await self.storage.start()
         await self.device_controller.start()
@@ -219,11 +220,13 @@ class MatterServer:
 
     def signal_event(self, evt: EventType, data: Any = None) -> None:
         """Signal event to listeners."""
+        if TYPE_CHECKING:
+            assert self.loop
         for callback in self._subscribers:
             if asyncio.iscoroutinefunction(callback):
                 asyncio.create_task(callback(evt, data))
             else:
-                callback(evt, data)
+                self.loop.call_soon_threadsafe(callback, evt, data)
 
     def scope_ipv6_lla(self, ip_addr: str) -> str:
         """Scope IPv6 link-local addresses to primary interface.


### PR DESCRIPTION
- Remove Timeout (as it is no longer needed now we identified the source)
- Allow cached ip in background scanner
- Use SDK resolve in node setup instead of zeroconf/ping
- Allow running the loop in debug mode on dev setup
- fix interview_node
- handle race condition in ping
- better debouncing of mdns