### PR TITLE
Added custom cluster for energy consumption data for Neo smart plug

### DIFF
--- a/matter_server/common/custom_clusters.py
+++ b/matter_server/common/custom_clusters.py
@@ -237,11 +237,12 @@ class EveCluster(Cluster, CustomClusterMixin):
 
             value: float32 = 0
 
+
 @dataclass
 class NeoCluster(Cluster, CustomClusterMixin):
     """Custom (vendor-specific) cluster for Neo - Vendor ID 4991 (0x137F)."""
 
-    id: ClassVar[int] = 0x00125dfc11
+    id: ClassVar[int] = 0x00125DFC11
 
     @ChipUtility.classproperty
     def descriptor(cls) -> ClusterObjectDescriptor:
@@ -249,16 +250,16 @@ class NeoCluster(Cluster, CustomClusterMixin):
         return ClusterObjectDescriptor(
             Fields=[
                 ClusterObjectFieldDescriptor(
-                    Label="wattAccumulated", Tag=0x00125d0021, Type=float32
+                    Label="wattAccumulated", Tag=0x00125D0021, Type=float32
                 ),
                 ClusterObjectFieldDescriptor(
-                    Label="watt", Tag=0x00125d0023, Type=float32
+                    Label="watt", Tag=0x00125D0023, Type=float32
                 ),
                 ClusterObjectFieldDescriptor(
-                    Label="current", Tag=0x00125d0022, Type=float32
+                    Label="current", Tag=0x00125D0022, Type=float32
                 ),
                 ClusterObjectFieldDescriptor(
-                    Label="voltage", Tag=0x00125d0024, Type=float32
+                    Label="voltage", Tag=0x00125D0024, Type=float32
                 ),
             ]
         )
@@ -275,17 +276,15 @@ class NeoCluster(Cluster, CustomClusterMixin):
         class Watt(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
             """Watt Attribute within the Neo Cluster."""
 
-            should_poll = True
-
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
                 """Return cluster id."""
-                return 0x00125dfc11
+                return 0x00125DFC11
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
                 """Return attribute id."""
-                return 0x00125d0023
+                return 0x00125D0023
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
@@ -298,17 +297,15 @@ class NeoCluster(Cluster, CustomClusterMixin):
         class WattAccumulated(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
             """WattAccumulated Attribute within the Neo Cluster."""
 
-            should_poll = True
-
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
                 """Return cluster id."""
-                return 0x00125dfc11
+                return 0x00125DFC11
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
                 """Return attribute id."""
-                return 0x00125d0021
+                return 0x00125D0021
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
@@ -321,17 +318,15 @@ class NeoCluster(Cluster, CustomClusterMixin):
         class Voltage(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
             """Voltage Attribute within the Neo Cluster."""
 
-            should_poll = True
-
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
                 """Return cluster id."""
-                return 0x00125dfc11
+                return 0x00125DFC11
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
                 """Return attribute id."""
-                return 0x00125d0024
+                return 0x00125D0024
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
@@ -344,17 +339,15 @@ class NeoCluster(Cluster, CustomClusterMixin):
         class Current(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
             """Current Attribute within the Neo Cluster."""
 
-            should_poll = True
-
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
                 """Return cluster id."""
-                return 0x00125dfc11
+                return 0x00125DFC11
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
                 """Return attribute id."""
-                return 0x00125d0022
+                return 0x00125D0022
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:

--- a/matter_server/common/custom_clusters.py
+++ b/matter_server/common/custom_clusters.py
@@ -237,6 +237,132 @@ class EveCluster(Cluster, CustomClusterMixin):
 
             value: float32 = 0
 
+@dataclass
+class NeoCluster(Cluster, CustomClusterMixin):
+    """Custom (vendor-specific) cluster for Neo - Vendor ID 4991 (0x137F)."""
+
+    id: ClassVar[int] = 0x00125dfc11
+
+    @ChipUtility.classproperty
+    def descriptor(cls) -> ClusterObjectDescriptor:
+        """Return descriptor for this cluster."""
+        return ClusterObjectDescriptor(
+            Fields=[
+                ClusterObjectFieldDescriptor(
+                    Label="wattAccumulated", Tag=0x00125d0021, Type=float32
+                ),
+                ClusterObjectFieldDescriptor(
+                    Label="watt", Tag=0x00125d0023, Type=float32
+                ),
+                ClusterObjectFieldDescriptor(
+                    Label="current", Tag=0x00125d0022, Type=float32
+                ),
+                ClusterObjectFieldDescriptor(
+                    Label="voltage", Tag=0x00125d0024, Type=float32
+                ),
+            ]
+        )
+
+    watt: float32 | None = None
+    wattAccumulated: float32 | None = None
+    voltage: float32 | None = None
+    current: float32 | None = None
+
+    class Attributes:
+        """Attributes for the Neo Cluster."""
+
+        @dataclass
+        class Watt(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """Watt Attribute within the Neo Cluster."""
+
+            should_poll = True
+
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                """Return cluster id."""
+                return 0x00125dfc11
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                """Return attribute id."""
+                return 0x00125d0023
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
+                return ClusterObjectFieldDescriptor(Type=float32)
+
+            value: float32 = 0
+
+        @dataclass
+        class WattAccumulated(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """WattAccumulated Attribute within the Neo Cluster."""
+
+            should_poll = True
+
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                """Return cluster id."""
+                return 0x00125dfc11
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                """Return attribute id."""
+                return 0x00125d0021
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
+                return ClusterObjectFieldDescriptor(Type=float32)
+
+            value: float32 = 0
+
+        @dataclass
+        class Voltage(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """Voltage Attribute within the Neo Cluster."""
+
+            should_poll = True
+
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                """Return cluster id."""
+                return 0x00125dfc11
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                """Return attribute id."""
+                return 0x00125d0024
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
+                return ClusterObjectFieldDescriptor(Type=float32)
+
+            value: float32 = 0
+
+        @dataclass
+        class Current(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """Current Attribute within the Neo Cluster."""
+
+            should_poll = True
+
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                """Return cluster id."""
+                return 0x00125dfc11
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                """Return attribute id."""
+                return 0x00125d0022
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
+                return ClusterObjectFieldDescriptor(Type=float32)
+
+            value: float32 = 0
+
 
 def check_polled_attributes(node_data: MatterNodeData) -> set[str]:
     """Check if custom attributes are present in the node data that need to be polled."""


### PR DESCRIPTION
I added a custom cluster definition for energy consumption data that the Neo Coolcam Matter smart plug measures and writes to this cluster.

However the raw values for voltage and watt will need additional scaling, the voltage raw value for e.g. 227.3 V is "2273", the watt raw value for e.g. 10.1 W is "101". Current is reported in mA. Wattaccumulated is reported in Wh, however the time frame for each accumulation measurement does not seem to be constant.  

In addition I could not yet find a raw value for total energy consumption, even so the Tuya app reports such a value.