### PR TITLE
Skip unneeded dataclass conversion in storage

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -39,7 +39,6 @@ from ..common.helpers.api import api_command
 from ..common.helpers.util import (
     create_attribute_path_from_attribute,
     dataclass_from_dict,
-    dataclass_to_dict,
     parse_attribute_path,
     parse_value,
 )
@@ -1349,7 +1348,7 @@ class MatterDeviceController:
         node = self._nodes[node_id]
         self.server.storage.set(
             DATA_KEY_NODES,
-            value=dataclass_to_dict(node),
+            value=node,
             subkey=str(node_id),
             force=force,
         )


### PR DESCRIPTION
We changed our datamodel a while ago and we only store the raw node attributes now so we don't have to deal with the custom dataclasses at all serverside. The MatterNode object is a basic dataclass that is perfectly serializable by orjson directly. Skip the unneeded dataclass_to dict to store the MatterNode object to persistent storage.

supersedes https://github.com/home-assistant-libs/python-matter-server/pull/653