### PR TITLE
Pin Python Matter server dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,12 +15,12 @@ classifiers = [
   "Topic :: Home Automation",
 ]
 dependencies = [
-  "aiohttp",
-  "aiorun",
-  "async-timeout",
-  "coloredlogs",
-  "dacite",
-  "orjson",
+  "aiohttp==3.9.5",
+  "aiorun==2023.7.2",
+  "async-timeout==4.0.3",
+  "coloredlogs==15.0.1",
+  "dacite==1.8.1",
+  "orjson==3.9.15",
   "home-assistant-chip-clusters==2024.4.1",
 ]
 description = "Python Matter WebSocket Server"


### PR DESCRIPTION
Pin the Python Matter server dependencies to specific versions. This avoids surprises. Specifically, also pin orjson to 3.9.15 as newer versions seem to crash on some platforms (observed in the Home Assistant Core project).