### PR TITLE
Update to Matter SDK wheels 2024.6.0

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -1301,6 +1301,15 @@ class MatterDeviceController:
         elif (now - last_seen) > NODE_MDNS_BACKOFF:
             # node came back online after being offline for a while or restarted
             logger.info("Node %s re-discovered on MDNS", node_id)
+        elif state_change == ServiceStateChange.Added:
+            # Trigger node re-subscriptions when mDNS entry got added
+            logger.info("Node %s activity on MDNS, trigger resubscribe", node_id)
+            asyncio.create_task(
+                self._chip_device_controller.trigger_resubscribe_if_scheduled(
+                    node_id, "mDNS state change detected"
+                )
+            )
+            return
         else:
             # ignore all other cases
             return

--- a/matter_server/server/sdk.py
+++ b/matter_server/server/sdk.py
@@ -396,3 +396,14 @@ class ChipDeviceControllerWrapper:
     def node_has_subscription(self, node_id: int) -> bool:
         """Check if a node has an active subscription."""
         return node_id in self._subscriptions
+
+    async def trigger_resubscribe_if_scheduled(self, node_id: int, reason: str) -> None:
+        """Trigger resubscribe now if a resubscribe is scheduled.
+
+        If the ReadClient currently has a resubscription attempt scheduled, This
+        function allows to trigger that attempt immediately. This is useful
+        when the server side is up and communicating, and it's a good time to
+        try to resubscribe.
+        """
+        if sub := self._subscriptions.get(node_id, None):
+            await sub.TriggerResubscribeIfScheduled(reason)

--- a/matter_server/server/stack.py
+++ b/matter_server/server/stack.py
@@ -107,7 +107,6 @@ class MatterStack:
 
         self._chip_stack = ChipStack(
             persistentStoragePath=storage_file,
-            installDefaultLogHandler=False,
             enableServerInteractions=False,
         )
 

--- a/matter_server/server/stack.py
+++ b/matter_server/server/stack.py
@@ -8,10 +8,11 @@ import chip.CertificateAuthority
 from chip.ChipStack import ChipStack
 import chip.logging
 from chip.logging import (
-    ERROR_CATEGORY_DETAIL,
-    ERROR_CATEGORY_ERROR,
-    ERROR_CATEGORY_NONE,
-    ERROR_CATEGORY_PROGRESS,
+    LOG_CATEGORY_AUTOMATION,
+    LOG_CATEGORY_DETAIL,
+    LOG_CATEGORY_ERROR,
+    LOG_CATEGORY_NONE,
+    LOG_CATEGORY_PROGRESS,
 )
 from chip.logging.library_handle import _GetLoggingLibraryHandle
 from chip.logging.types import LogRedirectCallback_t
@@ -45,13 +46,13 @@ def _redirect_to_python_logging(
     # unknown/None as critical.
     level = logging.CRITICAL
 
-    if category == ERROR_CATEGORY_ERROR:
+    if category == LOG_CATEGORY_ERROR:
         level = CHIP_ERROR
-    elif category == ERROR_CATEGORY_PROGRESS:
+    elif category == LOG_CATEGORY_PROGRESS:
         level = CHIP_PROGRESS
-    elif category == ERROR_CATEGORY_DETAIL:
+    elif category == LOG_CATEGORY_DETAIL:
         level = CHIP_DETAIL
-    elif category == 4:  # TODO: Add automation level to upstream Python bindings
+    elif category == LOG_CATEGORY_AUTOMATION:
         level = CHIP_AUTOMATION
 
     logger.log(level, "%s", message)
@@ -62,15 +63,15 @@ def init_logging(category: str) -> None:
 
     _LOGGER.info("Initializing CHIP/Matter Logging...")
     global _category_num  # pylint: disable=global-statement  # noqa: PLW0603
-    _category_num = ERROR_CATEGORY_NONE
+    _category_num = LOG_CATEGORY_NONE
     if category == "ERROR":
-        _category_num = ERROR_CATEGORY_ERROR
+        _category_num = LOG_CATEGORY_ERROR
     elif category == "PROGRESS":
-        _category_num = ERROR_CATEGORY_PROGRESS
+        _category_num = LOG_CATEGORY_PROGRESS
     elif category == "DETAIL":
-        _category_num = ERROR_CATEGORY_DETAIL
+        _category_num = LOG_CATEGORY_DETAIL
     elif category == "AUTOMATION":
-        _category_num = 4
+        _category_num = LOG_CATEGORY_AUTOMATION
 
     logging.addLevelName(CHIP_ERROR, "CHIP_ERROR")
     logging.addLevelName(CHIP_PROGRESS, "CHIP_PROGRESS")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "async-timeout",
   "coloredlogs",
   "orjson",
-  "home-assistant-chip-clusters==2024.5.2",
+  "home-assistant-chip-clusters==2024.6.0",
 ]
 description = "Python Matter WebSocket Server"
 license = {text = "Apache-2.0"}
@@ -39,7 +39,7 @@ server = [
   "cryptography==42.0.8",
   "orjson==3.10.3",
   "zeroconf==0.132.2",
-  "home-assistant-chip-core==2024.5.2",
+  "home-assistant-chip-core==2024.6.0",
 ]
 test = [
   "codespell==2.3.0",


### PR DESCRIPTION
Matter SDK/CHIP wheels [2024.6.0 release notes](https://github.com/home-assistant-libs/chip-wheels/releases/tag/2024.6.0).

This mostly aligns the Matter SDK Python bindings to what is in latest master.

Probably most noteworthy is that SendCommand/GetConnectedDevice are now asyncio friendly throughout, so should never block even when the CHIP thread is very busy. No such cases have been observed, so this is mostly theoretical at this point.

Some unnecessary locking has been dropped which potentially could improve performance.

And finally, the API `TriggerResubscribeIfScheduled` on subscriptions is exposed to Python. This allows to resubscribe subscriptions quicker when a device re-appears.