### PR TITLE
Add flag for test-net DCL

### DIFF
--- a/matter_server/server/__main__.py
+++ b/matter_server/server/__main__.py
@@ -98,6 +98,12 @@ parser.add_argument(
     default=None,
     help="Directory where PAA root certificates are stored.",
 )
+parser.add_argument(
+    "--use-test-net-dcl",
+    type=bool,
+    default=False,
+    help="Use PAA root certificates and other device information from test-net DCL.",
+)
 
 args = parser.parse_args()
 
@@ -181,6 +187,7 @@ def main() -> None:
         args.listen_address,
         args.primary_interface,
         args.paa_root_cert_dir,
+        args.use_test_net_dcl,
     )
 
     async def handle_stop(loop: asyncio.AbstractEventLoop) -> None:

--- a/matter_server/server/__main__.py
+++ b/matter_server/server/__main__.py
@@ -99,10 +99,10 @@ parser.add_argument(
     help="Directory where PAA root certificates are stored.",
 )
 parser.add_argument(
-    "--use-test-net-dcl",
+    "--enable-test-net-dcl",
     type=bool,
     default=False,
-    help="Use PAA root certificates and other device information from test-net DCL.",
+    help="Enable PAA root certificates and other device information from test-net DCL.",
 )
 
 args = parser.parse_args()
@@ -187,7 +187,7 @@ def main() -> None:
         args.listen_address,
         args.primary_interface,
         args.paa_root_cert_dir,
-        args.use_test_net_dcl,
+        args.enable_test_net_dcl,
     )
 
     async def handle_stop(loop: asyncio.AbstractEventLoop) -> None:

--- a/matter_server/server/server.py
+++ b/matter_server/server/server.py
@@ -108,6 +108,7 @@ class MatterServer:
         listen_addresses: list[str] | None = None,
         primary_interface: str | None = None,
         paa_root_cert_dir: Path | None = None,
+        use_test_net_dcl: bool = False,
     ) -> None:
         """Initialize the Matter Server."""
         self.storage_path = storage_path
@@ -120,6 +121,7 @@ class MatterServer:
             self.paa_root_cert_dir = DEFAULT_PAA_ROOT_CERTS_DIR
         else:
             self.paa_root_cert_dir = Path(paa_root_cert_dir).absolute()
+        self.use_test_net_dcl = use_test_net_dcl
         self.logger = logging.getLogger(__name__)
         self.app = web.Application()
         self.loop: asyncio.AbstractEventLoop | None = None
@@ -156,7 +158,11 @@ class MatterServer:
 
         # (re)fetch all PAA certificates once at startup
         # NOTE: this must be done before initializing the controller
-        await fetch_certificates(self.paa_root_cert_dir)
+        await fetch_certificates(
+            self.paa_root_cert_dir,
+            fetch_test_certificates=self.use_test_net_dcl,
+            fetch_production_certificates=True,
+        )
 
         # Initialize our (intermediate) device controller which keeps track
         # of Matter devices and their subscriptions.

--- a/matter_server/server/server.py
+++ b/matter_server/server/server.py
@@ -108,7 +108,7 @@ class MatterServer:
         listen_addresses: list[str] | None = None,
         primary_interface: str | None = None,
         paa_root_cert_dir: Path | None = None,
-        use_test_net_dcl: bool = False,
+        enable_test_net_dcl: bool = False,
     ) -> None:
         """Initialize the Matter Server."""
         self.storage_path = storage_path
@@ -121,7 +121,7 @@ class MatterServer:
             self.paa_root_cert_dir = DEFAULT_PAA_ROOT_CERTS_DIR
         else:
             self.paa_root_cert_dir = Path(paa_root_cert_dir).absolute()
-        self.use_test_net_dcl = use_test_net_dcl
+        self.enable_test_net_dcl = enable_test_net_dcl
         self.logger = logging.getLogger(__name__)
         self.app = web.Application()
         self.loop: asyncio.AbstractEventLoop | None = None
@@ -160,7 +160,7 @@ class MatterServer:
         # NOTE: this must be done before initializing the controller
         await fetch_certificates(
             self.paa_root_cert_dir,
-            fetch_test_certificates=self.use_test_net_dcl,
+            fetch_test_certificates=self.enable_test_net_dcl,
             fetch_production_certificates=True,
         )
 


### PR DESCRIPTION
Currently we fetch PAA certificates from the test-net DCL server by default. Often these are the same certificates as the production DCL, so this doesn't really have that much impact. However, those certs are really only required for development as certified devices will be present on the production DCL.

In the future we'll fetch more information from the DCL such as device update information etc. For these cases we really don't want production users to use test-net DCL by default.

This moves test-net DCL use behind a flag. By default this should be off.