### PR TITLE
Pass PAA certificate path by default to data directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,5 @@ RUN \
 VOLUME ["/data"]
 EXPOSE 5580
 
-ENTRYPOINT ["matter-server", "--storage-path", "/data"]
+ENTRYPOINT [ "matter-server" ]
+CMD [ "--storage-path", "/data", "--paa-root-cert-dir", "/data/credentials" ]


### PR DESCRIPTION
We already passed /data as data directory so far. Let's move the PAA credentials to that location as well so they persist over container restarts. This avoids unnecessary PAA certificates downloads for container installations.