### PR TITLE
Fix open commissioning window

### DIFF
--- a/matter_server/server/sdk.py
+++ b/matter_server/server/sdk.py
@@ -168,7 +168,7 @@ class ChipDeviceControllerWrapper:
     ) -> CommissioningParameters:
         """Open a commissioning window to commission a device present on this controller to another."""
         async with self._get_node_lock(node_id):
-            await self._call_sdk(
+            return await self._call_sdk(
                 self._chip_controller.OpenCommissioningWindow,
                 nodeid=node_id,
                 timeout=timeout,


### PR DESCRIPTION
The refactoring broke opening the commission window by missing out returning the Commissioning parameters. Return the Commissioning parameters again.