### PR TITLE
Update to Matter SDK wheels 2024.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "async-timeout",
   "coloredlogs",
   "orjson",
-  "home-assistant-chip-clusters==2024.6.0",
+  "home-assistant-chip-clusters==2024.6.1",
 ]
 description = "Python Matter WebSocket Server"
 license = {text = "Apache-2.0"}
@@ -39,7 +39,7 @@ server = [
   "cryptography==42.0.8",
   "orjson==3.10.5",
   "zeroconf==0.132.2",
-  "home-assistant-chip-core==2024.6.0",
+  "home-assistant-chip-core==2024.6.1",
 ]
 test = [
   "codespell==2.3.0",


### PR DESCRIPTION
Matter SDK/CHIP wheels [2024.6.1 release notes](https://github.com/home-assistant-libs/chip-wheels/releases/tag/2024.6.1).

This update improves the implementation of the commissioning API's considerably, using thread-safe Python provided futures (see https://github.com/project-chip/connectedhomeip/pull/33891). In practice it should not make a difference, as the API is still not reentrant. But it will be easier to transition to an asyncio based API.

Another notable change is that with this update mDNS discovery is disabled immediately after discovering the device in question when using the on-network commissioning mode. The on-network commissioning mode is used by both the Android and the Apple companion app. 

This prevents spurious error logs like this: `Unknown filter type; all matches will fail`.

Note: On Android, the half-card commissioning uses the on-network commissioning mode. However, the in-app commissioning flow uses the IP address which doesn't do a mDNS discovery).

