### PR TITLE
Log effective reporting interval

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -1111,7 +1111,16 @@ class MatterDeviceController:
         # pylint: disable=protected-access
         tlv_attributes = sub._readTransaction._cache.attributeTLVCache
         node.attributes.update(parse_attributes_from_read_result(tlv_attributes))
-        node_logger.info("Subscription succeeded")
+
+        report_interval_floor, report_interval_ceiling = (
+            sub.GetReportingIntervalsSeconds()
+        )
+        node_logger.info(
+            "Subscription succeeded with report interval [%d, %d]",
+            report_interval_floor,
+            report_interval_ceiling,
+        )
+
         self._node_last_seen[node_id] = time.time()
         self.server.signal_event(EventType.NODE_UPDATED, node)
 


### PR DESCRIPTION
We request a certain report interval, but some devices (especially ICD SIT, Intermittently Connected Devices with Short Idle Time) may report with a higher ceiling because these devices might want to sleep for longer. Logging this information can be helpful to debug issues with such deviecs.