### PR TITLE
Remove executor limit

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -115,6 +115,7 @@ class MatterDeviceController:
         self._fallback_node_scanner_task: asyncio.Task | None = None
         self._node_setup_throttle = asyncio.Semaphore(5)
         self._mdns_event_timer: dict[str, asyncio.TimerHandle] = {}
+        self._resolve_lock = asyncio.Lock()
 
     async def initialize(self) -> None:
         """Async initialize of controller."""
@@ -1132,12 +1133,13 @@ class MatterDeviceController:
                 retries,
             )
             time_start = time.time()
-            return await self._call_sdk(
-                self.chip_controller.GetConnectedDeviceSync,
-                nodeid=node_id,
-                allowPASE=False,
-                timeoutMs=None,
-            )
+            async with self._resolve_lock:
+                return await self._call_sdk(
+                    self.chip_controller.GetConnectedDeviceSync,
+                    nodeid=node_id,
+                    allowPASE=False,
+                    timeoutMs=None,
+                )
         except ChipStackError as err:
             if attempt >= retries:
                 # when we're out of retries, raise NodeNotResolving

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import asyncio
 from collections import deque
-from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from functools import partial
 import logging
@@ -114,9 +113,6 @@ class MatterDeviceController:
         self._aiozc: AsyncZeroconf | None = None
         self._fallback_node_scanner_timer: asyncio.TimerHandle | None = None
         self._fallback_node_scanner_task: asyncio.Task | None = None
-        self._sdk_executor = ThreadPoolExecutor(
-            max_workers=1, thread_name_prefix="SDKExecutor"
-        )
         self._node_setup_throttle = asyncio.Semaphore(10)
         self._mdns_event_timer: dict[str, asyncio.TimerHandle] = {}
 
@@ -1050,7 +1046,7 @@ class MatterDeviceController:
         return cast(
             _T,
             await self.server.loop.run_in_executor(
-                self._sdk_executor,
+                None,
                 partial(target, *args, **kwargs),
             ),
         )

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -113,7 +113,7 @@ class MatterDeviceController:
         self._aiozc: AsyncZeroconf | None = None
         self._fallback_node_scanner_timer: asyncio.TimerHandle | None = None
         self._fallback_node_scanner_task: asyncio.Task | None = None
-        self._node_setup_throttle = asyncio.Semaphore(10)
+        self._node_setup_throttle = asyncio.Semaphore(5)
         self._mdns_event_timer: dict[str, asyncio.TimerHandle] = {}
 
     async def initialize(self) -> None:


### PR DESCRIPTION
While bug hunting we suspected that the the C-Types wrapper to the SDK may not be completely thread safe so we added a limit on the asyncio executor to limit it to a single thread. Now that we have more insight in the lockup bug, it does not seem to be the cause and inspecting the code reveals that the code is pretty thread safe actually...

As I read it now everything is already thread safe as every action is posted as job to the sdk with the chipStack.Call or chipStack.CallAsync and then the result is returned when the job has been executed by the sdk, which will schedule the work on its own threads.

Now that we have limited the executor to a single executor, we're blocking concurrent actions.
For example if we're busy resolving a node, we cant execute any device commands at the same time which gives a bad UX.

The only thing that needs proper guarding is simultane interactions to the same node, otherwise you get for example the SDK setting up the case session in one worker and then another thread tries to interact with the node. Even that has been guarded in the SDK code as it logs a warning in that case but let's prevent that.

**So this PR will;**

- remove the single thread limit on the executor
- add (back) a lock for sdk operations on a single node
- limit number of simultane node setups to 5, this is just a precaution to not overload the network