### PR TITLE
Add direct bluetooth commissioning support

### DIFF
--- a/matter_server/common/models.py
+++ b/matter_server/common/models.py
@@ -166,6 +166,7 @@ class ServerInfoMessage:
     sdk_version: str
     wifi_credentials_set: bool
     thread_credentials_set: bool
+    bluetooth_enabled: bool
 
 
 MessageType = (

--- a/matter_server/server/__main__.py
+++ b/matter_server/server/__main__.py
@@ -103,6 +103,12 @@ parser.add_argument(
     action="store_true",
     help="Enable PAA root certificates and other device information from test-net DCL.",
 )
+parser.add_argument(
+    "--bluetooth-adapter",
+    type=int,
+    required=False,
+    help="Optional bluetooth adapter (id) to enable direct commisisoning support.",
+)
 
 args = parser.parse_args()
 

--- a/matter_server/server/__main__.py
+++ b/matter_server/server/__main__.py
@@ -193,6 +193,7 @@ def main() -> None:
         args.primary_interface,
         args.paa_root_cert_dir,
         args.enable_test_net_dcl,
+        args.bluetooth_adapter,
     )
 
     async def handle_stop(loop: asyncio.AbstractEventLoop) -> None:

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -258,8 +258,10 @@ class MatterDeviceController:
 
         :return: The NodeInfo of the commissioned device.
         """
-        node_id = self._get_next_node_id()
+        if not network_only and not self.server.bluetooth_enabled:
+            raise NodeCommissionFailed("Bluetooth commissioning is not available.")
 
+        node_id = self._get_next_node_id()
         LOGGER.info(
             "Starting Matter commissioning with code using Node ID %s.",
             node_id,

--- a/matter_server/server/stack.py
+++ b/matter_server/server/stack.py
@@ -96,9 +96,11 @@ class MatterStack:
         self.logger.info("Initializing CHIP/Matter Controller Stack...")
         storage_file = os.path.join(server.storage_path, "chip.json")
         self.logger.debug(
-            "Using storage file: %s - Using bluetooth adapter: %s",
+            "Using storage file: %s - Bluetooth commissioning enabled: %s",
             storage_file,
-            "NO" if bluetooth_adapter_id is None else bluetooth_adapter_id,
+            "NO"
+            if bluetooth_adapter_id is None
+            else f"YES (adapter {bluetooth_adapter_id})",
         )
         # give the fake adapter id of 999 to disable bluetooth
         # because None means use the default adapter

--- a/matter_server/server/stack.py
+++ b/matter_server/server/stack.py
@@ -89,13 +89,20 @@ class MatterStack:
     def __init__(
         self,
         server: "MatterServer",
+        bluetooth_adapter_id: int | None = None,
     ) -> None:
         """Initialize Matter Stack."""
         self.logger = logging.getLogger(__name__)
         self.logger.info("Initializing CHIP/Matter Controller Stack...")
         storage_file = os.path.join(server.storage_path, "chip.json")
-        self.logger.debug("Using storage file: %s", storage_file)
-        chip.native.Init()
+        self.logger.debug(
+            "Using storage file: %s - Using bluetooth adapter: %s",
+            storage_file,
+            "NO" if bluetooth_adapter_id is None else bluetooth_adapter_id,
+        )
+        # give the fake adapter id of 999 to disable bluetooth
+        # because None means use the default adapter
+        chip.native.Init(999 if bluetooth_adapter_id is None else bluetooth_adapter_id)
 
         # Initialize logging after stack init!
         # See: https://github.com/project-chip/connectedhomeip/issues/20233


### PR DESCRIPTION
Add (explicit) support for commissioning using Bluetooth next to on-network commissioning.
Because it can be very unstable for some bluetooth adapters (like the pi builtin adapter for example), it requires a specific bluetooth adapter id/index 