### PR TITLE
Don't use threadsafe variant in signal_event

### DIFF
--- a/matter_server/server/server.py
+++ b/matter_server/server/server.py
@@ -252,7 +252,7 @@ class MatterServer:
             if asyncio.iscoroutinefunction(callback):
                 asyncio.create_task(callback(evt, data))
             else:
-                self.loop.call_soon_threadsafe(callback, evt, data)
+                self.loop.call_soon(callback, evt, data)
 
     def scope_ipv6_lla(self, ip_addr: str) -> str:
         """Scope IPv6 link-local addresses to primary interface.


### PR DESCRIPTION
All calls to signal_event are made in the asyncio event loop thread. Therefore, we don't need to use the threadsafe variant of call_soon() anymore.

This was anyways a bit brittle as asyncio.create_task() is not threadsafe, so calling signal_event from a different thread was not really safe.