### PR TITLE
Bump schema version to 9

### DIFF
--- a/matter_server/server/const.py
+++ b/matter_server/server/const.py
@@ -4,7 +4,7 @@ import pathlib
 from typing import Final
 
 # The minimum schema version (of a client) the server can support
-MIN_SCHEMA_VERSION = 5
+MIN_SCHEMA_VERSION = 9
 
 # schema version of our data model
 # only bump if the format of the data in MatterNodeData changed


### PR DESCRIPTION
With #715, the schema actually changed as an API (subscribe_attribute) got removed. Retroactively bump the schema version to 9.