### PR TITLE
Update to Matter SDK wheels 2024.6.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "async-timeout",
   "coloredlogs",
   "orjson",
-  "home-assistant-chip-clusters==2024.6.2",
+  "home-assistant-chip-clusters==2024.6.3",
 ]
 description = "Python Matter WebSocket Server"
 license = {text = "Apache-2.0"}
@@ -39,7 +39,7 @@ server = [
   "cryptography==42.0.8",
   "orjson==3.10.5",
   "zeroconf==0.132.2",
-  "home-assistant-chip-core==2024.6.2",
+  "home-assistant-chip-core==2024.6.3",
 ]
 test = [
   "codespell==2.3.0",


### PR DESCRIPTION
Matter SDK/CHIP wheels [2024.6.3 release notes](https://github.com/home-assistant-libs/chip-wheels/releases/tag/2024.6.3).

This lifts the connected device limit from 64 to 1024.