### PR TITLE
Don't regard update information without a valid URL

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -1024,7 +1024,7 @@ class MatterDeviceController:
             node_logger.info("No new update found.")
             return None, None
 
-        if "otaUrl" not in update:
+        if "otaUrl" not in update or update["otaUrl"].strip().length == 0:
             raise UpdateCheckError("Update found, but no OTA URL provided.")
 
         node_logger.info(

--- a/matter_server/server/ota/dcl.py
+++ b/matter_server/server/ota/dcl.py
@@ -62,6 +62,9 @@ async def _check_update_version(
     if version_candidate["softwareVersionValid"] is False:
         return None
 
+    if version_candidate["otaUrl"].strip() == "":
+        return None
+
     # Check minApplicableSoftwareVersion/maxApplicableSoftwareVersion
     min_sw_version = version_candidate["minApplicableSoftwareVersion"]
     max_sw_version = version_candidate["maxApplicableSoftwareVersion"]

--- a/tests/server/ota/fixtures/4442-67-197888.json
+++ b/tests/server/ota/fixtures/4442-67-197888.json
@@ -1,0 +1,19 @@
+{
+  "modelVersion": {
+    "vid": 4442,
+    "pid": 67,
+    "softwareVersion": 197888,
+    "softwareVersionString": "3.5.0",
+    "cdVersionNumber": 1,
+    "firmwareInformation": "",
+    "softwareVersionValid": true,
+    "otaUrl": "",
+    "otaFileSize": "0",
+    "otaChecksum": "",
+    "otaChecksumType": 0,
+    "minApplicableSoftwareVersion": 0,
+    "maxApplicableSoftwareVersion": 197888,
+    "releaseNotesUrl": "",
+    "creator": "cosmos1sggrrmw05e6alve8umwdaszade5qxyt53kthud"
+  }
+}

--- a/tests/server/ota/fixtures/4442-67-197910.json
+++ b/tests/server/ota/fixtures/4442-67-197910.json
@@ -1,0 +1,19 @@
+{
+  "modelVersion": {
+    "vid": 4442,
+    "pid": 67,
+    "softwareVersion": 197910,
+    "softwareVersionString": "3.5.22",
+    "cdVersionNumber": 1,
+    "firmwareInformation": "",
+    "softwareVersionValid": true,
+    "otaUrl": "",
+    "otaFileSize": "0",
+    "otaChecksum": "",
+    "otaChecksumType": 0,
+    "minApplicableSoftwareVersion": 0,
+    "maxApplicableSoftwareVersion": 197910,
+    "releaseNotesUrl": "",
+    "creator": "cosmos1sggrrmw05e6alve8umwdaszade5qxyt53kthud"
+  }
+}

--- a/tests/server/ota/fixtures/4442-67-198340.json
+++ b/tests/server/ota/fixtures/4442-67-198340.json
@@ -1,0 +1,19 @@
+{
+  "modelVersion": {
+    "vid": 4442,
+    "pid": 67,
+    "softwareVersion": 198340,
+    "softwareVersionString": "3.6.196",
+    "cdVersionNumber": 1,
+    "firmwareInformation": "",
+    "softwareVersionValid": true,
+    "otaUrl": "https://nl67-firmware.s3.amazonaws.com/3.6.196_r8.matter",
+    "otaFileSize": "755976",
+    "otaChecksum": "46pqTh87M5fNhvR/zzt1M0RNQcVa8bApOCat7aKQ3KA=",
+    "otaChecksumType": 1,
+    "minApplicableSoftwareVersion": 198317,
+    "maxApplicableSoftwareVersion": 198340,
+    "releaseNotesUrl": "",
+    "creator": "cosmos1sggrrmw05e6alve8umwdaszade5qxyt53kthud"
+  }
+}

--- a/tests/server/ota/fixtures/4442-67.json
+++ b/tests/server/ota/fixtures/4442-67.json
@@ -1,0 +1,12 @@
+{
+  "modelVersions": {
+    "vid": 4442,
+    "pid": 67,
+    "softwareVersions": [
+      197120,
+      197888,
+      197910,
+      198340
+    ]
+  }
+}

--- a/tests/server/ota/test_dcl.py
+++ b/tests/server/ota/test_dcl.py
@@ -72,3 +72,19 @@ async def test_check_updates_specific_version(aioresponse):
     result = await check_for_update(MagicMock(), 4447, 8194, 1000, 1011)
 
     assert result == data["modelVersion"]
+
+
+async def test_check_no_update_if_url_empty(aioresponse):
+    """Test the case checks if latest version gets picked version."""
+    # Call the function with a current software version of 1000 and request 1011 as update
+    data = _load_fixture("4442-67.json")
+    aioresponse.get(url="/dcl/model/versions/4442/67", payload=data)
+    data = _load_fixture("4442-67-197888.json")
+    aioresponse.get(url="/dcl/model/versions/4442/67/197888", payload=data)
+    data = _load_fixture("4442-67-197910.json")
+    aioresponse.get(url="/dcl/model/versions/4442/67/197910", payload=data)
+    data = _load_fixture("4442-67-198340.json")
+    aioresponse.get(url="/dcl/model/versions/4442/67/198340", payload=data)
+    result = await check_for_update(MagicMock(), 4442, 67, 197120)
+
+    assert result is None


### PR DESCRIPTION
Skip updates which don't have an URL. We can't update such a node, so simply pretend as if they don't exist in the version info.