### PR TITLE
Handle value specified as bytes received as integer

### DIFF
--- a/matter_server/common/helpers/util.py
+++ b/matter_server/common/helpers/util.py
@@ -220,6 +220,9 @@ def parse_value(
             # unfortunately sometimes the data is malformed
             # as it is not super important we ignore it (for now)
             return b""
+    # handle value typed/specified as bytes but parsed as integer in the tlv parser
+    if value_type is bytes and isinstance(value, int):
+        return bytes(value)
 
     # Matter SDK specific types
     if value_type is uint and (

--- a/matter_server/common/helpers/util.py
+++ b/matter_server/common/helpers/util.py
@@ -222,7 +222,7 @@ def parse_value(
             return b""
     # handle value typed/specified as bytes but parsed as integer in the tlv parser
     if value_type is bytes and isinstance(value, int):
-        return bytes(value)
+        return value.to_bytes(4, "big")
 
     # Matter SDK specific types
     if value_type is uint and (

--- a/matter_server/common/helpers/util.py
+++ b/matter_server/common/helpers/util.py
@@ -220,9 +220,13 @@ def parse_value(
             # unfortunately sometimes the data is malformed
             # as it is not super important we ignore it (for now)
             return b""
-    # handle value typed/specified as bytes but parsed as integer in the tlv parser
-    if value_type is bytes and isinstance(value, int):
-        return value.to_bytes(4, "big")
+
+    # handle NOCStruct.noc which is typed/specified as bytes but parsed
+    # as integer in the tlv parser somehow.
+    # https://github.com/home-assistant/core/issues/113279
+    # https://github.com/home-assistant/core/issues/116304
+    if name == "NOCStruct.noc" and not isinstance(value, bytes):
+        return b""
 
     # Matter SDK specific types
     if value_type is uint and (

--- a/tests/common/test_parser.py
+++ b/tests/common/test_parser.py
@@ -107,6 +107,6 @@ def test_dataclass_from_dict():
     # test extra keys not silently ignored in strict mode
     with pytest.raises(KeyError):
         dataclass_from_dict(BasicModel, raw2, strict=True)
-    # test int gets converted to bytes
-    res = parse_value("int_value_that_should_be_bytes", 5, bytes)
-    assert res == b"\x00\x00\x00\x05"
+    # test NOCStruct.noc edge case
+    res = parse_value("NOCStruct.noc", 5, bytes)
+    assert res == b""

--- a/tests/common/test_parser.py
+++ b/tests/common/test_parser.py
@@ -77,7 +77,6 @@ def test_dataclass_from_dict():
     raw["b"] = 2
     res = dataclass_from_dict(BasicModel, raw)
     assert res.b == 2.0
-
     # test datetime string
     assert isinstance(res.f, datetime.datetime)
     assert res.f.month == 12

--- a/tests/common/test_parser.py
+++ b/tests/common/test_parser.py
@@ -110,4 +110,4 @@ def test_dataclass_from_dict():
         dataclass_from_dict(BasicModel, raw2, strict=True)
     # test int gets converted to bytes
     res = parse_value("int_value_that_should_be_bytes", 5, bytes)
-    assert isinstance(res, bytes)
+    assert res == b"\x00\x00\x00\x05"

--- a/tests/common/test_parser.py
+++ b/tests/common/test_parser.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 import pytest
 
-from matter_server.common.helpers.util import dataclass_from_dict
+from matter_server.common.helpers.util import dataclass_from_dict, parse_value
 
 
 class MatterIntEnum(IntEnum):
@@ -77,6 +77,7 @@ def test_dataclass_from_dict():
     raw["b"] = 2
     res = dataclass_from_dict(BasicModel, raw)
     assert res.b == 2.0
+
     # test datetime string
     assert isinstance(res.f, datetime.datetime)
     assert res.f.month == 12
@@ -107,3 +108,6 @@ def test_dataclass_from_dict():
     # test extra keys not silently ignored in strict mode
     with pytest.raises(KeyError):
         dataclass_from_dict(BasicModel, raw2, strict=True)
+    # test int gets converted to bytes
+    res = parse_value("int_value_that_should_be_bytes", 5, bytes)
+    assert isinstance(res, bytes)


### PR DESCRIPTION
Somehow some devices send some values (such as the Noc) as integer instead of bytes so our parser chokes on that.
Not sure if this is device related or somehow the tlv parser doesnt handle it but its not super big deal.
Convert it so parsing the values doesnt crash in the client.

Fixes https://github.com/home-assistant/core/issues/116304
Fixes https://github.com/home-assistant/core/issues/113279