### PR TITLE
Use ping binary for IPv6

### DIFF
--- a/matter_server/server/helpers/utils.py
+++ b/matter_server/server/helpers/utils.py
@@ -16,7 +16,7 @@ async def ping_ip(ip_address: str, timeout: int = 2, attempts: int = 1) -> bool:
         # macos does not have support for -W (timeout) on ping6 ?!
         cmd = f"ping6 -c 1 {ip_address}"
     elif is_ipv6:
-        cmd = f"ping6 -c 1 -W {timeout} {ip_address}"
+        cmd = f"ping -6 -c 1 -W {timeout} {ip_address}"
     else:
         cmd = f"ping -c 1 -W {timeout} {ip_address}"
     while attempts:


### PR DESCRIPTION
On Linux, the ping binary can be used for IPv4 or IPv6. In fact, on distributions which have ping6 it is just a symlink to ping. But not all Distributions seem to have the symlink. So rather use the regular ping binary and explicitly specify the IP version.