### PR TITLE
Add software update capability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN \
 
 ARG PYTHON_MATTER_SERVER
 
-ENV chip_example_url "https://github.com/home-assistant-libs/matter-linux-ota-provider/releases/download/2024.7.0"
+ENV chip_example_url "https://github.com/home-assistant-libs/matter-linux-ota-provider/releases/download/2024.7.1"
 ARG TARGETPLATFORM
 
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN \
     set -x \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
+        curl \
         libuv1 \
         zlib1g \
         libjson-c5 \
@@ -24,6 +25,21 @@ RUN \
         /usr/src/*
 
 ARG PYTHON_MATTER_SERVER
+
+ENV chip_example_url "https://github.com/agners/matter-linux-example-apps/releases/download/v1.3.0.0"
+ARG TARGETPLATFORM
+
+RUN \
+    set -x \
+    && echo "${TARGETPLATFORM}" \
+    && if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then \
+        curl -Lo /usr/local/bin/chip-ota-provider-app "${chip_example_url}/chip-ota-provider-app-x86-64"; \
+    elif [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
+        curl -Lo /usr/local/bin/chip-ota-provider-app "${chip_example_url}/chip-ota-provider-app-aarch64"; \
+    else \
+        exit 1; \
+    fi \
+    && chmod +x /usr/local/bin/chip-ota-provider-app
 
 # hadolint ignore=DL3013
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN \
 
 ARG PYTHON_MATTER_SERVER
 
-ENV chip_example_url "https://github.com/agners/matter-linux-example-apps/releases/download/v1.3.0.0"
+ENV chip_example_url "https://github.com/home-assistant-libs/matter-linux-ota-provider/releases/download/2024.7.0"
 ARG TARGETPLATFORM
 
 RUN \

--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -29,6 +29,7 @@ from ..common.models import (
     EventType,
     MatterNodeData,
     MatterNodeEvent,
+    MatterSoftwareVersion,
     MessageType,
     NodePingResult,
     ResultMessageBase,
@@ -509,7 +510,7 @@ class MatterClient:
         """Interview a node."""
         await self.send_command(APICommand.INTERVIEW_NODE, node_id=node_id)
 
-    async def check_node_update(self, node_id: int) -> dict[str, Any]:
+    async def check_node_update(self, node_id: int) -> MatterSoftwareVersion | None:
         """Check Node for updates.
 
         Return a dict with the available update information. Most notable
@@ -518,10 +519,11 @@ class MatterClient:
 
         The "softwareVersionString" is a human friendly version string.
         """
-        node_update = await self.send_command(
-            APICommand.CHECK_NODE_UPDATE, node_id=node_id
-        )
-        return cast(dict[str, Any], node_update)
+        data = await self.send_command(APICommand.CHECK_NODE_UPDATE, node_id=node_id)
+        if data is None:
+            return None
+
+        return dataclass_from_dict(MatterSoftwareVersion, data)
 
     async def update_node(
         self,

--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -519,7 +519,7 @@ class MatterClient:
 
         The "softwareVersionString" is a human friendly version string.
         """
-        data = await self.send_command(APICommand.CHECK_NODE_UPDATE, node_id=node_id)
+        data = await self.send_command(APICommand.CHECK_NODE_UPDATE, node_id=node_id, require_schema=10)
         if data is None:
             return None
 
@@ -532,7 +532,10 @@ class MatterClient:
     ) -> None:
         """Start node update to a particular version."""
         await self.send_command(
-            APICommand.UPDATE_NODE, node_id=node_id, software_version=software_version
+            APICommand.UPDATE_NODE,
+            node_id=node_id,
+            software_version=software_version,
+            require_schema=10
         )
 
     def _prepare_message(

--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -523,7 +523,11 @@ class MatterClient:
         )
         return cast(dict[str, Any], node_update)
 
-    async def update_node(self, node_id: int, software_version: int) -> None:
+    async def update_node(
+        self,
+        node_id: int,
+        software_version: int | str,
+    ) -> None:
         """Start node update to a particular version."""
         await self.send_command(
             APICommand.UPDATE_NODE, node_id=node_id, software_version=software_version

--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -519,7 +519,9 @@ class MatterClient:
 
         The "softwareVersionString" is a human friendly version string.
         """
-        data = await self.send_command(APICommand.CHECK_NODE_UPDATE, node_id=node_id, require_schema=10)
+        data = await self.send_command(
+            APICommand.CHECK_NODE_UPDATE, node_id=node_id, require_schema=10
+        )
         if data is None:
             return None
 
@@ -535,7 +537,7 @@ class MatterClient:
             APICommand.UPDATE_NODE,
             node_id=node_id,
             software_version=software_version,
-            require_schema=10
+            require_schema=10,
         )
 
     def _prepare_message(

--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -509,6 +509,26 @@ class MatterClient:
         """Interview a node."""
         await self.send_command(APICommand.INTERVIEW_NODE, node_id=node_id)
 
+    async def check_node_update(self, node_id: int) -> dict[str, Any]:
+        """Check Node for updates.
+
+        Return a dict with the available update information. Most notable
+        "softwareVersion" contains the integer value of the update version which then
+        can be used for the update_node command to trigger the update.
+
+        The "softwareVersionString" is a human friendly version string.
+        """
+        node_update = await self.send_command(
+            APICommand.CHECK_NODE_UPDATE, node_id=node_id
+        )
+        return cast(dict[str, Any], node_update)
+
+    async def update_node(self, node_id: int, software_version: int) -> None:
+        """Start node update to a particular version."""
+        await self.send_command(
+            APICommand.UPDATE_NODE, node_id=node_id, software_version=software_version
+        )
+
     def _prepare_message(
         self,
         command: str,

--- a/matter_server/common/const.py
+++ b/matter_server/common/const.py
@@ -2,7 +2,7 @@
 
 # schema version is used to determine compatibility between server and client
 # bump schema if we add new features and/or make other (breaking) changes
-SCHEMA_VERSION = 9
+SCHEMA_VERSION = 10
 
 
 VERBOSE_LOG_LEVEL = 5

--- a/matter_server/common/errors.py
+++ b/matter_server/common/errors.py
@@ -77,6 +77,18 @@ class InvalidCommand(MatterError):
     error_code = 9
 
 
+class UpdateCheckError(MatterError):
+    """Error raised when there was an error during searching for updates."""
+
+    error_code = 10
+
+
+class UpdateError(MatterError):
+    """Error raised when there was an error during applying updates."""
+
+    error_code = 11
+
+
 def exception_from_error_code(error_code: int) -> type[MatterError]:
     """Return correct Exception class from error_code."""
     return ERROR_MAP.get(error_code, MatterError)

--- a/matter_server/common/models.py
+++ b/matter_server/common/models.py
@@ -47,6 +47,7 @@ class APICommand(str, Enum):
     PING_NODE = "ping_node"
     GET_NODE_IP_ADDRESSES = "get_node_ip_addresses"
     IMPORT_TEST_NODE = "import_test_node"
+    CHECK_NODE_UPDATE = "check_node_update"
     UPDATE_NODE = "update_node"
 
 

--- a/matter_server/common/models.py
+++ b/matter_server/common/models.py
@@ -47,6 +47,7 @@ class APICommand(str, Enum):
     PING_NODE = "ping_node"
     GET_NODE_IP_ADDRESSES = "get_node_ip_addresses"
     IMPORT_TEST_NODE = "import_test_node"
+    UPDATE_NODE = "update_node"
 
 
 EventCallBackType = Callable[[EventType, Any], None]

--- a/matter_server/common/models.py
+++ b/matter_server/common/models.py
@@ -211,3 +211,21 @@ class CommissioningParameters:
     setup_pin_code: int
     setup_manual_code: str
     setup_qr_code: str
+
+
+@dataclass
+class MatterSoftwareVersion:
+    """Representation of a Matter software version. Return by the check_node_update command.
+
+    This holds Matter software version information similar to what is available from the CSA DCL.
+    https://on.dcl.csa-iot.org/#/Query/ModelVersion.
+    """
+
+    vid: int
+    pid: int
+    software_version: int
+    software_version_string: str
+    firmware_information: str | None
+    min_applicable_software_version: int
+    max_applicable_software_version: int
+    release_notes_url: str | None

--- a/matter_server/common/models.py
+++ b/matter_server/common/models.py
@@ -229,3 +229,30 @@ class MatterSoftwareVersion:
     min_applicable_software_version: int
     max_applicable_software_version: int
     release_notes_url: str | None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> MatterSoftwareVersion:
+        """Initialize from dict."""
+        return cls(
+            vid=data["vid"],
+            pid=data["pid"],
+            software_version=data["software_version"],
+            software_version_string=data["software_version_string"],
+            firmware_information=data["firmware_information"],
+            min_applicable_software_version=data["min_applicable_software_version"],
+            max_applicable_software_version=data["max_applicable_software_version"],
+            release_notes_url=data["release_notes_url"],
+        )
+
+    def as_dict(self) -> dict:
+        """Return dict representation of the object."""
+        return {
+            "vid": self.vid,
+            "pid": self.pid,
+            "software_version": self.software_version,
+            "software_version_string": self.software_version_string,
+            "firmware_information": self.firmware_information,
+            "min_applicable_software_version": self.min_applicable_software_version,
+            "max_applicable_software_version": self.max_applicable_software_version,
+            "release_notes_url": self.release_notes_url,
+        }

--- a/matter_server/common/models.py
+++ b/matter_server/common/models.py
@@ -213,6 +213,14 @@ class CommissioningParameters:
     setup_qr_code: str
 
 
+class UpdateSource(Enum):
+    """Enum with possible sources for a software update."""
+
+    MAIN_NET_DCL = "main-net-dcl"
+    TEST_NET_DCL = "test-net-dcl"
+    LOCAL = "local"
+
+
 @dataclass
 class MatterSoftwareVersion:
     """Representation of a Matter software version. Return by the check_node_update command.
@@ -229,6 +237,7 @@ class MatterSoftwareVersion:
     min_applicable_software_version: int
     max_applicable_software_version: int
     release_notes_url: str | None
+    update_source: UpdateSource
 
     @classmethod
     def from_dict(cls, data: dict) -> MatterSoftwareVersion:
@@ -242,6 +251,7 @@ class MatterSoftwareVersion:
             min_applicable_software_version=data["min_applicable_software_version"],
             max_applicable_software_version=data["max_applicable_software_version"],
             release_notes_url=data["release_notes_url"],
+            update_source=UpdateSource(data["update_source"]),
         )
 
     def as_dict(self) -> dict:
@@ -255,4 +265,5 @@ class MatterSoftwareVersion:
             "min_applicable_software_version": self.min_applicable_software_version,
             "max_applicable_software_version": self.max_applicable_software_version,
             "release_notes_url": self.release_notes_url,
+            "update_source": str(self.update_source),
         }

--- a/matter_server/server/__main__.py
+++ b/matter_server/server/__main__.py
@@ -116,6 +116,12 @@ parser.add_argument(
     nargs="+",
     help="List of node IDs to show logs from (applies only to server logs).",
 )
+parser.add_argument(
+    "--ota-provider-dir",
+    type=str,
+    default=None,
+    help="Directory where OTA Provider stores software updates and configuration.",
+)
 
 args = parser.parse_args()
 
@@ -216,6 +222,7 @@ def main() -> None:
         args.paa_root_cert_dir,
         args.enable_test_net_dcl,
         args.bluetooth_adapter,
+        args.ota_provider_dir,
     )
 
     async def handle_stop(loop: asyncio.AbstractEventLoop) -> None:

--- a/matter_server/server/const.py
+++ b/matter_server/server/const.py
@@ -20,3 +20,5 @@ DEFAULT_PAA_ROOT_CERTS_DIR: Final[pathlib.Path] = (
     .parent.resolve()
     .joinpath("credentials/development/paa-root-certs")
 )
+
+DEFAULT_OTA_PROVIDER_DIR: Final[pathlib.Path] = pathlib.Path().cwd().joinpath("updates")

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -32,7 +32,7 @@ from matter_server.common.custom_clusters import check_polled_attributes
 from matter_server.common.models import CommissionableNodeData, CommissioningParameters
 from matter_server.server.helpers.attributes import parse_attributes_from_read_result
 from matter_server.server.helpers.utils import ping_ip
-from matter_server.server.ota.dcl import check_for_update
+from matter_server.server.ota import check_for_update
 from matter_server.server.ota.provider import ExternalOtaProvider
 from matter_server.server.sdk import ChipDeviceControllerWrapper
 

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -159,7 +159,7 @@ class MatterDeviceController:
         self._polled_attributes: dict[int, set[str]] = {}
         self._custom_attribute_poller_timer: asyncio.TimerHandle | None = None
         self._custom_attribute_poller_task: asyncio.Task | None = None
-        self._ota_provider = ExternalOtaProvider(ota_provider_dir)
+        self._ota_provider = ExternalOtaProvider(server.vendor_id, ota_provider_dir)
 
     async def initialize(self) -> None:
         """Initialize the device controller."""
@@ -932,12 +932,6 @@ class MatterDeviceController:
                 f"Software version {software_version} is not available for node {node_id}."
             )
 
-        if self.chip_controller is None:
-            raise RuntimeError("Device Controller not initialized.")
-
-        if not self._ota_provider:
-            raise UpdateError("No OTA provider found, updates not possible")
-
         if self._ota_provider.is_busy():
             raise UpdateError(
                 "No OTA provider currently busy, updates currently not possible"
@@ -948,7 +942,7 @@ class MatterDeviceController:
 
         # Make sure any previous instances get stopped
         await self._ota_provider.start_update(
-            self,
+            self._chip_device_controller,
             node_id,
         )
 

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -43,7 +43,6 @@ from ..common.errors import (
     NodeNotReady,
     NodeNotResolving,
     UpdateCheckError,
-    UpdateError,
 )
 from ..common.helpers.api import api_command
 from ..common.helpers.json import JSON_DECODE_EXCEPTIONS, json_loads
@@ -930,11 +929,6 @@ class MatterDeviceController:
         if update is None:
             raise UpdateCheckError(
                 f"Software version {software_version} is not available for node {node_id}."
-            )
-
-        if self._ota_provider.is_busy():
-            raise UpdateError(
-                "No OTA provider currently busy, updates currently not possible"
             )
 
         # Add update to the OTA provider

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -43,6 +43,7 @@ from ..common.errors import (
     NodeNotReady,
     NodeNotResolving,
     UpdateCheckError,
+    UpdateError,
 )
 from ..common.helpers.api import api_command
 from ..common.helpers.json import JSON_DECODE_EXCEPTIONS, json_loads
@@ -139,6 +140,7 @@ class MatterDeviceController:
         self._wifi_credentials_set: bool = False
         self._thread_credentials_set: bool = False
         self._nodes_in_setup: set[int] = set()
+        self._nodes_in_ota: set[int] = set()
         self._node_last_seen: dict[int, float] = {}
         self._nodes: dict[int, MatterNodeData] = {}
         self._last_known_ip_addresses: dict[int, list[str]] = {}
@@ -943,6 +945,13 @@ class MatterDeviceController:
         )
 
         try:
+            if node_id in self._nodes_in_ota:
+                raise UpdateError(
+                    f"Node {node_id} is already in the process of updating."
+                )
+
+            self._nodes_in_ota.add(node_id)
+
             # Make sure any previous instances get stopped
             node_logger.info("Starting update using OTA Provider.")
             await ota_provider.start_update(
@@ -953,6 +962,7 @@ class MatterDeviceController:
             self._attribute_update_callbacks[node_id].remove(
                 ota_provider.check_update_state
             )
+            self._nodes_in_ota.remove(node_id)
 
         return update
 

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -915,7 +915,9 @@ class MatterDeviceController:
         return await self._check_node_update(node_id)
 
     @api_command(APICommand.UPDATE_NODE)
-    async def update_node(self, node_id: int, software_version: int) -> dict | None:
+    async def update_node(
+        self, node_id: int, software_version: int | str
+    ) -> dict | None:
         """
         Update a node to a new software version.
 
@@ -945,7 +947,7 @@ class MatterDeviceController:
     async def _check_node_update(
         self,
         node_id: int,
-        requested_software_version: int | None = None,
+        requested_software_version: int | str | None = None,
     ) -> dict | None:
         node_logger = LOGGER.getChild(f"node_{node_id}")
         node = self._nodes[node_id]

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -35,7 +35,7 @@ from matter_server.common.models import (
 )
 from matter_server.server.helpers.attributes import parse_attributes_from_read_result
 from matter_server.server.helpers.utils import ping_ip
-from matter_server.server.ota import check_for_update
+from matter_server.server.ota import check_for_update, load_local_updates
 from matter_server.server.ota.provider import ExternalOtaProvider
 from matter_server.server.sdk import ChipDeviceControllerWrapper
 
@@ -168,6 +168,7 @@ class MatterDeviceController:
             await self._chip_device_controller.get_compressed_fabric_id()
         )
         self._fabric_id_hex = hex(self._compressed_fabric_id)[2:]
+        await load_local_updates(self._ota_provider_dir)
 
     async def start(self) -> None:
         """Handle logic on controller start."""

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -18,12 +18,11 @@ import time
 from typing import TYPE_CHECKING, Any, cast
 
 from chip.ChipDeviceCtrl import ChipDeviceController
-from chip.clusters import Attribute, Objects as Clusters, Types
+from chip.clusters import Attribute, Objects as Clusters
 from chip.clusters.Attribute import ValueDecodeFailure
 from chip.clusters.ClusterObjects import ALL_ATTRIBUTES, ALL_CLUSTERS, Cluster
 from chip.discovery import DiscoveryType
 from chip.exceptions import ChipStackError
-from chip.interaction_model import Status
 from zeroconf import BadTypeInNameException, IPVersion, ServiceStateChange, Zeroconf
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo, AsyncZeroconf
 
@@ -112,6 +111,12 @@ BASIC_INFORMATION_SOFTWARE_VERSION_STRING_ATTRIBUTE_PATH = (
         0, Clusters.BasicInformation.Attributes.SoftwareVersionString
     )
 )
+OTA_SOFTWARE_UPDATE_REQUESTOR_UPDATE_STATE_ATTRIBUTE_PATH = (
+    create_attribute_path_from_attribute(
+        0, Clusters.OtaSoftwareUpdateRequestor.Attributes.UpdateState
+    )
+)
+
 
 # pylint: disable=too-many-lines,too-many-instance-attributes,too-many-public-methods
 
@@ -910,83 +915,6 @@ class MatterDeviceController:
 
         return await self._check_node_update(node_id)
 
-    async def _initialize_ota_provider(self, ota_provider: ExternalOtaProvider) -> None:
-        """Commissions the OTA Provider."""
-
-        if self.chip_controller is None:
-            raise RuntimeError("Device Controller not initialized.")
-
-        # The OTA Provider has not been commissioned yet, let's do it now.
-        LOGGER.info("Commissioning the built-in OTA Provider App.")
-        try:
-            ota_provider_node = await self.commission_on_network(
-                ota_provider.get_passcode(),
-                # TODO: Filtering by long discriminator seems broken
-                # filter_type=FilterType.LONG_DISCRIMINATOR,
-                # filter=ota_provider.get_descriminator(),
-            )
-            ota_provider_node_id = ota_provider_node.node_id
-        except NodeCommissionFailed:
-            LOGGER.error("Failed to commission OTA Provider App!")
-            return
-
-        LOGGER.info(
-            "OTA Provider App commissioned with node id %d.",
-            ota_provider_node_id,
-        )
-
-        # Adjust ACL of OTA Requestor such that Node peer-to-peer communication
-        # is allowed.
-        try:
-            read_result = await self.chip_controller.ReadAttribute(
-                ota_provider_node_id, [(0, Clusters.AccessControl.Attributes.Acl)]
-            )
-            acl_list = cast(
-                list,
-                read_result[0][Clusters.AccessControl][
-                    Clusters.AccessControl.Attributes.Acl
-                ],
-            )
-
-            # Add new ACL entry...
-            acl_list.append(
-                Clusters.AccessControl.Structs.AccessControlEntryStruct(
-                    fabricIndex=1,
-                    privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kOperate,
-                    authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
-                    subjects=Types.NullValue,
-                    targets=[
-                        Clusters.AccessControl.Structs.AccessControlTargetStruct(
-                            cluster=Clusters.OtaSoftwareUpdateProvider.id,
-                            endpoint=0,
-                            deviceType=Types.NullValue,
-                        )
-                    ],
-                )
-            )
-
-            # And write. This is persistent, so only need to be done after we commissioned
-            # the OTA Provider App.
-            write_result: Attribute.AttributeWriteResult = (
-                await self.chip_controller.WriteAttribute(
-                    ota_provider_node_id,
-                    [(0, Clusters.AccessControl.Attributes.Acl(acl_list))],
-                )
-            )
-            if write_result[0].Status != Status.Success:
-                logging.error(
-                    "Failed writing adjusted OTA Provider App ACL: Status %s.",
-                    str(write_result[0].Status),
-                )
-                await self.remove_node(ota_provider_node_id)
-                raise UpdateError("Error while setting up OTA Provider.")
-        except ChipStackError as ex:
-            logging.exception("Failed adjusting OTA Provider App ACL.", exc_info=ex)
-            await self.remove_node(ota_provider_node_id)
-            raise UpdateError("Error while setting up OTA Provider.") from ex
-
-        ota_provider.set_node_id(ota_provider_node_id)
-
     @api_command(APICommand.UPDATE_NODE)
     async def update_node(self, node_id: int, software_version: int) -> dict | None:
         """
@@ -1008,48 +936,21 @@ class MatterDeviceController:
             raise RuntimeError("Device Controller not initialized.")
 
         if not self._ota_provider:
-            raise UpdateError("No OTA provider found, updates not possible.")
+            raise UpdateError("No OTA provider found, updates not possible")
+
+        if self._ota_provider.is_busy():
+            raise UpdateError(
+                "No OTA provider currently busy, updates currently not possible"
+            )
 
         # Add update to the OTA provider
         await self._ota_provider.download_update(update)
 
-        ota_provider_node_id = self._ota_provider.get_node_id()
-        if ota_provider_node_id is None:
-            LOGGER.info("Initializing OTA Provider")
-        elif ota_provider_node_id not in self._nodes:
-            LOGGER.warning(
-                "OTA Provider node id %d no longer exists! Resetting...",
-                ota_provider_node_id,
-            )
-            await self._ota_provider.reset()
-            ota_provider_node_id = None
-
         # Make sure any previous instances get stopped
-        await self._ota_provider.stop()
-        await self._ota_provider.start()
-
-        # Wait for OTA provider to be ready
-        # TODO: Detect when OTA provider is ready
-        await asyncio.sleep(2)
-
-        if not ota_provider_node_id:
-            await self._initialize_ota_provider(self._ota_provider)
-
-        # Notify update node about the availability of the OTA Provider. It will query
-        # the OTA provider and start the update.
-        try:
-            await self.chip_controller.SendCommand(
-                nodeid=node_id,
-                endpoint=0,
-                payload=Clusters.OtaSoftwareUpdateRequestor.Commands.AnnounceOTAProvider(
-                    providerNodeID=ota_provider_node_id,
-                    vendorID=self.server.vendor_id,
-                    announcementReason=Clusters.OtaSoftwareUpdateRequestor.Enums.AnnouncementReasonEnum.kUpdateAvailable,
-                    endpoint=ExternalOtaProvider.ENDPOINT_ID,
-                ),
-            )
-        except ChipStackError as ex:
-            raise UpdateError("Error while announcing OTA Provider to node.") from ex
+        await self._ota_provider.start_update(
+            self,
+            node_id,
+        )
 
         return update
 
@@ -1141,6 +1042,16 @@ class MatterDeviceController:
             ):
                 # schedule a full interview of the node if the software version changed
                 self._loop.create_task(self.interview_node(node_id))
+
+            # work out if update state changed
+            if (
+                str(path) == OTA_SOFTWARE_UPDATE_REQUESTOR_UPDATE_STATE_ATTRIBUTE_PATH
+                and new_value != old_value
+            ):
+                if self._ota_provider:
+                    loop.create_task(
+                        self._ota_provider.check_update_state(node_id, new_value)
+                    )
 
             # store updated value in node attributes
             node.attributes[str(path)] = new_value

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -32,7 +32,7 @@ from matter_server.common.custom_clusters import check_polled_attributes
 from matter_server.common.models import CommissionableNodeData, CommissioningParameters
 from matter_server.server.helpers.attributes import parse_attributes_from_read_result
 from matter_server.server.helpers.utils import ping_ip
-from matter_server.server.ota.dcl import check_updates
+from matter_server.server.ota.dcl import check_for_update
 from matter_server.server.ota.provider import ExternalOtaProvider
 from matter_server.server.sdk import ChipDeviceControllerWrapper
 
@@ -928,7 +928,7 @@ class MatterDeviceController:
             BASIC_INFORMATION_SOFTWARE_VERSION_STRING_ATTRIBUTE_PATH
         )
 
-        update = await check_updates(node_id, vid, pid, software_version)
+        update = await check_for_update(vid, pid, software_version)
         if not update:
             node_logger.info("No new update found.")
             return None

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -32,6 +32,7 @@ from matter_server.common.models import CommissionableNodeData, CommissioningPar
 from matter_server.server.helpers.attributes import parse_attributes_from_read_result
 from matter_server.server.helpers.utils import ping_ip
 from matter_server.server.ota.dcl import check_updates
+from matter_server.server.ota.provider import ExternalOtaProvider
 from matter_server.server.sdk import ChipDeviceControllerWrapper
 
 from ..common.errors import (
@@ -149,6 +150,7 @@ class MatterDeviceController:
         self._polled_attributes: dict[int, set[str]] = {}
         self._custom_attribute_poller_timer: asyncio.TimerHandle | None = None
         self._custom_attribute_poller_task: asyncio.Task | None = None
+        self._ota_provider = ExternalOtaProvider()
 
     async def initialize(self) -> None:
         """Initialize the device controller."""
@@ -922,6 +924,7 @@ class MatterDeviceController:
             )
 
             # Add to OTA provider
+            await self._ota_provider.download_update(update)
 
         return update
 

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -949,7 +949,7 @@ class MatterDeviceController:
         notify the node about the new update.
         """
 
-        node_logger = LOGGER.getChild(f"node_{node_id}")
+        node_logger = self.get_node_logger(LOGGER, node_id)
         node_logger.info("Update to software version %r", software_version)
 
         update = await self._check_node_update(node_id, software_version)
@@ -997,7 +997,7 @@ class MatterDeviceController:
         node_id: int,
         requested_software_version: int | str | None = None,
     ) -> dict | None:
-        node_logger = LOGGER.getChild(f"node_{node_id}")
+        node_logger = self.get_node_logger(LOGGER, node_id)
         node = self._nodes[node_id]
 
         node_logger.debug("Check for updates.")

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -1013,7 +1013,7 @@ class MatterDeviceController:
         )
 
         update = await check_for_update(
-            vid, pid, software_version, requested_software_version
+            node_logger, vid, pid, software_version, requested_software_version
         )
         if not update:
             node_logger.info("No new update found.")

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -910,6 +910,83 @@ class MatterDeviceController:
 
         return await self._check_node_update(node_id)
 
+    async def _initialize_ota_provider(self, ota_provider: ExternalOtaProvider) -> None:
+        """Commissions the OTA Provider."""
+
+        if self.chip_controller is None:
+            raise RuntimeError("Device Controller not initialized.")
+
+        # The OTA Provider has not been commissioned yet, let's do it now.
+        LOGGER.info("Commissioning the built-in OTA Provider App.")
+        try:
+            ota_provider_node = await self.commission_on_network(
+                ota_provider.get_passcode(),
+                # TODO: Filtering by long discriminator seems broken
+                # filter_type=FilterType.LONG_DISCRIMINATOR,
+                # filter=ota_provider.get_descriminator(),
+            )
+            ota_provider_node_id = ota_provider_node.node_id
+        except NodeCommissionFailed:
+            LOGGER.error("Failed to commission OTA Provider App!")
+            return
+
+        LOGGER.info(
+            "OTA Provider App commissioned with node id %d.",
+            ota_provider_node_id,
+        )
+
+        # Adjust ACL of OTA Requestor such that Node peer-to-peer communication
+        # is allowed.
+        try:
+            read_result = await self.chip_controller.ReadAttribute(
+                ota_provider_node_id, [(0, Clusters.AccessControl.Attributes.Acl)]
+            )
+            acl_list = cast(
+                list,
+                read_result[0][Clusters.AccessControl][
+                    Clusters.AccessControl.Attributes.Acl
+                ],
+            )
+
+            # Add new ACL entry...
+            acl_list.append(
+                Clusters.AccessControl.Structs.AccessControlEntryStruct(
+                    fabricIndex=1,
+                    privilege=Clusters.AccessControl.Enums.AccessControlEntryPrivilegeEnum.kOperate,
+                    authMode=Clusters.AccessControl.Enums.AccessControlEntryAuthModeEnum.kCase,
+                    subjects=Types.NullValue,
+                    targets=[
+                        Clusters.AccessControl.Structs.AccessControlTargetStruct(
+                            cluster=Clusters.OtaSoftwareUpdateProvider.id,
+                            endpoint=0,
+                            deviceType=Types.NullValue,
+                        )
+                    ],
+                )
+            )
+
+            # And write. This is persistent, so only need to be done after we commissioned
+            # the OTA Provider App.
+            write_result: Attribute.AttributeWriteResult = (
+                await self.chip_controller.WriteAttribute(
+                    ota_provider_node_id,
+                    [(0, Clusters.AccessControl.Attributes.Acl(acl_list))],
+                )
+            )
+            if write_result[0].Status != Status.Success:
+                logging.error(
+                    "Failed writing adjusted OTA Provider App ACL: Status %s.",
+                    str(write_result[0].Status),
+                )
+                await self.remove_node(ota_provider_node_id)
+                raise UpdateError("Error while setting up OTA Provider.")
+        except ChipStackError as ex:
+            logging.exception("Failed adjusting OTA Provider App ACL.", exc_info=ex)
+            await self.remove_node(ota_provider_node_id)
+            raise UpdateError("Error while setting up OTA Provider.") from ex
+
+        ota_provider.set_node_id(ota_provider_node_id)
+
     @api_command(APICommand.UPDATE_NODE)
     async def update_node(self, node_id: int, software_version: int) -> dict | None:
         """
@@ -937,7 +1014,9 @@ class MatterDeviceController:
         await self._ota_provider.download_update(update)
 
         ota_provider_node_id = self._ota_provider.get_node_id()
-        if ota_provider_node_id not in self._nodes:
+        if ota_provider_node_id is None:
+            LOGGER.info("Initializing OTA Provider")
+        elif ota_provider_node_id not in self._nodes:
             LOGGER.warning(
                 "OTA Provider node id %d no longer exists! Resetting...",
                 ota_provider_node_id,
@@ -947,82 +1026,17 @@ class MatterDeviceController:
 
         # Make sure any previous instances get stopped
         await self._ota_provider.stop()
-        self._ota_provider.start()
+        await self._ota_provider.start()
 
         # Wait for OTA provider to be ready
         # TODO: Detect when OTA provider is ready
         await asyncio.sleep(2)
 
         if not ota_provider_node_id:
-            # The OTA Provider has not been commissioned yet, let's do it now.
-            LOGGER.info("Commissioning the built-in OTA Provider App.")
-            try:
-                ota_provider_node = await self.commission_on_network(
-                    self._ota_provider.get_passcode(),
-                    # TODO: Filtering by long discriminator seems broken
-                    # filter_type=FilterType.LONG_DISCRIMINATOR,
-                    # filter=self._ota_provider.get_descriminator(),
-                )
-                ota_provider_node_id = ota_provider_node.node_id
-            except NodeCommissionFailed:
-                LOGGER.error("Failed to commission OTA Provider App!")
-                return None
-            LOGGER.info(
-                "OTA Provider App commissioned with node id %d.",
-                ota_provider_node_id,
-            )
+            await self._initialize_ota_provider(self._ota_provider)
 
-            # Adjust ACL of OTA Requestor such that Node peer-to-peer communication
-            # is allowed.
-            try:
-                read_result = await self.chip_controller.ReadAttribute(
-                    ota_provider_node_id, [(0, Clusters.AccessControl.Attributes.Acl)]
-                )
-                acl_list = cast(
-                    list,
-                    read_result[0][Clusters.AccessControl][
-                        Clusters.AccessControl.Attributes.Acl
-                    ],
-                )
-
-                # Add new ACL entry...
-                acl_list.append(
-                    Clusters.AccessControl.Structs.AccessControlEntryStruct(
-                        fabricIndex=1,
-                        privilege=3,
-                        authMode=2,
-                        subjects=Types.NullValue,
-                        targets=[
-                            Clusters.AccessControl.Structs.AccessControlTargetStruct(
-                                cluster=41, endpoint=0, deviceType=Types.NullValue
-                            )
-                        ],
-                    )
-                )
-
-                # And write. This is persistent, so only need to be done after we commissioned
-                # the OTA Provider App.
-                write_result: Attribute.AttributeWriteResult = (
-                    await self.chip_controller.WriteAttribute(
-                        ota_provider_node_id,
-                        [(0, Clusters.AccessControl.Attributes.Acl(acl_list))],
-                    )
-                )
-                if write_result[0].Status != Status.Success:
-                    logging.error(
-                        "Failed writing adjusted OTA Provider App ACL: Status %s.",
-                        str(write_result[0].Status),
-                    )
-                    await self.remove_node(ota_provider_node_id)
-                    raise UpdateError("Error while setting up OTA Provider.")
-            except ChipStackError as ex:
-                logging.exception("Failed adjusting OTA Provider App ACL.", exc_info=ex)
-                await self.remove_node(ota_provider_node_id)
-                raise UpdateError("Error while setting up OTA Provider.") from ex
-
-            self._ota_provider.set_node_id(ota_provider_node_id)
-
-        # Notify node about the new update!
+        # Notify update node about the availability of the OTA Provider. It will query
+        # the OTA provider and start the update.
         try:
             await self.chip_controller.SendCommand(
                 nodeid=node_id,

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -919,6 +919,9 @@ class MatterDeviceController:
         notify the node about the new update.
         """
 
+        node_logger = LOGGER.getChild(f"node_{node_id}")
+        node_logger.info("Update to software version %r", software_version)
+
         update = await self._check_node_update(node_id, software_version)
         if update is None:
             raise UpdateCheckError(
@@ -932,6 +935,7 @@ class MatterDeviceController:
 
         await ota_provider.initialize()
 
+        node_logger.info("Downloading update from '%s'", update["otaUrl"])
         await ota_provider.download_update(update)
 
         self._attribute_update_callbacks.setdefault(node_id, []).append(
@@ -940,6 +944,7 @@ class MatterDeviceController:
 
         try:
             # Make sure any previous instances get stopped
+            node_logger.info("Starting update using OTA Provider.")
             await ota_provider.start_update(
                 self._chip_device_controller,
                 node_id,

--- a/matter_server/server/helpers/__init__.py
+++ b/matter_server/server/helpers/__init__.py
@@ -1,1 +1,4 @@
 """Helpers/utils for the Matter Server."""
+
+DCL_PRODUCTION_URL = "https://on.dcl.csa-iot.org"
+DCL_TEST_URL = "https://on.test-net.dcl.csa-iot.org"

--- a/matter_server/server/helpers/paa_certificates.py
+++ b/matter_server/server/helpers/paa_certificates.py
@@ -19,14 +19,14 @@ from cryptography import x509
 from cryptography.hazmat.primitives import serialization
 from cryptography.utils import CryptographyDeprecationWarning
 
+from matter_server.server.helpers import DCL_PRODUCTION_URL, DCL_TEST_URL
+
 # Git repo details
 OWNER = "project-chip"
 REPO = "connectedhomeip"
 PATH = "credentials/development/paa-root-certs"
 
 LOGGER = logging.getLogger(__name__)
-PRODUCTION_URL = "https://on.dcl.csa-iot.org"
-TEST_URL = "https://on.test-net.dcl.csa-iot.org"
 GIT_URL = f"https://raw.githubusercontent.com/{OWNER}/{REPO}/master/{PATH}"
 
 
@@ -226,7 +226,7 @@ async def fetch_certificates(
         fetch_count = await fetch_dcl_certificates(
             paa_root_cert_dir=paa_root_cert_dir,
             base_name="dcld_production_",
-            base_url=PRODUCTION_URL,
+            base_url=DCL_PRODUCTION_URL,
         )
         LOGGER.info("Fetched %s PAA root certificates from DCL.", fetch_count)
         total_fetch_count += fetch_count
@@ -235,7 +235,7 @@ async def fetch_certificates(
         fetch_count = await fetch_dcl_certificates(
             paa_root_cert_dir=paa_root_cert_dir,
             base_name="dcld_test_",
-            base_url=TEST_URL,
+            base_url=DCL_TEST_URL,
         )
         LOGGER.info("Fetched %s PAA root certificates from Test DCL.", fetch_count)
         total_fetch_count += fetch_count

--- a/matter_server/server/ota/__init__.py
+++ b/matter_server/server/ota/__init__.py
@@ -11,6 +11,8 @@ HARDCODED_UPDATES: dict[tuple[int, int], dict] = {
         "softwareVersionString": "2.0",
         "cdVersionNumber": 1,
         "softwareVersionValid": True,
+        "otaChecksum": "7qcyvg2kPmKZaDLIk8C7Vyteqf4DI73x0tFZkmPALCo=",
+        "otaChecksumType": 1,
         "minApplicableSoftwareVersion": 1,
         "maxApplicableSoftwareVersion": 1,
         "otaUrl": "https://github.com/agners/matter-linux-example-apps/releases/download/v1.3.0.0/chip-ota-requestor-app-x86-64.ota",

--- a/matter_server/server/ota/__init__.py
+++ b/matter_server/server/ota/__init__.py
@@ -18,6 +18,19 @@ HARDCODED_UPDATES: dict[tuple[int, int], dict] = {
         "otaUrl": "https://github.com/agners/matter-linux-example-apps/releases/download/v1.3.0.0/chip-ota-requestor-app-x86-64.ota",
         "releaseNotesUrl": "https://github.com/agners/matter-linux-example-apps/releases/tag/v1.3.0.0",
     },
+    (0x143D, 0x1001): {
+        "vid": 0x143D,
+        "pid": 0x1001,
+        "softwareVersion": 10010011,
+        "softwareVersionString": "1.1.11-c85ba1e-dirty",
+        "cdVersionNumber": 1,
+        "softwareVersionValid": True,
+        "otaChecksum": "x2sK9xjVuGff0eefYa4cporDO+Z+WVxxw+JP5Ol+5og=",
+        "otaChecksumType": 1,
+        "minApplicableSoftwareVersion": 10010000,
+        "maxApplicableSoftwareVersion": 10010011,
+        "otaUrl": "https://raw.githubusercontent.com/ChampOnBon/Onvis/master/S4/debug.ota",
+    },
 }
 
 

--- a/matter_server/server/ota/__init__.py
+++ b/matter_server/server/ota/__init__.py
@@ -1,0 +1,28 @@
+"""OTA implementation for the Matter Server."""
+
+from matter_server.server.ota import dcl
+
+HARDCODED_UPDATES: dict[tuple[int, int], dict] = {
+    # OTA requestor example app, useful for testing
+    (0xFFF1, 0x8001): {
+        "vid": 0xFFF1,
+        "pid": 0x8001,
+        "softwareVersion": 2,
+        "softwareVersionString": "2.0",
+        "cdVersionNumber": 1,
+        "softwareVersionValid": True,
+        "minApplicableSoftwareVersion": 1,
+        "maxApplicableSoftwareVersion": 1,
+        "otaUrl": "https://github.com/agners/matter-linux-example-apps/releases/download/v1.3.0.0/chip-ota-requestor-app-x86-64.ota",
+    }
+}
+
+
+async def check_for_update(
+    vid: int, pid: int, current_software_version: int
+) -> None | dict:
+    """Check for software updates."""
+    if (vid, pid) in HARDCODED_UPDATES:
+        return HARDCODED_UPDATES[(vid, pid)]
+
+    return await dcl.check_for_update(vid, pid, current_software_version)

--- a/matter_server/server/ota/__init__.py
+++ b/matter_server/server/ota/__init__.py
@@ -1,39 +1,30 @@
 """OTA implementation for the Matter Server."""
 
+import asyncio
+import json
 from logging import LoggerAdapter
+from pathlib import Path
 
 from matter_server.server.ota import dcl
 
-HARDCODED_UPDATES: dict[tuple[int, int], dict] = {
-    # OTA requestor example app, useful for testing
-    (0xFFF1, 0x8001): {
-        "vid": 0xFFF1,
-        "pid": 0x8001,
-        "softwareVersion": 2,
-        "softwareVersionString": "2.0",
-        "cdVersionNumber": 1,
-        "softwareVersionValid": True,
-        "otaChecksum": "7qcyvg2kPmKZaDLIk8C7Vyteqf4DI73x0tFZkmPALCo=",
-        "otaChecksumType": 1,
-        "minApplicableSoftwareVersion": 1,
-        "maxApplicableSoftwareVersion": 1,
-        "otaUrl": "https://github.com/agners/matter-linux-example-apps/releases/download/v1.3.0.0/chip-ota-requestor-app-x86-64.ota",
-        "releaseNotesUrl": "https://github.com/agners/matter-linux-example-apps/releases/tag/v1.3.0.0",
-    },
-    (0x143D, 0x1001): {
-        "vid": 0x143D,
-        "pid": 0x1001,
-        "softwareVersion": 10010011,
-        "softwareVersionString": "1.1.11-c85ba1e-dirty",
-        "cdVersionNumber": 1,
-        "softwareVersionValid": True,
-        "otaChecksum": "x2sK9xjVuGff0eefYa4cporDO+Z+WVxxw+JP5Ol+5og=",
-        "otaChecksumType": 1,
-        "minApplicableSoftwareVersion": 10010000,
-        "maxApplicableSoftwareVersion": 10010011,
-        "otaUrl": "https://raw.githubusercontent.com/ChampOnBon/Onvis/master/S4/debug.ota",
-    },
-}
+_local_updates: dict[tuple[int, int], dict] = {}
+
+
+async def load_local_updates(ota_provider_dir: Path) -> None:
+    """Load updates from locally stored json files."""
+
+    def _load_update(ota_provider_dir: Path) -> None:
+        for update_file in ota_provider_dir.glob("*.json"):
+            with open(update_file) as f:
+                update = json.load(f)
+                model_version = update["modelVersion"]
+                _local_updates[(model_version["vid"], model_version["pid"])] = (
+                    model_version
+                )
+
+    await asyncio.get_running_loop().run_in_executor(
+        None, _load_update, ota_provider_dir
+    )
 
 
 async def check_for_update(
@@ -44,8 +35,8 @@ async def check_for_update(
     requested_software_version: int | str | None = None,
 ) -> None | dict:
     """Check for software updates."""
-    if (vid, pid) in HARDCODED_UPDATES:
-        update = HARDCODED_UPDATES[(vid, pid)]
+    if (vid, pid) in _local_updates:
+        update = _local_updates[(vid, pid)]
         if (
             requested_software_version is None
             or update["softwareVersion"] == requested_software_version

--- a/matter_server/server/ota/__init__.py
+++ b/matter_server/server/ota/__init__.py
@@ -14,6 +14,8 @@ async def load_local_updates(ota_provider_dir: Path) -> None:
     """Load updates from locally stored json files."""
 
     def _load_update(ota_provider_dir: Path) -> None:
+        if not ota_provider_dir.exists():
+            return
         for update_file in ota_provider_dir.glob("*.json"):
             with open(update_file) as f:
                 update = json.load(f)

--- a/matter_server/server/ota/__init__.py
+++ b/matter_server/server/ota/__init__.py
@@ -19,10 +19,18 @@ HARDCODED_UPDATES: dict[tuple[int, int], dict] = {
 
 
 async def check_for_update(
-    vid: int, pid: int, current_software_version: int
+    vid: int,
+    pid: int,
+    current_software_version: int,
+    requested_software_version: int | None = None,
 ) -> None | dict:
     """Check for software updates."""
     if (vid, pid) in HARDCODED_UPDATES:
-        return HARDCODED_UPDATES[(vid, pid)]
+        update = HARDCODED_UPDATES[(vid, pid)]
+        if (
+            requested_software_version is None
+            or update["softwareVersion"] == requested_software_version
+        ):
+            return update
 
     return await dcl.check_for_update(vid, pid, current_software_version)

--- a/matter_server/server/ota/__init__.py
+++ b/matter_server/server/ota/__init__.py
@@ -16,7 +16,8 @@ HARDCODED_UPDATES: dict[tuple[int, int], dict] = {
         "minApplicableSoftwareVersion": 1,
         "maxApplicableSoftwareVersion": 1,
         "otaUrl": "https://github.com/agners/matter-linux-example-apps/releases/download/v1.3.0.0/chip-ota-requestor-app-x86-64.ota",
-    }
+        "releaseNotesUrl": "https://github.com/agners/matter-linux-example-apps/releases/tag/v1.3.0.0",
+    },
 }
 
 

--- a/matter_server/server/ota/__init__.py
+++ b/matter_server/server/ota/__init__.py
@@ -1,5 +1,7 @@
 """OTA implementation for the Matter Server."""
 
+from logging import LoggerAdapter
+
 from matter_server.server.ota import dcl
 
 HARDCODED_UPDATES: dict[tuple[int, int], dict] = {
@@ -35,6 +37,7 @@ HARDCODED_UPDATES: dict[tuple[int, int], dict] = {
 
 
 async def check_for_update(
+    logger: LoggerAdapter,
     vid: int,
     pid: int,
     current_software_version: int,
@@ -51,5 +54,5 @@ async def check_for_update(
             return update
 
     return await dcl.check_for_update(
-        vid, pid, current_software_version, requested_software_version
+        logger, vid, pid, current_software_version, requested_software_version
     )

--- a/matter_server/server/ota/__init__.py
+++ b/matter_server/server/ota/__init__.py
@@ -38,7 +38,7 @@ async def check_for_update(
     vid: int,
     pid: int,
     current_software_version: int,
-    requested_software_version: int | None = None,
+    requested_software_version: int | str | None = None,
 ) -> None | dict:
     """Check for software updates."""
     if (vid, pid) in HARDCODED_UPDATES:
@@ -46,7 +46,10 @@ async def check_for_update(
         if (
             requested_software_version is None
             or update["softwareVersion"] == requested_software_version
+            or update["softwareVersionString"] == requested_software_version
         ):
             return update
 
-    return await dcl.check_for_update(vid, pid, current_software_version)
+    return await dcl.check_for_update(
+        vid, pid, current_software_version, requested_software_version
+    )

--- a/matter_server/server/ota/dcl.py
+++ b/matter_server/server/ota/dcl.py
@@ -1,0 +1,60 @@
+"""Handle OTA software version endpoints of the DCL."""
+
+import logging
+from typing import Any
+
+from aiohttp import ClientError, ClientSession
+
+from matter_server.server.helpers import DCL_PRODUCTION_URL
+
+LOGGER = logging.getLogger(__name__)
+
+
+async def get_software_versions(node_id: int, vid: int, pid: int) -> Any:
+    """Check DCL if there are updates available for a particular node."""
+    async with ClientSession(raise_for_status=True) as http_session:
+        # fetch the paa certificates list
+        async with http_session.get(
+            f"{DCL_PRODUCTION_URL}/dcl/model/versions/{vid}/{pid}"
+        ) as response:
+            return await response.json()
+
+
+async def get_software_version(
+    node_id: int, vid: int, pid: int, software_version: int
+) -> Any:
+    """Check DCL if there are updates available for a particular node."""
+    async with ClientSession(raise_for_status=True) as http_session:
+        # fetch the paa certificates list
+        async with http_session.get(
+            f"{DCL_PRODUCTION_URL}/dcl/model/versions/{vid}/{pid}/{software_version}"
+        ) as response:
+            return await response.json()
+
+
+async def check_updates(
+    node_id: int, vid: int, pid: int, current_software_version: int
+) -> None | dict:
+    """Check if there is a newer software version available on the DCL."""
+    try:
+        versions = await get_software_versions(node_id, vid, pid)
+
+        software_versions: list[int] = versions["modelVersions"]["softwareVersions"]
+        latest_software_version = max(software_versions)
+        if latest_software_version <= current_software_version:
+            return None
+
+        version: dict = await get_software_version(
+            node_id, vid, pid, latest_software_version
+        )
+        if isinstance(version, dict) and "modelVersion" in version:
+            result: Any = version["modelVersion"]
+            if isinstance(result, dict):
+                return result
+
+        logging.error("Unexpected DCL response.")
+        return None
+
+    except (ClientError, TimeoutError) as err:
+        LOGGER.error("Fetching software version failed: error %s", err, exc_info=err)
+    return None

--- a/matter_server/server/ota/dcl.py
+++ b/matter_server/server/ota/dcl.py
@@ -9,8 +9,6 @@ from aiohttp import ClientError, ClientSession
 from matter_server.common.errors import UpdateCheckError
 from matter_server.server.helpers import DCL_PRODUCTION_URL
 
-LOGGER = logging.getLogger(__name__)
-
 
 async def _get_software_versions(session: ClientSession, vid: int, pid: int) -> Any:
     """Check DCL if there are updates available for a particular node."""
@@ -74,6 +72,7 @@ async def _check_update_version(
 
 
 async def check_for_update(
+    logger: logging.LoggerAdapter,
     vid: int,
     pid: int,
     current_software_version: int,
@@ -97,7 +96,7 @@ async def check_for_update(
             # Get all versions and check each one of them.
             versions = await _get_software_versions(session, vid, pid)
             if versions is None:
-                LOGGER.info(
+                logger.info(
                     "There is no update information for this device on the DCL."
                 )
                 return None
@@ -126,7 +125,7 @@ async def check_for_update(
                     requested_software_version,
                 ):
                     return version_candidate
-                LOGGER.debug("Software version %d not applicable.", version)
+                logger.debug("Software version %d not applicable.", version)
             return None
 
     except (ClientError, TimeoutError) as err:

--- a/matter_server/server/ota/dcl.py
+++ b/matter_server/server/ota/dcl.py
@@ -10,7 +10,7 @@ from matter_server.server.helpers import DCL_PRODUCTION_URL
 LOGGER = logging.getLogger(__name__)
 
 
-async def get_software_versions(vid: int, pid: int) -> Any:
+async def _get_software_versions(vid: int, pid: int) -> Any:
     """Check DCL if there are updates available for a particular node."""
     async with ClientSession(raise_for_status=True) as http_session:
         # fetch the paa certificates list
@@ -20,7 +20,7 @@ async def get_software_versions(vid: int, pid: int) -> Any:
             return await response.json()
 
 
-async def get_software_version(vid: int, pid: int, software_version: int) -> Any:
+async def _get_software_version(vid: int, pid: int, software_version: int) -> Any:
     """Check DCL if there are updates available for a particular node."""
     async with ClientSession(raise_for_status=True) as http_session:
         # fetch the paa certificates list
@@ -30,12 +30,45 @@ async def get_software_version(vid: int, pid: int, software_version: int) -> Any
             return await response.json()
 
 
-async def check_for_update(
-    vid: int, pid: int, current_software_version: int
+async def _check_update_version(
+    vid: int, pid: int, version: int, current_software_version: int
 ) -> None | dict:
-    """Check if there is a newer software version available on the DCL."""
+    version_res: dict = await _get_software_version(vid, pid, version)
+    if not isinstance(version_res, dict):
+        raise TypeError("Unexpected DCL response.")
+
+    if "modelVersion" not in version_res:
+        raise ValueError("Unexpected DCL response.")
+
+    version_candidate: dict = cast(dict, version_res["modelVersion"])
+
+    # Check minApplicableSoftwareVersion/maxApplicableSoftwareVersion
+    min_sw_version = version_candidate["minApplicableSoftwareVersion"]
+    max_sw_version = version_candidate["maxApplicableSoftwareVersion"]
+    if (
+        current_software_version < min_sw_version
+        or current_software_version > max_sw_version
+    ):
+        return None
+
+    return version_candidate
+
+
+async def check_for_update(
+    vid: int,
+    pid: int,
+    current_software_version: int,
+    requested_software_version: int | None = None,
+) -> None | dict:
+    """Check if there is a software update available on the DCL."""
     try:
-        versions = await get_software_versions(vid, pid)
+        if requested_software_version is not None:
+            return await _check_update_version(
+                vid, pid, requested_software_version, current_software_version
+            )
+
+        # Get all versions and check each one of them.
+        versions = await _get_software_versions(vid, pid)
 
         all_software_versions: list[int] = versions["modelVersions"]["softwareVersions"]
         newer_software_versions = [
@@ -51,26 +84,11 @@ async def check_for_update(
 
         # Check if latest firmware is applicable, and backtrack from there
         for version in sorted(newer_software_versions, reverse=True):
-            version_res: dict = await get_software_version(vid, pid, version)
-            if not isinstance(version_res, dict):
-                raise TypeError("Unexpected DCL response.")
-
-            if "modelVersion" not in version_res:
-                raise ValueError("Unexpected DCL response.")
-
-            version_candidate: dict = cast(dict, version_res["modelVersion"])
-
-            # Check minApplicableSoftwareVersion/maxApplicableSoftwareVersion
-            min_sw_version = version_candidate["minApplicableSoftwareVersion"]
-            max_sw_version = version_candidate["maxApplicableSoftwareVersion"]
-            if (
-                current_software_version < min_sw_version
-                or current_software_version > max_sw_version
+            if version_candidate := await _check_update_version(
+                vid, pid, version, current_software_version
             ):
-                LOGGER.debug("Software version %d not applicable.", version)
-                continue
-
-            return version_candidate
+                return version_candidate
+            LOGGER.debug("Software version %d not applicable.", version)
         return None
 
     except (ClientError, TimeoutError) as err:

--- a/matter_server/server/ota/dcl.py
+++ b/matter_server/server/ota/dcl.py
@@ -1,7 +1,7 @@
 """Handle OTA software version endpoints of the DCL."""
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 from aiohttp import ClientError, ClientSession
 
@@ -10,7 +10,7 @@ from matter_server.server.helpers import DCL_PRODUCTION_URL
 LOGGER = logging.getLogger(__name__)
 
 
-async def get_software_versions(node_id: int, vid: int, pid: int) -> Any:
+async def get_software_versions(vid: int, pid: int) -> Any:
     """Check DCL if there are updates available for a particular node."""
     async with ClientSession(raise_for_status=True) as http_session:
         # fetch the paa certificates list
@@ -20,9 +20,7 @@ async def get_software_versions(node_id: int, vid: int, pid: int) -> Any:
             return await response.json()
 
 
-async def get_software_version(
-    node_id: int, vid: int, pid: int, software_version: int
-) -> Any:
+async def get_software_version(vid: int, pid: int, software_version: int) -> Any:
     """Check DCL if there are updates available for a particular node."""
     async with ClientSession(raise_for_status=True) as http_session:
         # fetch the paa certificates list
@@ -32,27 +30,47 @@ async def get_software_version(
             return await response.json()
 
 
-async def check_updates(
-    node_id: int, vid: int, pid: int, current_software_version: int
+async def check_for_update(
+    vid: int, pid: int, current_software_version: int
 ) -> None | dict:
     """Check if there is a newer software version available on the DCL."""
     try:
-        versions = await get_software_versions(node_id, vid, pid)
+        versions = await get_software_versions(vid, pid)
 
-        software_versions: list[int] = versions["modelVersions"]["softwareVersions"]
-        latest_software_version = max(software_versions)
-        if latest_software_version <= current_software_version:
+        all_software_versions: list[int] = versions["modelVersions"]["softwareVersions"]
+        newer_software_versions = [
+            version
+            for version in all_software_versions
+            if version > current_software_version
+        ]
+
+        # Check if there is a newer software version available
+        if not newer_software_versions:
+            LOGGER.info("No newer software version available.")
             return None
 
-        version: dict = await get_software_version(
-            node_id, vid, pid, latest_software_version
-        )
-        if isinstance(version, dict) and "modelVersion" in version:
-            result: Any = version["modelVersion"]
-            if isinstance(result, dict):
-                return result
+        # Check if latest firmware is applicable, and backtrack from there
+        for version in sorted(newer_software_versions, reverse=True):
+            version_res: dict = await get_software_version(vid, pid, version)
+            if not isinstance(version_res, dict):
+                raise TypeError("Unexpected DCL response.")
 
-        logging.error("Unexpected DCL response.")
+            if "modelVersion" not in version_res:
+                raise ValueError("Unexpected DCL response.")
+
+            version_candidate: dict = cast(dict, version_res["modelVersion"])
+
+            # Check minApplicableSoftwareVersion/maxApplicableSoftwareVersion
+            min_sw_version = version_candidate["minApplicableSoftwareVersion"]
+            max_sw_version = version_candidate["maxApplicableSoftwareVersion"]
+            if (
+                current_software_version < min_sw_version
+                or current_software_version > max_sw_version
+            ):
+                LOGGER.debug("Software version %d not applicable.", version)
+                continue
+
+            return version_candidate
         return None
 
     except (ClientError, TimeoutError) as err:

--- a/matter_server/server/ota/dcl.py
+++ b/matter_server/server/ota/dcl.py
@@ -93,4 +93,6 @@ async def check_for_update(
         return None
 
     except (ClientError, TimeoutError) as err:
-        raise UpdateCheckError("Fetching software version failed.") from err
+        raise UpdateCheckError(
+            f"Fetching software versions from DCL for device with vendor id {vid} product id {pid} failed."
+        ) from err

--- a/matter_server/server/ota/dcl.py
+++ b/matter_server/server/ota/dcl.py
@@ -5,6 +5,7 @@ from typing import Any, cast
 
 from aiohttp import ClientError, ClientSession
 
+from matter_server.common.errors import UpdateCheckError
 from matter_server.server.helpers import DCL_PRODUCTION_URL
 
 LOGGER = logging.getLogger(__name__)
@@ -92,5 +93,4 @@ async def check_for_update(
         return None
 
     except (ClientError, TimeoutError) as err:
-        LOGGER.error("Fetching software version failed: error %s", err, exc_info=err)
-    return None
+        raise UpdateCheckError("Fetching software version failed.") from err

--- a/matter_server/server/ota/provider.py
+++ b/matter_server/server/ota/provider.py
@@ -6,6 +6,7 @@ import functools
 import json
 import logging
 from pathlib import Path
+import secrets
 from typing import TYPE_CHECKING, Final
 from urllib.parse import unquote, urlparse
 
@@ -37,9 +38,12 @@ class DeviceSoftwareVersionModel:  # pylint: disable=C0103
 
 
 @dataclass
-class UpdateFile:  # pylint: disable=C0103
+class OtaProviderImageList:  # pylint: disable=C0103
     """Update File for OTA Provider JSON descriptor file."""
 
+    otaProviderDiscriminator: int
+    otaProviderPasscode: int
+    otaProviderNodeId: int | None
     deviceSoftwareVersionModel: list[DeviceSoftwareVersionModel]
 
 
@@ -50,23 +54,103 @@ class ExternalOtaProvider:
     for devices.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, ota_provider_dir: Path) -> None:
         """Initialize the OTA provider."""
+        self._ota_provider_dir: Path = ota_provider_dir
+        self._ota_provider_image_list_file: Path = ota_provider_dir / "updates.json"
+        self._ota_provider_image_list: OtaProviderImageList | None = None
         self._ota_provider_proc: Process | None = None
         self._ota_provider_task: asyncio.Task | None = None
 
+    async def initialize(self) -> None:
+        """Initialize OTA Provider."""
+
+        loop = asyncio.get_event_loop()
+
+        # Take existence of image list file as indicator if we need to initialize the
+        # OTA Provider.
+        if not await loop.run_in_executor(
+            None, self._ota_provider_image_list_file.exists
+        ):
+            await loop.run_in_executor(
+                None, functools.partial(DEFAULT_UPDATES_PATH.mkdir, exist_ok=True)
+            )
+
+            # Initialize with random data. Node ID will get written once paired by
+            # device controller.
+            self._ota_provider_image_list = OtaProviderImageList(
+                otaProviderDiscriminator=secrets.randbelow(2**12),
+                otaProviderPasscode=secrets.randbelow(2**21),
+                otaProviderNodeId=None,
+                deviceSoftwareVersionModel=[],
+            )
+        else:
+
+            def _read_update_json(
+                update_json_path: Path,
+            ) -> None | OtaProviderImageList:
+                with open(update_json_path, "r") as json_file:
+                    data = json.load(json_file)
+                    return dataclass_from_dict(OtaProviderImageList, data)
+
+            self._ota_provider_image_list = await loop.run_in_executor(
+                None, _read_update_json, self._ota_provider_image_list_file
+            )
+
+    def _get_ota_provider_image_list(self) -> OtaProviderImageList:
+        if self._ota_provider_image_list is None:
+            raise RuntimeError("OTA provider image list not initialized.")
+        return self._ota_provider_image_list
+
+    def get_node_id(self) -> int | None:
+        """Get Node ID of the OTA Provider App."""
+
+        return self._get_ota_provider_image_list().otaProviderNodeId
+
+    def get_descriminator(self) -> int:
+        """Return OTA Provider App discriminator."""
+
+        return self._get_ota_provider_image_list().otaProviderDiscriminator
+
+    def get_passcode(self) -> int:
+        """Return OTA Provider App passcode."""
+
+        return self._get_ota_provider_image_list().otaProviderPasscode
+
+    def set_node_id(self, node_id: int) -> None:
+        """Set Node ID of the OTA Provider App."""
+
+        self._get_ota_provider_image_list().otaProviderNodeId = node_id
+
     async def _start_ota_provider(self) -> None:
-        # TODO: Randomize discriminator
+        def _write_ota_provider_image_list_json(
+            ota_provider_image_list_file: Path,
+            ota_provider_image_list: OtaProviderImageList,
+        ) -> None:
+            update_file_dict = asdict(ota_provider_image_list)
+            with open(ota_provider_image_list_file, "w") as json_file:
+                json.dump(update_file_dict, json_file, indent=4)
+
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            None,
+            _write_ota_provider_image_list_json,
+            self._ota_provider_image_list_file,
+            self._get_ota_provider_image_list(),
+        )
+
         ota_provider_cmd = [
             "chip-ota-provider-app",
             "--discriminator",
-            "22",
+            str(self._get_ota_provider_image_list().otaProviderDiscriminator),
+            "--passcode",
+            str(self._get_ota_provider_image_list().otaProviderPasscode),
             "--secured-device-port",
             "5565",
             "--KVS",
-            "/data/chip_kvs_provider",
+            str(self._ota_provider_dir / "chip_kvs_ota_provider"),
             "--otaImageList",
-            str(DEFAULT_UPDATES_PATH / "updates.json"),
+            str(self._ota_provider_image_list_file),
         ]
 
         LOGGER.info("Starting OTA Provider")
@@ -80,40 +164,41 @@ class ExternalOtaProvider:
         loop = asyncio.get_event_loop()
         self._ota_provider_task = loop.create_task(self._start_ota_provider())
 
+    async def reset(self) -> None:
+        """Reset the OTA Provider App state."""
+
+        def _remove_update_data(ota_provider_dir: Path) -> None:
+            for path in ota_provider_dir.iterdir():
+                if not path.is_dir():
+                    path.unlink()
+
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(None, _remove_update_data, self._ota_provider_dir)
+
+        await self.initialize()
+
     async def stop(self) -> None:
         """Stop the OTA Provider."""
         if self._ota_provider_proc:
             LOGGER.info("Terminating OTA Provider")
-            self._ota_provider_proc.terminate()
+            loop = asyncio.get_event_loop()
+            try:
+                await loop.run_in_executor(None, self._ota_provider_proc.terminate)
+            except ProcessLookupError as ex:
+                LOGGER.warning("Stopping OTA Provider failed with error:", exc_info=ex)
         if self._ota_provider_task:
             await self._ota_provider_task
 
     async def add_update(self, update_desc: dict, ota_file: Path) -> None:
         """Add update to the OTA provider."""
 
-        update_json_path = DEFAULT_UPDATES_PATH / "updates.json"
-
-        def _read_update_json(update_json_path: Path) -> None | UpdateFile:
-            if not update_json_path.exists():
-                return None
-
-            with open(update_json_path, "r") as json_file:
-                data = json.load(json_file)
-                return dataclass_from_dict(UpdateFile, data)
-
-        loop = asyncio.get_running_loop()
-        update_file = await loop.run_in_executor(
-            None, _read_update_json, update_json_path
-        )
-
-        if not update_file:
-            update_file = UpdateFile(deviceSoftwareVersionModel=[])
-
         local_ota_url = str(ota_file)
-        for i, device_software in enumerate(update_file.deviceSoftwareVersionModel):
+        for i, device_software in enumerate(
+            self._get_ota_provider_image_list().deviceSoftwareVersionModel
+        ):
             if device_software.otaURL == local_ota_url:
                 LOGGER.debug("Device software entry exists already, replacing!")
-                del update_file.deviceSoftwareVersionModel[i]
+                del self._get_ota_provider_image_list().deviceSoftwareVersionModel[i]
 
         # Convert to OTA Requestor descriptor file
         new_device_software = DeviceSoftwareVersionModel(
@@ -127,18 +212,8 @@ class ExternalOtaProvider:
             maxApplicableSoftwareVersion=update_desc["maxApplicableSoftwareVersion"],
             otaURL=local_ota_url,
         )
-        update_file.deviceSoftwareVersionModel.append(new_device_software)
-
-        def _write_update_json(update_json_path: Path, update_file: UpdateFile) -> None:
-            update_file_dict = asdict(update_file)
-            with open(update_json_path, "w") as json_file:
-                json.dump(update_file_dict, json_file, indent=4)
-
-        await loop.run_in_executor(
-            None,
-            _write_update_json,
-            update_json_path,
-            update_file,
+        self._get_ota_provider_image_list().deviceSoftwareVersionModel.append(
+            new_device_software
         )
 
     async def download_update(self, update_desc: dict) -> None:

--- a/matter_server/server/ota/provider.py
+++ b/matter_server/server/ota/provider.py
@@ -1,0 +1,139 @@
+"""Handling Matter OTA provider."""
+
+import asyncio
+from dataclasses import asdict, dataclass
+import json
+import logging
+from pathlib import Path
+from typing import Final
+from urllib.parse import unquote, urlparse
+
+from aiohttp import ClientError, ClientSession
+
+from matter_server.common.helpers.util import dataclass_from_dict
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_UPDATES_PATH: Final[Path] = Path("updates")
+
+
+@dataclass
+class DeviceSoftwareVersionModel:  # pylint: disable=C0103
+    """Device Software Version Model for OTA Provider JSON descriptor file."""
+
+    vendorId: int
+    productId: int
+    softwareVersion: int
+    softwareVersionString: str
+    cDVersionNumber: int
+    softwareVersionValid: bool
+    minApplicableSoftwareVersion: int
+    maxApplicableSoftwareVersion: int
+    otaURL: str
+
+
+@dataclass
+class UpdateFile:  # pylint: disable=C0103
+    """Update File for OTA Provider JSON descriptor file."""
+
+    deviceSoftwareVersionModel: list[DeviceSoftwareVersionModel]
+
+
+class ExternalOtaProvider:
+    """Class handling Matter OTA Provider.
+
+    The OTA Provider class implements a Matter OTA (over-the-air) update provider
+    for devices.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the OTA provider."""
+
+    def start(self) -> None:
+        """Start the OTA Provider."""
+
+    async def add_update(self, update_desc: dict, ota_file: Path) -> None:
+        """Add update to the OTA provider."""
+
+        update_json_path = DEFAULT_UPDATES_PATH / "updates.json"
+
+        def _read_update_json(update_json_path: Path) -> None | UpdateFile:
+            if not update_json_path.exists():
+                return None
+
+            with open(update_json_path, "r") as json_file:
+                data = json.load(json_file)
+                return dataclass_from_dict(UpdateFile, data)
+
+        loop = asyncio.get_running_loop()
+        update_file = await loop.run_in_executor(
+            None, _read_update_json, update_json_path
+        )
+
+        if not update_file:
+            update_file = UpdateFile(deviceSoftwareVersionModel=[])
+
+        # Convert to OTA Requestor descriptor file
+        update_file.deviceSoftwareVersionModel.append(
+            DeviceSoftwareVersionModel(
+                vendorId=update_desc["vid"],
+                productId=update_desc["pid"],
+                softwareVersion=update_desc["softwareVersion"],
+                softwareVersionString=update_desc["softwareVersionString"],
+                cDVersionNumber=update_desc["cdVersionNumber"],
+                softwareVersionValid=update_desc["softwareVersionValid"],
+                minApplicableSoftwareVersion=update_desc[
+                    "minApplicableSoftwareVersion"
+                ],
+                maxApplicableSoftwareVersion=update_desc[
+                    "maxApplicableSoftwareVersion"
+                ],
+                otaURL=str(ota_file),
+            )
+        )
+
+        def _write_update_json(update_json_path: Path, update_file: UpdateFile) -> None:
+            update_file_dict = asdict(update_file)
+            with open(update_json_path, "w") as json_file:
+                json.dump(update_file_dict, json_file, indent=4)
+
+        await loop.run_in_executor(
+            None,
+            _write_update_json,
+            update_json_path,
+            update_file,
+        )
+
+    async def download_update(self, update_desc: dict) -> None:
+        """Download update file from OTA Path and add it to the OTA provider."""
+
+        url = update_desc["otaUrl"]
+        parsed_url = urlparse(url)
+        file_name = unquote(Path(parsed_url.path).name)
+
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, DEFAULT_UPDATES_PATH.mkdir)
+
+        file_path = DEFAULT_UPDATES_PATH / file_name
+
+        try:
+            async with ClientSession(raise_for_status=True) as session:
+                # fetch the paa certificates list
+                logging.debug("Download update from f{url}.")
+                async with session.get(url) as response:
+                    with file_path.open("wb") as f:
+                        while True:
+                            chunk = await response.content.read(1024)
+                            if not chunk:
+                                break
+                            f.write(chunk)
+                LOGGER.info(
+                    "File '%s' downloaded to '%s'", file_name, DEFAULT_UPDATES_PATH
+                )
+
+        except (ClientError, TimeoutError) as err:
+            LOGGER.error(
+                "Fetching software version failed: error %s", err, exc_info=err
+            )
+
+        await self.add_update(update_desc, file_path)

--- a/matter_server/server/ota/provider.py
+++ b/matter_server/server/ota/provider.py
@@ -179,7 +179,7 @@ class ExternalOtaProvider:
             "--discriminator",
             str(ota_provider_discriminator),
             "--secured-device-port",
-            "0",
+            "5540",
             "--KVS",
             str(self._ota_provider_dir / f"chip_kvs_ota_provider_{timestamp}"),
             "--filepath",
@@ -212,7 +212,7 @@ class ExternalOtaProvider:
                 ota_provider_node_id,
             )
 
-            # Notify update node about the availability of the OTA Provider. 
+            # Notify update node about the availability of the OTA Provider.
             # It will query the OTA provider and start the update.
             try:
                 await chip_device_controller.send_command(

--- a/matter_server/server/ota/provider.py
+++ b/matter_server/server/ota/provider.py
@@ -359,6 +359,7 @@ class ExternalOtaProvider:
                 self._ota_done.set_exception(
                     UpdateError("Target node did not process the update file")
                 )
+                return
 
             LOGGER.info(
                 "Node %d update state idle, assuming done.", self._ota_target_node_id

--- a/matter_server/server/ota/provider.py
+++ b/matter_server/server/ota/provider.py
@@ -353,11 +353,21 @@ class ExternalOtaProvider:
             Clusters.OtaSoftwareUpdateRequestor.Enums.UpdateStateEnum, new_value
         )
 
+        old_update_state = cast(
+            Clusters.OtaSoftwareUpdateRequestor.Enums.UpdateStateEnum, old_value
+        )
+
         # Update state of target node changed, check if update is done.
         if (
             update_state
             == Clusters.OtaSoftwareUpdateRequestor.Enums.UpdateStateEnum.kIdle
         ):
+            if (
+                old_update_state
+                == Clusters.OtaSoftwareUpdateRequestor.Enums.UpdateStateEnum.kQuerying
+            ):
+                raise UpdateError("Target node did not process the update file")
+
             LOGGER.info(
                 "Node %d update state idle, assuming done.", self._ota_target_node_id
             )

--- a/matter_server/server/ota/provider.py
+++ b/matter_server/server/ota/provider.py
@@ -54,6 +54,8 @@ class ExternalOtaProvider:
     for devices.
     """
 
+    ENDPOINT_ID: Final[int] = 0
+
     def __init__(self, ota_provider_dir: Path) -> None:
         """Initialize the OTA provider."""
         self._ota_provider_dir: Path = ota_provider_dir

--- a/matter_server/server/ota/provider.py
+++ b/matter_server/server/ota/provider.py
@@ -225,7 +225,7 @@ class ExternalOtaProvider:
 
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(
-            None, functools.partial(DEFAULT_UPDATES_PATH.mkdir, exists_ok=True)
+            None, functools.partial(DEFAULT_UPDATES_PATH.mkdir, exist_ok=True)
         )
 
         file_path = DEFAULT_UPDATES_PATH / file_name
@@ -236,7 +236,7 @@ class ExternalOtaProvider:
         try:
             async with ClientSession(raise_for_status=True) as session:
                 # fetch the paa certificates list
-                logging.debug("Download update from f{url}.")
+                LOGGER.debug("Download update from '%s'.", url)
                 async with session.get(url) as response:
                     with file_path.open("wb") as f:
                         while True:

--- a/matter_server/server/ota/provider.py
+++ b/matter_server/server/ota/provider.py
@@ -212,8 +212,8 @@ class ExternalOtaProvider:
                 ota_provider_node_id,
             )
 
-            # Notify update node about the availability of the OTA Provider. It will query
-            # the OTA provider and start the update.
+            # Notify update node about the availability of the OTA Provider. 
+            # It will query the OTA provider and start the update.
             try:
                 await chip_device_controller.send_command(
                     node_id,

--- a/tests/server/ota/test_dcl.py
+++ b/tests/server/ota/test_dcl.py
@@ -1,6 +1,6 @@
 """Test DCL OTA updates."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -62,7 +62,7 @@ def mock_get_software_version():
 async def test_check_updates(get_software_versions, get_software_version):
     """Test the case where the latest software version is applicable."""
     # Call the function with a current software version of 1000
-    result = await check_for_update(4447, 8194, 1000)
+    result = await check_for_update(MagicMock(), 4447, 8194, 1000)
 
     assert result == DCL_RESPONSE_SOFTWARE_VERSION_1011["modelVersion"]
 
@@ -72,7 +72,7 @@ async def test_check_updates_not_applicable(
 ):
     """Test the case where the latest software version is not applicable."""
     # Call the function with a current software version of 1
-    result = await check_for_update(4447, 8194, 1)
+    result = await check_for_update(MagicMock(), 4447, 8194, 1)
 
     assert result is None
 
@@ -80,6 +80,6 @@ async def test_check_updates_not_applicable(
 async def test_check_updates_specific_version(get_software_version):
     """Test the case to get a specific version."""
     # Call the function with a current software version of 1000 and request 1011 as update
-    result = await check_for_update(4447, 8194, 1000, 1011)
+    result = await check_for_update(MagicMock(), 4447, 8194, 1000, 1011)
 
     assert result == DCL_RESPONSE_SOFTWARE_VERSION_1011["modelVersion"]

--- a/tests/server/ota/test_dcl.py
+++ b/tests/server/ota/test_dcl.py
@@ -1,0 +1,75 @@
+"""Test DCL OTA updates."""
+
+from unittest.mock import AsyncMock, patch
+
+from matter_server.server.ota.dcl import check_for_update
+
+# Mock the DCL responses (sample from https://on.dcl.csa-iot.org/dcl/model/versions/4447/8194)
+DCL_RESPONSE_SOFTWARE_VERSIONS = {
+    "modelVersions": {
+        "vid": 4447,
+        "pid": 8194,
+        "softwareVersions": [1000, 1011],
+    }
+}
+
+# Mock the DCL responses (sample from https://on.dcl.csa-iot.org/dcl/model/versions/4447/8194/1011)
+DCL_RESPONSE_SOFTWARE_VERSION_1011 = {
+    "modelVersion": {
+        "vid": 4447,
+        "pid": 8194,
+        "softwareVersion": 1011,
+        "softwareVersionString": "1.0.1.1",
+        "cdVersionNumber": 1,
+        "firmwareInformation": "",
+        "softwareVersionValid": True,
+        "otaUrl": "https://cdn.aqara.com/cdn/opencloud-product/mainland/product-firmware/prd/aqara.matter.4447_8194/20240306154144_rel_up_to_enc_ota_sbl_app_aqara.matter.4447_8194_1.0.1.1_115F_2002_20240115195007_7a9b91.ota",
+        "otaFileSize": "615708",
+        "otaChecksum": "rFZ6WdH0DuuCf7HVoRmNjCF73mYZ98DGYpHoDKmf0Bw=",
+        "otaChecksumType": 1,
+        "minApplicableSoftwareVersion": 1000,
+        "maxApplicableSoftwareVersion": 1010,
+        "releaseNotesUrl": "",
+        "creator": "cosmos1qpz3ghnqj6my7gzegkftzav9hpxymkx6zdk73v",
+    }
+}
+
+
+async def test_check_updates():
+    """Test the case where the latest software version is applicable."""
+    with (
+        patch(
+            "matter_server.server.ota.dcl.get_software_versions",
+            new_callable=AsyncMock,
+            return_value=DCL_RESPONSE_SOFTWARE_VERSIONS,
+        ),
+        patch(
+            "matter_server.server.ota.dcl.get_software_version",
+            new_callable=AsyncMock,
+            return_value=DCL_RESPONSE_SOFTWARE_VERSION_1011,
+        ),
+    ):
+        # Call the function with a current software version of 1000
+        result = await check_for_update(4447, 8194, 1000)
+
+        assert result == DCL_RESPONSE_SOFTWARE_VERSION_1011["modelVersion"]
+
+
+async def test_check_updates_not_applicable():
+    """Test the case where the latest software version is not applicable."""
+    with (
+        patch(
+            "matter_server.server.ota.dcl.get_software_versions",
+            new_callable=AsyncMock,
+            return_value=DCL_RESPONSE_SOFTWARE_VERSIONS,
+        ),
+        patch(
+            "matter_server.server.ota.dcl.get_software_version",
+            new_callable=AsyncMock,
+            return_value=DCL_RESPONSE_SOFTWARE_VERSION_1011,
+        ),
+    ):
+        # Call the function with a current software version of 1
+        result = await check_for_update(4447, 8194, 1)
+
+        assert result is None


### PR DESCRIPTION
This adds software update capability to the Python Matter Server.

As it stands, the implementation does the following things:
1. Check the DCL for software updates for a particular device
2. If an update is available, it downloads the firmware locally
3. Prepares the OTA Provider on the Matter fabric (using the Linux OTA Provider example app)
3a. On first use, the OTA Provider App is first commissioned to the fabric
4. Notifies the node about the availability of the OTA Provider and the update

The node then communicates directly with the OTA Provider. Progress of the update can be observed in the OTA Software Update Requestor Cluster of the device being updated.

There are a few things which still need to be sorted out:

- [x] Lifecycle management of the OTA Provider App needs improvement (termination not working/adding more updates)
- [x] Potential candidates need to be better checked if they are indeed compatible (minApplicableSoftwareVersion/maxApplicableSoftwareVersion)
- [x] Checksum of the update files needs to be checked after download
- [x] Split between update check and update apply
- [x] Handle multiple update calls for the same node
- [ ] Support updates from testnet DCL