### PR TITLE
Fix SDK reentrancy issues

### DIFF
--- a/matter_server/server/sdk.py
+++ b/matter_server/server/sdk.py
@@ -59,7 +59,7 @@ class ChipDeviceControllerWrapper:
 
         self._node_lock: dict[int, asyncio.Lock] = {}
         self._subscriptions: dict[int, Attribute.SubscriptionTransaction] = {}
-        self._sdk_non_entrant_executer = ThreadPoolExecutor(max_workers=1)
+        self._sdk_non_entrant_executor = ThreadPoolExecutor(max_workers=1)
 
         # Instantiate the underlying ChipDeviceController instance on the Fabric
         self._chip_controller = self.server.stack.fabric_admin.NewController(
@@ -107,7 +107,7 @@ class ChipDeviceControllerWrapper:
         **kwargs: Any,
     ) -> _T:
         return await self._call_sdk_executor(
-            self._sdk_non_entrant_executer, target, *args, **kwargs
+            self._sdk_non_entrant_executor, target, *args, **kwargs
         )
 
     async def get_compressed_fabric_id(self) -> int:

--- a/matter_server/server/sdk.py
+++ b/matter_server/server/sdk.py
@@ -8,6 +8,7 @@ also makes the API more pythonic where possible.
 from __future__ import annotations
 
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 import logging
 import time
@@ -58,6 +59,7 @@ class ChipDeviceControllerWrapper:
 
         self._node_lock: dict[int, asyncio.Lock] = {}
         self._subscriptions: dict[int, Attribute.SubscriptionTransaction] = {}
+        self._sdk_non_entrant_executer = ThreadPoolExecutor(max_workers=1)
 
         # Instantiate the underlying ChipDeviceController instance on the Fabric
         self._chip_controller = self.server.stack.fabric_admin.NewController(
@@ -71,8 +73,9 @@ class ChipDeviceControllerWrapper:
             self._node_lock[node_id] = asyncio.Lock()
         return self._node_lock[node_id]
 
-    async def _call_sdk(
+    async def _call_sdk_executor(
         self,
+        executor: ThreadPoolExecutor | None,
         target: Callable[..., _T],
         *args: Any,
         **kwargs: Any,
@@ -84,9 +87,27 @@ class ChipDeviceControllerWrapper:
         return cast(
             _T,
             await self.server.loop.run_in_executor(
-                None,
+                executor,
                 partial(target, *args, **kwargs),
             ),
+        )
+
+    async def _call_sdk(
+        self,
+        target: Callable[..., _T],
+        *args: Any,
+        **kwargs: Any,
+    ) -> _T:
+        return await self._call_sdk_executor(None, target, *args, **kwargs)
+
+    async def _call_sdk_non_reentrant(
+        self,
+        target: Callable[..., _T],
+        *args: Any,
+        **kwargs: Any,
+    ) -> _T:
+        return await self._call_sdk_executor(
+            self._sdk_non_entrant_executer, target, *args, **kwargs
         )
 
     async def get_compressed_fabric_id(self) -> int:
@@ -109,7 +130,7 @@ class ChipDeviceControllerWrapper:
         discovery_type: DiscoveryType,
     ) -> PyChipError:
         """Commission a device using a QR Code or Manual Pairing Code."""
-        return await self._call_sdk(
+        return await self._call_sdk_non_reentrant(
             self._chip_controller.CommissionWithCode,
             setupPayload=setup_payload,
             nodeid=node_id,
@@ -124,7 +145,7 @@ class ChipDeviceControllerWrapper:
         disc_filter: Any = None,
     ) -> PyChipError:
         """Commission a device on the network."""
-        return await self._call_sdk(
+        return await self._call_sdk_non_reentrant(
             self._chip_controller.CommissionOnNetwork,
             nodeId=node_id,
             setupPinCode=setup_pin_code,
@@ -136,7 +157,7 @@ class ChipDeviceControllerWrapper:
         self, node_id: int, setup_pin_code: int, ip_addr: str
     ) -> PyChipError:
         """Commission a device using an IP address."""
-        return await self._call_sdk(
+        return await self._call_sdk_non_reentrant(
             self._chip_controller.CommissionIP,
             nodeid=node_id,
             setupPinCode=setup_pin_code,
@@ -168,7 +189,7 @@ class ChipDeviceControllerWrapper:
     ) -> CommissioningParameters:
         """Open a commissioning window to commission a device present on this controller to another."""
         async with self._get_node_lock(node_id):
-            return await self._call_sdk(
+            return await self._call_sdk_non_reentrant(
                 self._chip_controller.OpenCommissioningWindow,
                 nodeid=node_id,
                 timeout=timeout,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "async-timeout",
   "coloredlogs",
   "orjson",
-  "home-assistant-chip-clusters==2024.5.1",
+  "home-assistant-chip-clusters==2024.5.2",
 ]
 description = "Python Matter WebSocket Server"
 license = {text = "Apache-2.0"}
@@ -39,7 +39,7 @@ server = [
   "cryptography==42.0.7",
   "orjson==3.10.3",
   "zeroconf==0.132.2",
-  "home-assistant-chip-core==2024.5.1",
+  "home-assistant-chip-core==2024.5.2",
 ]
 test = [
   "codespell==2.3.0",


### PR DESCRIPTION
API calls to the native side of the SDK which have global callback functions called from the native side in ChipStack are not re-entrant since they use a shared Future object to signal the result. Currently these are all Commissioning and the Open Commission Window APIs. They can also be identified if they call CallAsyncWithCompleteCallback internally. Make sure those are called from a single Thread only.

Also bump the SDK which contains a fix where the same Future is unnecessarily cleared/set for regular API calls. This avoid re-entrancy issues between regular API calls and the ones with callbacks from the native side.

With this, all currently known re-entrancy issues should be addressed.