### PR TITLE
Fix OTA URL check syntax

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -1024,7 +1024,7 @@ class MatterDeviceController:
             node_logger.info("No new update found.")
             return None, None
 
-        if "otaUrl" not in update or update["otaUrl"].strip().length == 0:
+        if "otaUrl" not in update or update["otaUrl"].strip() == "":
             raise UpdateCheckError("Update found, but no OTA URL provided.")
 
         node_logger.info(


### PR DESCRIPTION
Previous commit added an update check with wrong syntax. Fix the syntax to make update check work again.