### PR TITLE
Refactor logic for handling Custom Clusters/Attributes

### DIFF
--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -463,18 +463,15 @@ class MatterClient:
     async def read_attribute(
         self,
         node_id: int,
-        attribute_path: str,
+        attribute_path: str | list[str],
     ) -> dict[str, Any]:
         """Read one or more attribute(s) on a node by specifying an attributepath."""
         updated_values = await self.send_command(
             APICommand.READ_ATTRIBUTE,
-            require_schema=4,
+            require_schema=9,
             node_id=node_id,
             attribute_path=attribute_path,
         )
-        if not isinstance(updated_values, dict):
-            # can happen is the server is running schema < 8
-            return {attribute_path: updated_values}
         return cast(dict[str, Any], updated_values)
 
     async def refresh_attribute(
@@ -509,23 +506,6 @@ class MatterClient:
     async def interview_node(self, node_id: int) -> None:
         """Interview a node."""
         await self.send_command(APICommand.INTERVIEW_NODE, node_id=node_id)
-
-    async def subscribe_attribute(
-        self, node_id: int, attribute_path: str | list[str]
-    ) -> None:
-        """
-        Subscribe to given AttributePath(s).
-
-        Either supply a single attribute path or a list of paths.
-        The given attribute path(s) will be added to the list of attributes that
-        are watched for the given node. This is persistent over restarts.
-        """
-        await self.send_command(
-            APICommand.SUBSCRIBE_ATTRIBUTE,
-            require_schema=4,
-            node_id=node_id,
-            attribute_path=attribute_path,
-        )
 
     async def send_command(
         self,

--- a/matter_server/common/const.py
+++ b/matter_server/common/const.py
@@ -2,7 +2,7 @@
 
 # schema version is used to determine compatibility between server and client
 # bump schema if we add new features and/or make other (breaking) changes
-SCHEMA_VERSION = 8
+SCHEMA_VERSION = 9
 
 
 VERBOSE_LOG_LEVEL = 5

--- a/matter_server/common/custom_clusters.py
+++ b/matter_server/common/custom_clusters.py
@@ -1,4 +1,4 @@
-"""Various models and helpers for (custom) Matter clusters."""
+"""Definitions for custom (vendor specific) Matter clusters."""
 
 from dataclasses import dataclass
 from typing import ClassVar
@@ -17,7 +17,21 @@ from chip.tlv import float32
 
 
 @dataclass
-class EveEnergyCluster(Cluster):
+class CustomCluster:
+    """Base model for a vendor specific custom cluster."""
+
+    should_poll: bool = False  # should the entire cluster be polled for state changes?
+
+
+@dataclass
+class CustomClusterAttribute:
+    """Base model for a vendor specific custom cluster attribute."""
+
+    should_poll: bool = False  # should this attribute be polled ?
+
+
+@dataclass
+class EveEnergyCluster(Cluster, CustomCluster):
     """Custom (vendor-specific) cluster for Eve Energy plug."""
 
     id: ClassVar[int] = 0x130AFC01
@@ -55,7 +69,7 @@ class EveEnergyCluster(Cluster):
         """Attributes for the EveEnergy Cluster."""
 
         @dataclass
-        class Watt(ClusterAttributeDescriptor):
+        class Watt(ClusterAttributeDescriptor, CustomClusterAttribute):
             """Watt Attribute within the EveEnergy Cluster."""
 
             @ChipUtility.classproperty
@@ -76,7 +90,7 @@ class EveEnergyCluster(Cluster):
             value: float32 = 0
 
         @dataclass
-        class WattAccumulated(ClusterAttributeDescriptor):
+        class WattAccumulated(ClusterAttributeDescriptor, CustomClusterAttribute):
             """WattAccumulated Attribute within the EveEnergy Cluster."""
 
             @ChipUtility.classproperty
@@ -97,7 +111,9 @@ class EveEnergyCluster(Cluster):
             value: float32 = 0
 
         @dataclass
-        class wattAccumulatedControlPoint(ClusterAttributeDescriptor):
+        class wattAccumulatedControlPoint(
+            ClusterAttributeDescriptor, CustomClusterAttribute
+        ):
             """wattAccumulatedControlPoint Attribute within the EveEnergy Cluster."""
 
             @ChipUtility.classproperty
@@ -118,7 +134,7 @@ class EveEnergyCluster(Cluster):
             value: float32 = 0
 
         @dataclass
-        class Voltage(ClusterAttributeDescriptor):
+        class Voltage(ClusterAttributeDescriptor, CustomClusterAttribute):
             """Voltage Attribute within the EveEnergy Cluster."""
 
             @ChipUtility.classproperty
@@ -139,7 +155,7 @@ class EveEnergyCluster(Cluster):
             value: float32 = 0
 
         @dataclass
-        class Current(ClusterAttributeDescriptor):
+        class Current(ClusterAttributeDescriptor, CustomClusterAttribute):
             """Current Attribute within the EveEnergy Cluster."""
 
             @ChipUtility.classproperty

--- a/matter_server/common/custom_clusters.py
+++ b/matter_server/common/custom_clusters.py
@@ -31,10 +31,11 @@ class CustomClusterAttribute:
 
 
 @dataclass
-class EveEnergyCluster(Cluster, CustomCluster):
-    """Custom (vendor-specific) cluster for Eve Energy plug."""
+class EveCluster(Cluster, CustomCluster):
+    """Custom (vendor-specific) cluster for Eve."""
 
     id: ClassVar[int] = 0x130AFC01
+    should_poll = True
 
     @ChipUtility.classproperty
     def descriptor(cls) -> ClusterObjectDescriptor:
@@ -66,11 +67,11 @@ class EveEnergyCluster(Cluster, CustomCluster):
     current: float32 | None = None
 
     class Attributes:
-        """Attributes for the EveEnergy Cluster."""
+        """Attributes for the Eve Cluster."""
 
         @dataclass
         class Watt(ClusterAttributeDescriptor, CustomClusterAttribute):
-            """Watt Attribute within the EveEnergy Cluster."""
+            """Watt Attribute within the Eve Cluster."""
 
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -91,7 +92,7 @@ class EveEnergyCluster(Cluster, CustomCluster):
 
         @dataclass
         class WattAccumulated(ClusterAttributeDescriptor, CustomClusterAttribute):
-            """WattAccumulated Attribute within the EveEnergy Cluster."""
+            """WattAccumulated Attribute within the Eve Cluster."""
 
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -114,7 +115,7 @@ class EveEnergyCluster(Cluster, CustomCluster):
         class wattAccumulatedControlPoint(
             ClusterAttributeDescriptor, CustomClusterAttribute
         ):
-            """wattAccumulatedControlPoint Attribute within the EveEnergy Cluster."""
+            """wattAccumulatedControlPoint Attribute within the Eve Cluster."""
 
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -135,7 +136,7 @@ class EveEnergyCluster(Cluster, CustomCluster):
 
         @dataclass
         class Voltage(ClusterAttributeDescriptor, CustomClusterAttribute):
-            """Voltage Attribute within the EveEnergy Cluster."""
+            """Voltage Attribute within the Eve Cluster."""
 
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
@@ -156,7 +157,7 @@ class EveEnergyCluster(Cluster, CustomCluster):
 
         @dataclass
         class Current(ClusterAttributeDescriptor, CustomClusterAttribute):
-            """Current Attribute within the EveEnergy Cluster."""
+            """Current Attribute within the Eve Cluster."""
 
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:

--- a/matter_server/common/models.py
+++ b/matter_server/common/models.py
@@ -42,7 +42,6 @@ class APICommand(str, Enum):
     DEVICE_COMMAND = "device_command"
     REMOVE_NODE = "remove_node"
     GET_VENDOR_NAMES = "get_vendor_names"
-    SUBSCRIBE_ATTRIBUTE = "subscribe_attribute"
     READ_ATTRIBUTE = "read_attribute"
     WRITE_ATTRIBUTE = "write_attribute"
     PING_NODE = "ping_node"

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -1552,7 +1552,7 @@ class MatterDeviceController:
                         else None,
                     )
                 # polling attributes is heavy on network traffic, so we throttle it a bit
-                await asyncio.sleep(5)
+                await asyncio.sleep(2)
         # reschedule self to run at next interval
         self._schedule_custom_attributes_poller()
 

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -1553,6 +1553,8 @@ class MatterDeviceController:
                     )
                 # polling attributes is heavy on network traffic, so we throttle it a bit
                 await asyncio.sleep(5)
