### PR TITLE
Edge case defect when importing the first test node into dashboard

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -865,7 +865,12 @@ class MatterDeviceController:
         else:
             dump_nodes = dump_data["data"]["server"]["nodes"]
         # node ids > 900000 are reserved for test nodes
-        next_test_node_id = max(*(x for x in self._nodes), TEST_NODE_START) + 1
+        if self._nodes:
+            next_test_node_id = max(*(x for x in self._nodes), TEST_NODE_START) + 1
+        else:
+            #an empty self._nodes dict evaluates to false so we set the first 
+            #test node id to TEST_NODE_START
+            next_test_node_id = TEST_NODE_START
         for node_dict in dump_nodes:
             node = dataclass_from_dict(MatterNodeData, node_dict, strict=True)
             node.node_id = next_test_node_id

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -868,8 +868,8 @@ class MatterDeviceController:
         if self._nodes:
             next_test_node_id = max(*(x for x in self._nodes), TEST_NODE_START) + 1
         else:
-            #an empty self._nodes dict evaluates to false so we set the first 
-            #test node id to TEST_NODE_START
+            # an empty self._nodes dict evaluates to false so we set the first
+            # test node id to TEST_NODE_START
             next_test_node_id = TEST_NODE_START
         for node_dict in dump_nodes:
             node = dataclass_from_dict(MatterNodeData, node_dict, strict=True)


### PR DESCRIPTION
Fixed for an edge case defect/bug when importing the first test node using the dashboard via a diagnostics file.

### Procedure to replicate bug:
1) run the python matter server (no matter nodes commissioned)
2) run the dashboard node app
3) attempted to try to import a device diagnostic file
    - tested with this [diagnostic file](https://gist.githubusercontent.com/oidebrett/bc8adb22da7d535a85dda163870b6bfe/raw/99c841c7f3dd1d463ce98ccbb0b718e58d0eee02/matter-260e4ed87923fb5ffd94045df082f99f-Smart%2520Plug%2520Mini-52001041c32f3b43790185078ec65ad0.json) 
4) the dashboard throws an error in device_controller.py file

`
File "/home/XXX/Projects/pip-python-matter-server/venv/lib/python3.11/site-packages/matter_server/server/device_controller.py", line 857, in import_test_node
    next_test_node_id = max(*(x for x in self._nodes), TEST_NODE_START) + 1
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'int' object is not iterable
`
### Fix for defect:
In the "import_test_node" function in device_controller.py, a check was coded for an empty dict for self._nodes and if empty set the next_test_node_id to TEST_NODE_START

