### PR TITLE
Skip updates from DCL which are considered invalid

### DIFF
--- a/matter_server/server/ota/dcl.py
+++ b/matter_server/server/ota/dcl.py
@@ -59,6 +59,9 @@ async def _check_update_version(
     ):
         return None
 
+    if version_candidate["softwareVersionValid"] is False:
+        return None
+
     # Check minApplicableSoftwareVersion/maxApplicableSoftwareVersion
     min_sw_version = version_candidate["minApplicableSoftwareVersion"]
     max_sw_version = version_candidate["maxApplicableSoftwareVersion"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ server = [
   "home-assistant-chip-core==2024.7.1",
 ]
 test = [
+  "aioresponses==0.7.6",
   "codespell==2.3.0",
   "isort==5.13.2",
   "mypy==1.10.1",

--- a/tests/server/ota/fixtures/4447-8194-1000.json
+++ b/tests/server/ota/fixtures/4447-8194-1000.json
@@ -1,0 +1,19 @@
+{
+  "modelVersion": {
+    "vid": 4447,
+    "pid": 8194,
+    "softwareVersion": 1000,
+    "softwareVersionString": "1.0.0.0",
+    "cdVersionNumber": 1,
+    "firmwareInformation": "",
+    "softwareVersionValid": true,
+    "otaUrl": "",
+    "otaFileSize": "0",
+    "otaChecksum": "",
+    "otaChecksumType": 0,
+    "minApplicableSoftwareVersion": 0,
+    "maxApplicableSoftwareVersion": 999,
+    "releaseNotesUrl": "",
+    "creator": "cosmos1qpz3ghnqj6my7gzegkftzav9hpxymkx6zdk73v"
+  }
+}

--- a/tests/server/ota/fixtures/4447-8194-1011-invalid.json
+++ b/tests/server/ota/fixtures/4447-8194-1011-invalid.json
@@ -1,0 +1,19 @@
+{
+  "modelVersion": {
+    "vid": 4447,
+    "pid": 8194,
+    "softwareVersion": 1011,
+    "softwareVersionString": "1.0.1.1",
+    "cdVersionNumber": 1,
+    "firmwareInformation": "",
+    "softwareVersionValid": false,
+    "otaUrl": "https://cdn.aqara.com/cdn/opencloud-product/mainland/product-firmware/prd/aqara.matter.4447_8194/20240306154144_rel_up_to_enc_ota_sbl_app_aqara.matter.4447_8194_1.0.1.1_115F_2002_20240115195007_7a9b91.ota",
+    "otaFileSize": "615708",
+    "otaChecksum": "rFZ6WdH0DuuCf7HVoRmNjCF73mYZ98DGYpHoDKmf0Bw=",
+    "otaChecksumType": 1,
+    "minApplicableSoftwareVersion": 1000,
+    "maxApplicableSoftwareVersion": 1010,
+    "releaseNotesUrl": "",
+    "creator": "cosmos1qpz3ghnqj6my7gzegkftzav9hpxymkx6zdk73v"
+  }
+}

--- a/tests/server/ota/fixtures/4447-8194-1011-valid.json
+++ b/tests/server/ota/fixtures/4447-8194-1011-valid.json
@@ -1,0 +1,19 @@
+{
+  "modelVersion": {
+    "vid": 4447,
+    "pid": 8194,
+    "softwareVersion": 1011,
+    "softwareVersionString": "1.0.1.1",
+    "cdVersionNumber": 1,
+    "firmwareInformation": "",
+    "softwareVersionValid": true,
+    "otaUrl": "https://cdn.aqara.com/cdn/opencloud-product/mainland/product-firmware/prd/aqara.matter.4447_8194/20240306154144_rel_up_to_enc_ota_sbl_app_aqara.matter.4447_8194_1.0.1.1_115F_2002_20240115195007_7a9b91.ota",
+    "otaFileSize": "615708",
+    "otaChecksum": "rFZ6WdH0DuuCf7HVoRmNjCF73mYZ98DGYpHoDKmf0Bw=",
+    "otaChecksumType": 1,
+    "minApplicableSoftwareVersion": 1000,
+    "maxApplicableSoftwareVersion": 1010,
+    "releaseNotesUrl": "",
+    "creator": "cosmos1qpz3ghnqj6my7gzegkftzav9hpxymkx6zdk73v"
+  }
+}

--- a/tests/server/ota/fixtures/4447-8194.json
+++ b/tests/server/ota/fixtures/4447-8194.json
@@ -1,0 +1,10 @@
+{
+  "modelVersions": {
+    "vid": 4447,
+    "pid": 8194,
+    "softwareVersions": [
+      1000,
+      1011
+    ]
+  }
+}


### PR DESCRIPTION
Skip updates which have the softwareVersionValid flag set to false. This avoids flashing potentially invalid software versions to Matter devices.