### PR TITLE
Remove unnecessary debug print statements

### DIFF
--- a/matter_server/server/server.py
+++ b/matter_server/server/server.py
@@ -291,7 +291,6 @@ class MatterServer:
         """Register all methods decorated as api_command."""
         for cls in (self, self._device_controller, self.vendor_info):
             for attr_name in dir(cls):
-                print(attr_name)
                 if attr_name.startswith("_"):
                     continue
                 val = getattr(cls, attr_name)


### PR DESCRIPTION
A debug print sneaked into the code late in review. This commit removes the print again.