+        # reschedule self to run at next interval
+        self._schedule_custom_attributes_poller()
 
     def _schedule_custom_attributes_poller(self) -> None:
         """Schedule running the custom clusters/attributes poller at X interval."""

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -779,22 +779,6 @@ class MatterDeviceController:
                 result.statusCode,
             )
 
-    @api_command(APICommand.SUBSCRIBE_ATTRIBUTE)
-    async def subscribe_attribute(
-        self, node_id: int, attribute_path: str | list[str]
-    ) -> None:
-        """
-        Subscribe to given AttributePath(s).
-
-        Either supply a single attribute path or a list of paths.
-        The given attribute path(s) will be added to the list of attributes that
-        are watched for the given node. This is persistent over restarts.
-        """
-        LOGGER.debug(
-            "The subscribe_attribute command has been deprecated and will be removed from"
-            " a future version. You no longer need to call this to subscribe to attribute changes."
-        )
-
     @api_command(APICommand.PING_NODE)
     async def ping_node(self, node_id: int, attempts: int = 1) -> NodePingResult:
         """Ping node on the currently known IP-adress(es)."""

--- a/scripts/generate_descriptions.py
+++ b/scripts/generate_descriptions.py
@@ -13,7 +13,6 @@ from chip.clusters.ClusterObjects import (
     ClusterAttributeDescriptor,
 )
 
-from matter_server.client.models.clusters import *  # noqa: F403
 from matter_server.client.models.device_types import (
     ALL_TYPES as DEVICE_TYPES,
     DeviceType,


### PR DESCRIPTION
- Refactor read_attribute so it can take both single attribute path and multiple (including wildcards)
- Move custom clusters into shared/common logic, accessible by both server and client
- Add logic to poll (required) custom clusters from the server
- Rename Eve custom cluster as its a Vendor-wide cluster, not only for Eve Energy