### PR TITLE
Override Liveness timeout on shutdown

### DIFF
--- a/matter_server/server/sdk.py
+++ b/matter_server/server/sdk.py
@@ -395,6 +395,13 @@ class ChipDeviceControllerWrapper:
         if sub := self._subscriptions.pop(node_id, None):
             await self._call_sdk(sub.Shutdown)
 
+    async def subscription_override_liveness_timeout(
+        self, node_id: int, liveness_timeout_ms: int
+    ) -> None:
+        """Override the liveness timeout for the subscription of the node."""
+        if sub := self._subscriptions.get(node_id, None):
+            await self._call_sdk(sub.OverrideLivenessTimeoutMs, liveness_timeout_ms)
+
     def node_has_subscription(self, node_id: int) -> bool:
         """Check if a node has an active subscription."""
         return node_id in self._subscriptions

--- a/matter_server/server/sdk.py
+++ b/matter_server/server/sdk.py
@@ -399,7 +399,7 @@ class ChipDeviceControllerWrapper:
         self, node_id: int, liveness_timeout_ms: int
     ) -> None:
         """Override the liveness timeout for the subscription of the node."""
-        if sub := self._subscriptions.get(node_id, None):
+        if sub := self._subscriptions.get(node_id):
             await self._call_sdk(sub.OverrideLivenessTimeoutMs, liveness_timeout_ms)
 
     def node_has_subscription(self, node_id: int) -> bool:


### PR DESCRIPTION
Override the liveness timeout when a node announces a shutdown. This causes the subscription logic to notice that the device went offline much quicker, which is especially nice for battery operated devices which have a high liveness timeout.

We use 5s as timeout to make sure the device really completed shutdown, and that the first subscription resumption triggered by this actually fails. We can restore the timeout to default immediately after, since the SDK is in subscription resumption mode now.

Another alternative would be to shutdown the subscription (mark the device as offline). This has the disadvantage that the controller needs to recreate the subscription from scratch when it comes back, which causes unnecessary traffic.

If the node stays offline for longer than 30s, we'll still trigger the offline logic which will shutdown the subscription entirely.