### PR TITLE
Some small tweaks to the subscripions logic

### DIFF
--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -18,6 +18,7 @@ from matter_server.common.errors import ERROR_MAP, NodeNotExists
 from ..common.helpers.util import (
     convert_ip_address,
     convert_mac_address,
+    create_attribute_path_from_attribute,
     dataclass_from_dict,
     dataclass_to_dict,
 )
@@ -218,6 +219,16 @@ class MatterClient:
         """
 
         node = self.get_node(node_id)
+
+        # refresh node's fabrics if the node is available so w ehave the latest info
+        if node.available:
+            await self.refresh_attribute(
+                node_id,
+                create_attribute_path_from_attribute(
+                    0, Clusters.OperationalCredentials.Attributes.Fabrics
+                ),
+            )
+
         fabrics: list[
             Clusters.OperationalCredentials.Structs.FabricDescriptorStruct
         ] = node.get_attribute_value(

--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -220,7 +220,7 @@ class MatterClient:
 
         node = self.get_node(node_id)
 
-        # refresh node's fabrics if the node is available so w ehave the latest info
+        # refresh node's fabrics if the node is available so we have the latest info
         if node.available:
             await self.refresh_attribute(
                 node_id,

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -66,7 +66,7 @@ DATA_KEY_NODES = "nodes"
 DATA_KEY_LAST_NODE_ID = "last_node_id"
 
 LOGGER = logging.getLogger(__name__)
-NODE_SUBSCRIPTION_CEILING_WIFI = 30
+NODE_SUBSCRIPTION_CEILING_WIFI = 60
 NODE_SUBSCRIPTION_CEILING_THREAD = 60
 NODE_SUBSCRIPTION_CEILING_BATTERY_POWERED = 600
 MAX_COMMISSION_RETRIES = 3
@@ -1090,8 +1090,6 @@ class MatterDeviceController:
                 events=[("*", 1)],
                 returnClusterObject=False,
                 reportInterval=(interval_floor, interval_ceiling),
-                fabricFiltered=False,
-                keepSubscriptions=True,
                 autoResubscribe=True,
             )
 


### PR DESCRIPTION
While we're still hunting down the cause for the continuous "subscription failed with Error: 50, re-subscribing in 0 ms" errors where the subscription of a node suddenly gets lost with no reason, I found a few tweaks. Not really solutions to the issue but still good to apply.

- Increase subscription ceiling for WiFi devices to 60 seconds (same as mains powered thread devices) as we see the error mostly for WiFi devices.

- Remove keepSubscriptions on the subscription itself as its kind of redundant with the autoResubscribe and saves a bit of stress on the device itself (hopefully) - though this is still very unclear.

- Remove fabricFiltered=False (so reinstate it being set to True) on the subscription itself as the only reason we were doing that is to have an up to date list of fabrics at all times. Removing it in the sub saves a little bit of stress on the device.

- Refresh the node's fabrics in the diagnostics itself to ensure we have the latest info as an alternative for having the fabricFiltered=False in the sub.