### PR TITLE
Update to Matter SDK wheels 2024.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "async-timeout",
   "coloredlogs",
   "orjson",
-  "home-assistant-chip-clusters==2024.6.4",
+  "home-assistant-chip-clusters==2024.7.0",
 ]
 description = "Python Matter WebSocket Server"
 license = {text = "Apache-2.0"}
@@ -39,7 +39,7 @@ server = [
   "cryptography==42.0.8",
   "orjson==3.10.5",
   "zeroconf==0.132.2",
-  "home-assistant-chip-core==2024.6.4",
+  "home-assistant-chip-core==2024.7.0",
 ]
 test = [
   "codespell==2.3.0",


### PR DESCRIPTION
This increases the secure session limit to 4096 which should allow subscriptions for more than the previous limit of 50 devices simultaneously.