### PR TITLE
Raise InvalidServerVersion when Server is too old too

### DIFF
--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -10,7 +10,6 @@ import uuid
 from chip.clusters import Objects as Clusters
 from chip.clusters.Types import NullValue
 
-from matter_server.common.const import SCHEMA_VERSION
 from matter_server.common.errors import ERROR_MAP, NodeNotExists
 
 from ..common.helpers.util import (
@@ -38,7 +37,7 @@ from ..common.models import (
     SuccessResultMessage,
 )
 from .connection import MatterClientConnection
-from .exceptions import ConnectionClosed, InvalidServerVersion, InvalidState
+from .exceptions import ConnectionClosed, InvalidState, ServerVersionTooOld
 from .models.node import (
     MatterFabricData,
     MatterNode,
@@ -524,12 +523,9 @@ class MatterClient:
             and self.server_info is not None
             and require_schema > self.server_info.schema_version
         ):
-            raise InvalidServerVersion(
+            raise ServerVersionTooOld(
                 "Command not available due to incompatible server version. Update the Matter "
                 f"Server to a version that supports at least api schema {require_schema}.",
-                SCHEMA_VERSION,
-                self.server_info.schema_version,
-                self.server_info.min_supported_schema_version,
             )
 
         return CommandMessage(

--- a/matter_server/client/connection.py
+++ b/matter_server/client/connection.py
@@ -80,13 +80,24 @@ class MatterClientConnection:
         self.server_info = info
 
         # basic check for server schema version compatibility
-        if info.min_supported_schema_version > SCHEMA_VERSION > info.schema_version:
-            # our schema version is too low and can't be handled by the server anymore.
+        if info.min_supported_schema_version > SCHEMA_VERSION:
+            # The client schema version is too low and can't be handled by the server anymore
             await self._ws_client.close()
             raise InvalidServerVersion(
                 f"Matter schema version is incompatible: {SCHEMA_VERSION}, "
                 f"the server requires at least {info.min_supported_schema_version} "
                 " - update the Matter client to a more recent version or downgrade the server.",
+                SCHEMA_VERSION,
+                info.schema_version,
+                info.min_supported_schema_version,
+            )
+        if info.schema_version < SCHEMA_VERSION:
+            # The client schema is too new and the server can't handle it yet
+            await self._ws_client.close()
+            raise InvalidServerVersion(
+                f"Matter schema version is incompatible: {SCHEMA_VERSION}, "
+                f"the server requires supports at most {info.schema_version} "
+                " - update the Matter server to a more recent version or downgrade the client.",
                 SCHEMA_VERSION,
                 info.schema_version,
                 info.min_supported_schema_version,

--- a/matter_server/client/connection.py
+++ b/matter_server/client/connection.py
@@ -80,13 +80,16 @@ class MatterClientConnection:
         self.server_info = info
 
         # basic check for server schema version compatibility
-        if info.min_supported_schema_version > SCHEMA_VERSION:
+        if info.min_supported_schema_version > SCHEMA_VERSION > info.schema_version:
             # our schema version is too low and can't be handled by the server anymore.
             await self._ws_client.close()
             raise InvalidServerVersion(
                 f"Matter schema version is incompatible: {SCHEMA_VERSION}, "
                 f"the server requires at least {info.min_supported_schema_version} "
-                " - update the Matter client to a more recent version or downgrade the server."
+                " - update the Matter client to a more recent version or downgrade the server.",
+                SCHEMA_VERSION,
+                info.schema_version,
+                info.min_supported_schema_version,
             )
 
         LOGGER.info(

--- a/matter_server/client/connection.py
+++ b/matter_server/client/connection.py
@@ -26,9 +26,10 @@ from .exceptions import (
     ConnectionClosed,
     ConnectionFailed,
     InvalidMessage,
-    InvalidServerVersion,
     InvalidState,
     NotConnected,
+    ServerVersionTooNew,
+    ServerVersionTooOld,
 )
 
 LOGGER = logging.getLogger(f"{__package__}.connection")
@@ -79,28 +80,22 @@ class MatterClientConnection:
         info = cast(ServerInfoMessage, await self.receive_message_or_raise())
         self.server_info = info
 
-        # basic check for server schema version compatibility
+        if info.schema_version < SCHEMA_VERSION:
+            # The client schema is too new, the server can't handle it yet
+            await self._ws_client.close()
+            raise ServerVersionTooOld(
+                f"Matter schema version is incompatible: {SCHEMA_VERSION}, "
+                f"the server supports at most {info.schema_version} "
+                "- update the Matter server to a more recent version or downgrade the client."
+            )
+
         if info.min_supported_schema_version > SCHEMA_VERSION:
             # The client schema version is too low and can't be handled by the server anymore
             await self._ws_client.close()
-            raise InvalidServerVersion(
+            raise ServerVersionTooNew(
                 f"Matter schema version is incompatible: {SCHEMA_VERSION}, "
                 f"the server requires at least {info.min_supported_schema_version} "
-                " - update the Matter client to a more recent version or downgrade the server.",
-                SCHEMA_VERSION,
-                info.schema_version,
-                info.min_supported_schema_version,
-            )
-        if info.schema_version < SCHEMA_VERSION:
-            # The client schema is too new and the server can't handle it yet
-            await self._ws_client.close()
-            raise InvalidServerVersion(
-                f"Matter schema version is incompatible: {SCHEMA_VERSION}, "
-                f"the server requires supports at most {info.schema_version} "
-                " - update the Matter server to a more recent version or downgrade the client.",
-                SCHEMA_VERSION,
-                info.schema_version,
-                info.min_supported_schema_version,
+                "- update the Matter client to a more recent version or downgrade the server."
             )
 
         LOGGER.info(

--- a/matter_server/client/exceptions.py
+++ b/matter_server/client/exceptions.py
@@ -53,3 +53,16 @@ class InvalidMessage(MatterClientException):
 
 class InvalidServerVersion(MatterClientException):
     """Exception raised when connected to server with incompatible version."""
+
+    def __init__(
+        self,
+        msg: str,
+        client_schema_version: int,
+        server_schema_version: int,
+        min_supported_schema_version: int,
+    ):
+        """Initialize an invalid server version error."""
+        super().__init__(msg)
+        self.client_schema_version = client_schema_version
+        self.server_schema_version = server_schema_version
+        self.min_supported_schema_version = min_supported_schema_version

--- a/matter_server/client/exceptions.py
+++ b/matter_server/client/exceptions.py
@@ -54,15 +54,10 @@ class InvalidMessage(MatterClientException):
 class InvalidServerVersion(MatterClientException):
     """Exception raised when connected to server with incompatible version."""
 
-    def __init__(
-        self,
-        msg: str,
-        client_schema_version: int,
-        server_schema_version: int,
-        min_supported_schema_version: int,
-    ):
-        """Initialize an invalid server version error."""
-        super().__init__(msg)
-        self.client_schema_version = client_schema_version
-        self.server_schema_version = server_schema_version
-        self.min_supported_schema_version = min_supported_schema_version
+
+class ServerVersionTooOld(InvalidServerVersion):
+    """Exception raised when connected to server with is too old to support this client."""
+
+
+class ServerVersionTooNew(InvalidServerVersion):
+    """Exception raised when connected to server with is too new for this client."""

--- a/matter_server/server/server.py
+++ b/matter_server/server/server.py
@@ -131,6 +131,10 @@ class MatterServer:
         self.command_handlers: dict[str, APICommandHandler] = {}
         self._device_controller: MatterDeviceController | None = None
         self._subscribers: set[EventCallBackType] = set()
+        if MIN_SCHEMA_VERSION > SCHEMA_VERSION:
+            raise RuntimeError(
+                "Minimum supported schema version can't be higher than current schema version."
+            )
 
     @cached_property
     def device_controller(self) -> MatterDeviceController:


### PR DESCRIPTION
Currently InvalidServerVersion was only raised when the client was too old (Server wasn't able to handle such an old client anymore), e.g. after a backwards incompatible change Server side.

However, if the client was newer than the Server schema version, no error was raised. This essentially never triggered the add-on update logic in Core.

This change makes sure that we raise InvalidServerVersion when the Server is too old for the client too. We also add properties to the Exception so a client can figure out which situation we are dealing with (too old/too new) and act accordingly.