### PR TITLE
Bump OTA Provider to 2024.7.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN \
 
 ARG PYTHON_MATTER_SERVER
 
-ENV chip_example_url "https://github.com/home-assistant-libs/matter-linux-ota-provider/releases/download/2024.7.1"
+ENV chip_example_url "https://github.com/home-assistant-libs/matter-linux-ota-provider/releases/download/2024.7.2"
 ARG TARGETPLATFORM
 
 RUN \


### PR DESCRIPTION
OTA Provider to 2024.7.2 increases the number of network endpoints supported. This makes the OTA Provider work on systems with many add-ons/network interfaces just like the controller itself.