### PR TITLE
Use mkdirs for paa_root_certs as the intermediate directories do not exist

### DIFF
--- a/matter_server/server/helpers/paa_certificates.py
+++ b/matter_server/server/helpers/paa_certificates.py
@@ -203,7 +203,7 @@ async def fetch_certificates(
                 if not path.is_dir():
                     path.unlink()
         else:
-            paa_root_cert_dir.mkdir()
+            paa_root_cert_dir.mkdirs()
         return None
 
     last_fetch = await loop.run_in_executor(

--- a/matter_server/server/helpers/paa_certificates.py
+++ b/matter_server/server/helpers/paa_certificates.py
@@ -203,7 +203,7 @@ async def fetch_certificates(
                 if not path.is_dir():
                     path.unlink()
         else:
-            paa_root_cert_dir.mkdirs()
+            paa_root_cert_dir.mkdir(parents=True)
         return None
 
     last_fetch = await loop.run_in_executor(


### PR DESCRIPTION
Fixes https://github.com/home-assistant-libs/python-matter-server/issues/704