### PR TITLE
Use milliseconds in log time stamp

### DIFF
--- a/matter_server/server/__main__.py
+++ b/matter_server/server/__main__.py
@@ -102,7 +102,9 @@ args = parser.parse_args()
 
 
 def _setup_logging() -> None:
-    log_fmt = "%(asctime)s (%(threadName)s) %(levelname)s [%(name)s] %(message)s"
+    log_fmt = (
+        "%(asctime)s.%(msecs)03d (%(threadName)s) %(levelname)s [%(name)s] %(message)s"
+    )
     custom_level_style = {
         **coloredlogs.DEFAULT_LEVEL_STYLES,
         "chip_automation": {"color": "green", "faint": True},


### PR DESCRIPTION
This can be useful during debugging and performance comparison and aligns with what Home Assistant Core is using.