### PR TITLE
[Eve Door] EveCluster --> Add attribute TimesOpened

### DIFF
--- a/matter_server/common/custom_clusters.py
+++ b/matter_server/common/custom_clusters.py
@@ -67,6 +67,9 @@ class EveCluster(Cluster, CustomClusterMixin):
         return ClusterObjectDescriptor(
             Fields=[
                 ClusterObjectFieldDescriptor(
+                    Label="timesOpened", Tag=0x130A0006, Type=int
+                ),
+                ClusterObjectFieldDescriptor(
                     Label="watt", Tag=0x130A000A, Type=float32
                 ),
                 ClusterObjectFieldDescriptor(
@@ -84,6 +87,7 @@ class EveCluster(Cluster, CustomClusterMixin):
             ]
         )
 
+    timesOpened: int | None = None
     watt: float32 | None = None
     wattAccumulated: float32 | None = None
     wattAccumulatedControlPoint: float32 | None = None
@@ -92,6 +96,30 @@ class EveCluster(Cluster, CustomClusterMixin):
 
     class Attributes:
         """Attributes for the Eve Cluster."""
+
+
+        @dataclass
+        class TimesOpened(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """TimesOpened Attribute within the Eve Cluster."""
+
+            should_poll = True
+
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                """Return cluster id."""
+                return 0x130AFC01
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                """Return attribute id."""
+                return 0x130A0006
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
+                return ClusterObjectFieldDescriptor(Type=int)
+
+            value: int = 0
 
         @dataclass
         class Watt(ClusterAttributeDescriptor, CustomClusterAttributeMixin):

--- a/matter_server/common/custom_clusters.py
+++ b/matter_server/common/custom_clusters.py
@@ -27,7 +27,6 @@ if TYPE_CHECKING:
 ALL_CUSTOM_CLUSTERS: dict[int, Cluster] = {}
 ALL_CUSTOM_ATTRIBUTES: dict[int, dict[int, ClusterAttributeDescriptor]] = {}
 
-
 @dataclass
 class CustomClusterMixin:
     """Base model for a vendor specific custom cluster."""

--- a/matter_server/common/custom_clusters.py
+++ b/matter_server/common/custom_clusters.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
 ALL_CUSTOM_CLUSTERS: dict[int, Cluster] = {}
 ALL_CUSTOM_ATTRIBUTES: dict[int, dict[int, ClusterAttributeDescriptor]] = {}
 
+
 @dataclass
 class CustomClusterMixin:
     """Base model for a vendor specific custom cluster."""
@@ -95,7 +96,6 @@ class EveCluster(Cluster, CustomClusterMixin):
 
     class Attributes:
         """Attributes for the Eve Cluster."""
-
 
         @dataclass
         class TimesOpened(ClusterAttributeDescriptor, CustomClusterAttributeMixin):


### PR DESCRIPTION
**EveCluster**

I would like to add attributes to the "EveCluster" cluster. You can see them here:

EveCluster Attributes for Eve Door:
- TimesOpened: 319422470 (0x00130a0006)

![image](https://github.com/home-assistant-libs/python-matter-server/assets/938089/fed1b772-8db7-4f6b-aec8-8e644acafde5)

