### PR TITLE
Add note about Docker default command

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,23 @@ docker run -d \
   --restart=unless-stopped \
   --security-opt apparmor=unconfined \
   -v $(pwd)/data:/data \
-  -v /run/dbus:/run/dbus:ro \
   --network=host \
   ghcr.io/home-assistant-libs/python-matter-server:stable
+```
+
+> [!NOTE]
+> The container has a default command line set (see Dockerfile). If you intend to pass additional arguments, you have to pass the default command line as well.
+
+To use local commissioning with Bluetooth, make sure to pass the D-Bus socket as well:
+```
+docker run -d \
+  --name matter-server \
+  --restart=unless-stopped \
+  --security-opt apparmor=unconfined \
+  -v $(pwd)/data:/data \
+  -v /run/dbus:/run/dbus:ro \
+  --network=host \
+  ghcr.io/home-assistant-libs/python-matter-server:stable --storage-path /data --paa-root-cert-dir /data/credentials --bluetooth-adapter 0
 ```
 
 ### Running using Docker compose

--- a/compose.yml
+++ b/compose.yml
@@ -12,4 +12,7 @@ services:
     volumes:
       # Create an .env file that sets the USERDIR environment variable.
       - ${USERDIR:-$HOME}/docker/matter-server/data:/data/
-      - /run/dbus:/run/dbus:ro
+      # Required for Bluetooth via D-Bus
+      #- /run/dbus:/run/dbus:ro
+    # If you adjust command line, make sure to pass the default CMD arguments too:
+    #command: --storage-path /data --paa-root-cert-dir /data/credentials --bluetooth-adapter 0


### PR DESCRIPTION
Our Dockerfile uses the CMD instruction to run the server with sensible default arguments. Often folks forget to add those when customizing their command. This adds a note to the README.md and the compose.yml file to remind them.

This also removes the D-Bus access in the default startup example since D-Bus is only required for Bluetooth support (which is no longer enabled by default). An additional example with the correct command line and D-Bus access should make it clear what needs to be done to restore previous behavior.