### PR TITLE
Convert --enable-test-net-dcl to a flag argument

### DIFF
--- a/matter_server/server/__main__.py
+++ b/matter_server/server/__main__.py
@@ -100,8 +100,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--enable-test-net-dcl",
-    type=bool,
-    default=False,
+    action="store_true",
     help="Enable PAA root certificates and other device information from test-net DCL.",
 )
 


### PR DESCRIPTION
This change converts the `--enable-test-net-dcl` command line argument to a flag which is much more natural for a boolean argument.