### PR TITLE
Allow the dashboard to be hosted in ingress

### DIFF
--- a/dashboard/src/entrypoint/main.ts
+++ b/dashboard/src/entrypoint/main.ts
@@ -5,11 +5,7 @@ async function main() {
 
   let url = "";
   // Detect if we're running in the (production) webserver included in the matter server or not.
-  if (location.href.includes(":5580")) {
-    // production server running inside the matter server
-    // Turn httpX url into wsX url and append "/ws"
-    url = "ws" + new URL("./ws", location.href).toString().substring(4);
-  } else {
+  if (location.href.includes(":5010")) {
     // development server, ask for url to matter server
     let storageUrl = localStorage.getItem("matterURL");
     if (!storageUrl) {
@@ -24,6 +20,11 @@ async function main() {
       localStorage.setItem("matterURL", storageUrl);
     }
     url = storageUrl;
+  }
+  else {
+    // assume production server running inside the matter server
+    // Turn httpX url into wsX url and append "/ws"
+    url = "ws" + new URL("./ws", location.href).toString().substring(4);
   }
 
   const client = new MatterClient(url);

--- a/dashboard/src/entrypoint/main.ts
+++ b/dashboard/src/entrypoint/main.ts
@@ -24,7 +24,10 @@ async function main() {
   else {
     // assume production server running inside the matter server
     // Turn httpX url into wsX url and append "/ws"
-    url = "ws" + new URL("./ws", location.href).toString().substring(4);
+    let baseUrl = window.location.origin + window.location.pathname;
+    if (baseUrl.endsWith('/')) { baseUrl = baseUrl.slice(0, -1); }
+    url = baseUrl.replace('http', 'ws') + '/ws';
+    console.log(`Connecting to Matter Server API using url: ${url}`);
   }
 
   const client = new MatterClient(url);


### PR DESCRIPTION
Swap the check around so we assume a production server when we don't detect the dev server port.
This is (still) just a simple approach without actually connecting if there's a server alive. Good enough for now.

