### PR TITLE
Add server argument to specify custom PAA root certificate location

### DIFF
--- a/matter_server/server/__main__.py
+++ b/matter_server/server/__main__.py
@@ -91,6 +91,12 @@ parser.add_argument(
     default=None,
     help="Primary network interface for link-local addresses (optional).",
 )
+parser.add_argument(
+    "--paa-root-cert-dir",
+    type=str,
+    default=None,
+    help="Directory where PAA root certificates are stored.",
+)
 
 args = parser.parse_args()
 
@@ -175,6 +181,7 @@ def main() -> None:
         int(args.port),
         args.listen_address,
         args.primary_interface,
+        args.paa_root_cert_dir,
     )
 
     async def handle_stop(loop: asyncio.AbstractEventLoop) -> None:

--- a/matter_server/server/const.py
+++ b/matter_server/server/const.py
@@ -1,4 +1,5 @@
 """Server-only constants for the Python Matter Server."""
+
 import pathlib
 from typing import Final
 

--- a/matter_server/server/const.py
+++ b/matter_server/server/const.py
@@ -1,7 +1,5 @@
 """Server-only constants for the Python Matter Server."""
 
-import pathlib
-from typing import Final
 
 # The minimum schema version (of a client) the server can support
 MIN_SCHEMA_VERSION = 5
@@ -10,15 +8,3 @@ MIN_SCHEMA_VERSION = 5
 # only bump if the format of the data in MatterNodeData changed
 # and a full re-interview is mandatory
 DATA_MODEL_SCHEMA_VERSION = 6
-
-# the paa-root-certs path is hardcoded in the sdk at this time
-# and always uses the development subfolder
-# regardless of anything you pass into instantiating the controller
-# revisit this once matter 1.1 is released
-PAA_ROOT_CERTS_DIR: Final[pathlib.Path] = (
-    pathlib.Path(__file__)
-    .parent.resolve()
-    .parent.resolve()
-    .parent.resolve()
-    .joinpath("credentials/development/paa-root-certs")
-)

--- a/matter_server/server/const.py
+++ b/matter_server/server/const.py
@@ -1,5 +1,6 @@
 """Server-only constants for the Python Matter Server."""
-
+import pathlib
+from typing import Final
 
 # The minimum schema version (of a client) the server can support
 MIN_SCHEMA_VERSION = 5
@@ -8,3 +9,13 @@ MIN_SCHEMA_VERSION = 5
 # only bump if the format of the data in MatterNodeData changed
 # and a full re-interview is mandatory
 DATA_MODEL_SCHEMA_VERSION = 6
+
+# Keep default location inherited from early version of the Python
+# bindings.
+DEFAULT_PAA_ROOT_CERTS_DIR: Final[pathlib.Path] = (
+    pathlib.Path(__file__)
+    .parent.resolve()
+    .parent.resolve()
+    .parent.resolve()
+    .joinpath("credentials/development/paa-root-certs")
+)

--- a/matter_server/server/server.py
+++ b/matter_server/server/server.py
@@ -7,7 +7,6 @@ from functools import partial
 import ipaddress
 import logging
 import os
-import pathlib
 from pathlib import Path
 import traceback
 from typing import TYPE_CHECKING, Any, Callable, Set, cast
@@ -30,7 +29,7 @@ from ..common.models import (
     ServerInfoMessage,
 )
 from ..server.client_handler import WebsocketClientHandler
-from .const import MIN_SCHEMA_VERSION
+from .const import DEFAULT_PAA_ROOT_CERTS_DIR, MIN_SCHEMA_VERSION
 from .device_controller import MatterDeviceController
 from .stack import MatterStack
 from .storage import StorageController
@@ -111,13 +110,7 @@ class MatterServer:
         self.listen_addresses = listen_addresses
         self.primary_interface = primary_interface
         if paa_root_cert_dir is None:
-            self.paa_root_cert_dir = (
-                pathlib.Path(__file__)
-                .parent.resolve()
-                .parent.resolve()
-                .parent.resolve()
-                .joinpath("credentials/development/paa-root-certs")
-            )
+            self.paa_root_cert_dir = DEFAULT_PAA_ROOT_CERTS_DIR
         else:
             self.paa_root_cert_dir = Path(paa_root_cert_dir).absolute()
         self.logger = logging.getLogger(__name__)


### PR DESCRIPTION
Add a new server argument --paa-root-cert-dir to allow a custom location for PAA root certificates. This allows to store them in a location which is preserved.