### PR TITLE
Fix minimal schema version error

### DIFF
--- a/matter_server/client/connection.py
+++ b/matter_server/client/connection.py
@@ -84,7 +84,7 @@ class MatterClientConnection:
             # our schema version is too low and can't be handled by the server anymore.
             await self._ws_client.close()
             raise InvalidServerVersion(
-                f"Matter schema version is incompatible: {info.schema_version}, "
+                f"Matter schema version is incompatible: {SCHEMA_VERSION}, "
                 f"the server requires at least {info.min_supported_schema_version} "
                 " - update the Matter client to a more recent version or downgrade the server."
             )


### PR DESCRIPTION
When the minimal schema version is not met, the client error message should state the schema version it is using instead of the servers current schema version.