### PR TITLE
Update to Matter SDK wheels 2024.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "async-timeout",
   "coloredlogs",
   "orjson",
-  "home-assistant-chip-clusters==2024.4.1",
+  "home-assistant-chip-clusters==2024.5.0",
 ]
 description = "Python Matter WebSocket Server"
 license = {text = "Apache-2.0"}
@@ -39,7 +39,7 @@ server = [
   "cryptography==42.0.7",
   "orjson==3.9.15",
   "zeroconf==0.132.2",
-  "home-assistant-chip-core==2024.4.1",
+  "home-assistant-chip-core==2024.5.0",
 ]
 test = [
   "codespell==2.2.6",


### PR DESCRIPTION
Matter SDK/CHIP wheels [2024.5.0 release notes](https://github.com/home-assistant-libs/chip-wheels/releases/tag/2024.5.0). 