### PR TITLE
Trim OTA checksum for whitespace before comparing

### DIFF
--- a/matter_server/server/ota/provider.py
+++ b/matter_server/server/ota/provider.py
@@ -303,11 +303,12 @@ class ExternalOtaProvider:
                 # Download finished, check checksum if necessary
                 if checksum_alg:
                     checksum = b64encode(checksum_alg.digest()).decode("ascii")
-                    if checksum != update_desc["otaChecksum"]:
+                    checksum_expected = update_desc["otaChecksum"].strip()
+                    if checksum != checksum_expected:
                         LOGGER.error(
-                            "Checksum mismatch for file '%s', expected: %s, got: %s",
+                            "Checksum mismatch for file '%s', expected: '%s', got: '%s'",
                             file_name,
-                            update_desc["otaChecksum"],
+                            checksum_expected,
                             checksum,
                         )
                         await loop.run_in_executor(None, file_path.unlink)


### PR DESCRIPTION
The OTA checksum is base64 encoded, whitespaces at the start or end are not part of the checksum. Simply strip them before comparing.

Fixes: #817