### PR TITLE
Drop Python safety module from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ test = [
   "pytest-aiohttp==1.0.5",
   "pytest-cov==5.0.0",
   "ruff==0.3.4",
-  "safety==3.0.1",
   "tomli==2.0.1",
 ]
 


### PR DESCRIPTION
It seems unused, so let's drop it.