### PR TITLE
Fix imports at runtime

### DIFF
--- a/matter_server/common/models.py
+++ b/matter_server/common/models.py
@@ -4,11 +4,9 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from datetime import datetime  # noqa: TCH003
 from enum import Enum
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from datetime import datetime
+from typing import Any
 
 # Enums and constants
 

--- a/matter_server/server/stack.py
+++ b/matter_server/server/stack.py
@@ -4,7 +4,7 @@ import logging
 import os
 from typing import TYPE_CHECKING
 
-from chip.CertificateAuthority import CertificateAuthorityManager
+import chip.CertificateAuthority
 from chip.ChipStack import ChipStack
 import chip.logging
 from chip.logging import (
@@ -112,8 +112,8 @@ class MatterStack:
 
         # Initialize Certificate Authority Manager
         # yeah this is a bit weird just to prevent a circular import in the underlying SDK
-        self.certificate_authority_manager: CertificateAuthorityManager = (
-            CertificateAuthorityManager(chipStack=self._chip_stack)
+        self.certificate_authority_manager: chip.CertificateAuthority.CertificateAuthorityManager = chip.CertificateAuthority.CertificateAuthorityManager(
+            chipStack=self._chip_stack
         )
         self.certificate_authority_manager.LoadAuthoritiesFromStorage()
 

--- a/matter_server/server/stack.py
+++ b/matter_server/server/stack.py
@@ -4,6 +4,7 @@ import logging
 import os
 from typing import TYPE_CHECKING
 
+from chip.CertificateAuthority import CertificateAuthorityManager
 from chip.ChipStack import ChipStack
 import chip.logging
 from chip.logging import (
@@ -17,7 +18,7 @@ from chip.logging.types import LogRedirectCallback_t
 import chip.native
 
 if TYPE_CHECKING:
-    from chip.CertificateAuthority import CertificateAuthorityManager
+    from chip.FabricAdmin import FabricAdmin
 
     from .server import MatterServer
 
@@ -112,9 +113,7 @@ class MatterStack:
         # Initialize Certificate Authority Manager
         # yeah this is a bit weird just to prevent a circular import in the underlying SDK
         self.certificate_authority_manager: CertificateAuthorityManager = (
-            chip.CertificateAuthority.CertificateAuthorityManager(
-                chipStack=self._chip_stack
-            )
+            CertificateAuthorityManager(chipStack=self._chip_stack)
         )
         self.certificate_authority_manager.LoadAuthoritiesFromStorage()
 
@@ -131,7 +130,7 @@ class MatterStack:
                 admin.vendorId == server.vendor_id
                 and admin.fabricId == server.fabric_id
             ):
-                self.fabric_admin = admin
+                self.fabric_admin: FabricAdmin = admin
                 break
         else:
             self.fabric_admin = cert_auth.NewFabricAdmin(


### PR DESCRIPTION
It seems that the linter changes introduced in #687 broke some imports necessary at runtime. Make sure both, runtime and linter are happy.