### PR TITLE
Update compose.yml to follow new Compose Specification

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   # python-matter-server
   matter-server:


### PR DESCRIPTION
The [new Docker Compose Specification](https://docs.docker.com/compose/compose-file/04-version-and-name/) makes obsolete the version top-level element