### PR TITLE
Log when the Matter server finished startup

### DIFF
--- a/matter_server/server/server.py
+++ b/matter_server/server/server.py
@@ -207,7 +207,7 @@ class MatterServer:
             self._runner, host=self.listen_addresses, port=self.port
         )
         await self._http.start()
-        self.logger.debug("Webserver initialized.")
+        self.logger.info("Matter Server successfully initialized.")
 
     async def stop(self) -> None:
         """Stop running the server."""

--- a/matter_server/server/server.py
+++ b/matter_server/server/server.py
@@ -181,8 +181,8 @@ class MatterServer:
 
         await self._device_controller.initialize()
         await self.storage.start()
-        await self._device_controller.start()
         await self.vendor_info.start()
+        await self._device_controller.start()
         mount_websocket(self, "/ws")
         self.app.router.add_route("GET", "/info", self._handle_info)
 


### PR DESCRIPTION
Add a log entry with info level when the Matter server finishes startup. This is useful to know when the server is ready and starts event based Node setup processing (from mDNS events).

Helps for situation like https://github.com/home-assistant/core/issues/121932