### PR TITLE
Add support for importing (temporary) test nodes

### DIFF
--- a/dashboard/src/client/models/model.ts
+++ b/dashboard/src/client/models/model.ts
@@ -77,6 +77,10 @@ export interface APICommands {
     requestArgs: {};
     response: {};
   };
+  import_test_node: {
+    requestArgs: { dump: string; };
+    response: null;
+  };
 }
 
 export interface CommandMessage {
@@ -97,29 +101,15 @@ export interface ServerInfoMessage {
 
 interface ServerEventNodeAdded {
   event: "node_added";
-  data: {
-    node_id: number;
-    date_commissioned: string; // Dates will be strings in JSON
-    last_interview: string;
-    interview_version: number;
-    available: boolean;
-    is_bridge: boolean;
-    attributes: { [key: string]: any };
-    attribute_subscriptions: Array<
-      [number | null, number | null, number | null]
-    >;
-  };
+  data: MatterNode;
 }
 interface ServerEventNodeUpdated {
   event: "node_updated";
-  data: {
-    node_id: number;
-    // TODO other things?
-  };
+  data: MatterNode;
 }
 interface ServerEventNodeRemoved {
   event: "node_removed";
-  data: {};
+  data: number;
 }
 interface ServerEventNodeEvent {
   event: "node_event";
@@ -142,18 +132,8 @@ interface ServerEventEndpointRemoved {
   data: {};
 }
 
-export interface EventMessage {
-  receive_time: Date;
-  event:
-    | ServerEventNodeAdded
-    | ServerEventNodeUpdated
-    | ServerEventNodeRemoved
-    | ServerEventNodeEvent
-    | ServerEventAttributeUpdated
-    | ServerEventServerShutdown
-    | ServerEventEndpointAdded
-    | ServerEventEndpointRemoved;
-}
+export type EventMessage = ServerEventNodeAdded | ServerEventNodeUpdated | ServerEventNodeRemoved | ServerEventNodeEvent | ServerEventAttributeUpdated | ServerEventServerShutdown | ServerEventEndpointAdded | ServerEventEndpointRemoved
+
 
 export interface ResultMessageBase {
   message_id: string;

--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -306,8 +306,8 @@ class MatterClient:
         mac_address = None
         attribute = Clusters.GeneralDiagnostics.Attributes.NetworkInterfaces
         network_interface: Clusters.GeneralDiagnostics.Structs.NetworkInterface
-        for network_interface in node.get_attribute_value(
-            0, cluster=None, attribute=attribute
+        for network_interface in (
+            node.get_attribute_value(0, cluster=None, attribute=attribute) or []
         ):
             # ignore invalid/non-operational interfaces
             if not network_interface.isOperational:
@@ -332,6 +332,11 @@ class MatterClient:
                 continue
             mac_address = convert_mac_address(network_interface.hardwareAddress)
             break
+        else:
+            self.logger.warning(
+                "Could not determine network_interface info for Node %s, "
+                "is it missing the GeneralDiagnostics/NetworkInterfaces Attribute?"
+            )
         # get thread/wifi specific info
         node_type = NodeType.UNKNOWN
         network_name = None

--- a/matter_server/common/models.py
+++ b/matter_server/common/models.py
@@ -47,6 +47,7 @@ class APICommand(str, Enum):
     WRITE_ATTRIBUTE = "write_attribute"
     PING_NODE = "ping_node"
     GET_NODE_IP_ADRESSES = "get_node_ip_addresses"
+    IMPORT_TEST_NODE = "import_test_node"
 
 
 EventCallBackType = Callable[[EventType, Any], None]

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -29,6 +29,7 @@ from matter_server.server.helpers.attributes import parse_attributes_from_read_r
 from matter_server.server.helpers.utils import ping_ip
 
 from ..common.errors import (
+    InvalidArguments,
     NodeCommissionFailed,
     NodeInterviewFailed,
     NodeNotExists,
@@ -36,6 +37,7 @@ from ..common.errors import (
     NodeNotResolving,
 )
 from ..common.helpers.api import api_command
+from ..common.helpers.json import JSON_DECODE_EXCEPTIONS, json_loads
 from ..common.helpers.util import (
     create_attribute_path_from_attribute,
     dataclass_from_dict,
@@ -78,6 +80,7 @@ FALLBACK_NODE_SCANNER_INTERVAL = 1800
 MDNS_TYPE_OPERATIONAL_NODE = "_matter._tcp.local."
 MDNS_TYPE_COMMISSIONABLE_NODE = "_matterc._udp.local."
 
+TEST_NODE_START = 900000
 
 ROUTING_ROLE_ATTRIBUTE_PATH = create_attribute_path_from_attribute(
     0, Clusters.ThreadNetworkDiagnostics.Attributes.RoutingRole
@@ -142,7 +145,6 @@ class MatterDeviceController:
         orphaned_nodes: set[str] = set()
         for node_id_str, node_dict in nodes.items():
             node_id = int(node_id_str)
-            is_test_node = node_id >= 900000
             if node_dict is None:
                 # Non-initialized (left-over) node from a failed commissioning attempt.
                 # NOTE: This code can be removed in a future version
@@ -167,8 +169,7 @@ class MatterDeviceController:
                     interview_version=0,
                 )
             # always mark node as unavailable at startup until subscriptions are ready
-            # with the exception of manually loaded testnodes
-            node.available = is_test_node
+            node.available = False
             self._nodes[node_id] = node
         # cleanup orhpaned nodes from storage
         for node_id_str in orphaned_nodes:
@@ -504,6 +505,14 @@ class MatterDeviceController:
         if self.chip_controller is None:
             raise RuntimeError("Device Controller not initialized.")
 
+        if node_id >= TEST_NODE_START:
+            LOGGER.info(
+                "interview_node called for test node %s",
+                node_id,
+            )
+            self.server.signal_event(EventType.NODE_UPDATED, self._nodes[node_id])
+            return
+
         try:
             LOGGER.info("Interviewing node: %s", node_id)
             async with self._get_node_lock(node_id):
@@ -569,6 +578,18 @@ class MatterDeviceController:
         cluster_cls: Cluster = ALL_CLUSTERS[cluster_id]
         command_cls = getattr(cluster_cls.Commands, command_name)
         command = dataclass_from_dict(command_cls, payload, allow_sdk_types=True)
+        if node_id >= TEST_NODE_START:
+            LOGGER.info(
+                "send_device_command called for test node %s on endpoint_id: %s - "
+                "cluster_id: %s - command_name: %s - payload: %s\n%s",
+                node_id,
+                endpoint_id,
+                cluster_id,
+                command_name,
+                payload,
+                command,
+            )
+            return None
         async with self._get_node_lock(node_id):
             return await self.chip_controller.SendCommand(
                 nodeid=node_id,
@@ -596,6 +617,17 @@ class MatterDeviceController:
         if TYPE_CHECKING:
             assert self.server.loop
             assert self.chip_controller
+
+        if node_id >= TEST_NODE_START:
+            LOGGER.info(
+                "read_attribute called for test node %s on path: %s - fabric_filtered: %s",
+                node_id,
+                attribute_path,
+                fabric_filtered,
+            )
+            if attribute_path in self._nodes[node_id].attributes:
+                return {attribute_path: self._nodes[node_id].attributes[attribute_path]}
+            return {}
 
         future = self.server.loop.create_future()
         device = await self._resolve_node(node_id)
@@ -644,6 +676,15 @@ class MatterDeviceController:
             value_type=attribute.attribute_type.Type,
             allow_sdk_types=True,
         )
+        if node_id >= TEST_NODE_START:
+            LOGGER.info(
+                "write_attribute called for test node %s on path %s - value %s\n%s",
+                node_id,
+                attribute_path,
+                value,
+                attribute,
+            )
+            return None
         async with self._get_node_lock(node_id):
             return await self.chip_controller.WriteAttribute(
                 nodeid=node_id,
@@ -672,11 +713,13 @@ class MatterDeviceController:
             DATA_KEY_NODES,
             subkey=str(node_id),
         )
+
         LOGGER.info("Node ID %s successfully removed from Matter server.", node_id)
 
         self.server.signal_event(EventType.NODE_REMOVED, node_id)
 
-        assert node is not None
+        if node is None or node_id >= TEST_NODE_START:
+            return
 
         attribute_path = create_attribute_path_from_attribute(
             0,
@@ -734,6 +777,8 @@ class MatterDeviceController:
     async def ping_node(self, node_id: int, attempts: int = 1) -> NodePingResult:
         """Ping node on the currently known IP-adress(es)."""
         result: NodePingResult = {}
+        if node_id >= TEST_NODE_START:
+            return {"0.0.0.0": True, "0000:1111:2222:3333:4444": True}
         node = self._nodes.get(node_id)
         if node is None:
             raise NodeNotExists(
@@ -820,6 +865,28 @@ class MatterDeviceController:
         # cache this info for later use
         self._last_known_ip_addresses[node_id] = ip_adresses
         return ip_adresses if scoped else [x.split("%")[0] for x in ip_adresses]
+
+    @api_command(APICommand.IMPORT_TEST_NODE)
+    async def import_test_node(self, dump: str) -> None:
+        """Import test node(s) from a HA or Matter server diagnostics dump."""
+        try:
+            dump_data = cast(dict, json_loads(dump))
+        except JSON_DECODE_EXCEPTIONS as err:
+            raise InvalidArguments("Invalid json") from err
+        # dump can either be a single dump or a full dump with multiple nodes
+        dump_nodes: list[dict[str, Any]]
+        if "node" in dump_data["data"]:
+            dump_nodes = [dump_data["data"]["node"]]
+        else:
+            dump_nodes = dump_data["data"]["server"]["nodes"]
+        # node ids > 900000 are reserved for test nodes
+        next_test_node_id = max(*(x for x in self._nodes), TEST_NODE_START) + 1
+        for node_dict in dump_nodes:
+            node = dataclass_from_dict(MatterNodeData, node_dict, strict=True)
+            node.node_id = next_test_node_id
+            next_test_node_id += 1
+            self._nodes[node.node_id] = node
+            self.server.signal_event(EventType.NODE_ADDED, node)
 
     async def _subscribe_node(self, node_id: int) -> None:
         """
@@ -1344,6 +1411,8 @@ class MatterDeviceController:
         """Schedule the write of the current node state to persistent storage."""
         if node_id not in self._nodes:
             return  # guard
+        if node_id >= TEST_NODE_START:
+            return  # test nodes are stored in memory only
         node = self._nodes[node_id]
         self.server.storage.set(
             DATA_KEY_NODES,

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -141,6 +141,7 @@ class MatterDeviceController:
         orphaned_nodes: set[str] = set()
         for node_id_str, node_dict in nodes.items():
             node_id = int(node_id_str)
+            is_test_node = node_id >= 900000
             if node_dict is None:
                 # Non-initialized (left-over) node from a failed commissioning attempt.
                 # NOTE: This code can be removed in a future version
@@ -165,7 +166,8 @@ class MatterDeviceController:
                     interview_version=0,
                 )
             # always mark node as unavailable at startup until subscriptions are ready
-            node.available = False
+            # with the exception of manually loaded testnodes
+            node.available = is_test_node
             self._nodes[node_id] = node
         # cleanup orhpaned nodes from storage
         for node_id_str in orphaned_nodes:

--- a/matter_server/server/storage.py
+++ b/matter_server/server/storage.py
@@ -87,9 +87,9 @@ class StorageController:
         if subkey:
             # we provide support for (1-level) nested dict
             self._data.setdefault(key, {})
-            self._data[key].pop(subkey)
+            self._data[key].pop(subkey, None)
         else:
-            self._data.pop(key)
+            self._data.pop(key, None)
         self.save(True)
 
     def __getitem__(self, key: str) -> Any:


### PR DESCRIPTION
This adds support to both the backend, client and the dashboard to import test nodes from a HA diagnostics dump.
This makes it easier to debug (device)specific issues and extending device type support.

- You can import a diagnostics file from the builtin dashboard
- It takes both a full (multi node) dump from the config entry and a single node dump
- the test nodes are also available in the client so you can debug it in HA
- actions performed on one of the test nodes are verbosely logged
- removing test nodes can be done by a regular remove command or restarting the server
- testnodes are not persisted on storage, they're memory only.