### PR TITLE
Better logging of client errors

### DIFF
--- a/matter_server/server/client_handler.py
+++ b/matter_server/server/client_handler.py
@@ -15,7 +15,7 @@ from chip.exceptions import ChipStackError
 from matter_server.common.helpers.json import json_dumps, json_loads
 from matter_server.common.models import EventType
 
-from ..common.errors import InvalidArguments, InvalidCommand, MatterError, SDKStackError
+from ..common.errors import InvalidArguments, InvalidCommand, MatterError
 from ..common.helpers.api import parse_arguments
 from ..common.helpers.util import dataclass_from_dict
 from ..common.models import (
@@ -204,16 +204,10 @@ class WebsocketClientHandler:
                 # only print the full stacktrace if debug logging is enabled
                 exc_info=err if self._logger.isEnabledFor(logging.DEBUG) else None,
             )
-            self._send_message(
-                ErrorResultMessage(msg.message_id, SDKStackError.error_code, str(err))
-            )
-        except Exception as err:  # pylint: disable=broad-except
-            self._logger.exception(
-                "Unhandled exception while handling: %s",
-                msg.command,
-            )
-            error_code = getattr(err, "error_code", 0)
             self._send_message(ErrorResultMessage(msg.message_id, error_code, str(err)))
+        except Exception as err:
+            self._send_message(ErrorResultMessage(msg.message_id, 0, str(err)))
+            raise err
 
     async def _writer(self) -> None:
         """Write outgoing messages."""

--- a/matter_server/server/client_handler.py
+++ b/matter_server/server/client_handler.py
@@ -198,8 +198,8 @@ class WebsocketClientHandler:
             if msg.args and (node_id := msg.args.get("node_id")):
                 message_str += f" (node {node_id})"
             self._logger.error(
-                "Error while handling command: %s: %s",
-                msg.command,
+                "Error while handling: %s: %s",
+                message_str,
                 str(err) or err.__class__.__name__,
                 # only print the full stacktrace if debug logging is enabled
                 exc_info=err if self._logger.isEnabledFor(logging.DEBUG) else None,
@@ -209,7 +209,7 @@ class WebsocketClientHandler:
             )
         except Exception as err:  # pylint: disable=broad-except
             self._logger.exception(
-                "Unhandled exception while handling command: %s",
+                "Unhandled exception while handling: %s",
                 msg.command,
             )
             error_code = getattr(err, "error_code", 0)


### PR DESCRIPTION
- Pretty log handled exceptions (with node id if possible)
- Print full stack traces for unhandled exceptions by re-raising it after informing the client