### PR TITLE
Reintroduce ability to get IP addresses without scope

### DIFF
--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -273,14 +273,14 @@ class MatterClient:
     async def get_node_ip_addresses(
         self, node_id: int, prefer_cache: bool = True, scoped: bool = False
     ) -> list[str]:
-        """Return the currently known (scoped) IP-adress(es)."""
+        """Return the currently known (scoped) IP-address(es)."""
         if TYPE_CHECKING:
             assert self.server_info is not None
         if self.server_info.schema_version >= 8:
             return cast(
                 list[str],
                 await self.send_command(
-                    APICommand.GET_NODE_IP_ADRESSES,
+                    APICommand.GET_NODE_IP_ADDRESSES,
                     require_schema=8,
                     node_id=node_id,
                     prefer_cache=prefer_cache,

--- a/matter_server/common/models.py
+++ b/matter_server/common/models.py
@@ -45,7 +45,7 @@ class APICommand(str, Enum):
     READ_ATTRIBUTE = "read_attribute"
     WRITE_ATTRIBUTE = "write_attribute"
     PING_NODE = "ping_node"
-    GET_NODE_IP_ADRESSES = "get_node_ip_addresses"
+    GET_NODE_IP_ADDRESSES = "get_node_ip_addresses"
     IMPORT_TEST_NODE = "import_test_node"
 
 


### PR DESCRIPTION
This commit reintroduces the ability to get IP addresses without scope. This is useful in case we are really not interested in the scope on client side e.g. because we know we run on a different system.

There is currently not need in Home Assistant for this feature, but rather to break it for no good reason just keep it around, it might be useful for someone.