### PR TITLE
Enable server interactions by default

### DIFF
--- a/matter_server/server/stack.py
+++ b/matter_server/server/stack.py
@@ -116,7 +116,7 @@ class MatterStack:
 
         self._chip_stack = ChipStack(
             persistentStoragePath=storage_file,
-            enableServerInteractions=False,
+            enableServerInteractions=True,
         )
 
         # Initialize Certificate Authority Manager


### PR DESCRIPTION
This enables server cluster interactions on a controller. But currently more importantly, it enables advertisement of active controller operational identities, or in other words, it makes sure that the controller publishes a mDNS/DNS-SD operational discovery service.

This is required for persistent subscriptions to work: Matter devices which support persistent subscriptions (e.g. Nanoleaf bulbs) will try to reestablish the subscriptions right after startup. For that to work they need to resolve the controller through operational discovery.

In other words, with this change nodes come much quicker available/controllable when they restart.