### PR TITLE
Do not filter out subscription updates by fabric

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -1094,6 +1094,7 @@ class MatterDeviceController:
                 return_cluster_objects=False,
                 report_interval=(interval_floor, interval_ceiling),
                 auto_resubscribe=True,
+                fabric_filtered=False,
             )
         )
 


### PR DESCRIPTION
While testing a Matter smart lock (Aqara U200) I noticed that state changes do not propagate when the lock is controlled from the keypad or another controller. Turns out that the state changes are not coming through as attribute update if the command was not issued by our controller, due to the fact we filter attribute updates by default by fabric.

This PR updates that behavior so we will also be notified by state changes originated from other controllers.
Other than maybe a little bit of extra traffic I don't see any side effects from this change.