### PR TITLE
Add Eve Weather custom attributes

### DIFF
--- a/matter_server/common/custom_clusters.py
+++ b/matter_server/common/custom_clusters.py
@@ -85,6 +85,9 @@ class EveCluster(Cluster, CustomClusterMixin):
                     Label="current", Tag=0x130A0009, Type=float32
                 ),
                 ClusterObjectFieldDescriptor(
+                    Label="altitude", Tag=0x130A0013, Type=int
+                ),
+                ClusterObjectFieldDescriptor(
                     Label="pressure", Tag=0x130A0014, Type=float32
                 ),
             ]

--- a/matter_server/common/custom_clusters.py
+++ b/matter_server/common/custom_clusters.py
@@ -84,6 +84,9 @@ class EveCluster(Cluster, CustomClusterMixin):
                 ClusterObjectFieldDescriptor(
                     Label="current", Tag=0x130A0009, Type=float32
                 ),
+                ClusterObjectFieldDescriptor(
+                    Label="pressure", Tag=0x130A0014, Type=float32
+                ),
             ]
         )
 


### PR DESCRIPTION
Update custom_clusters.py to add Eve Weather pressure attribute

- EveCluster -> AttributeId: 319422483 (0x00130a0013) --> altitude
- EveCluster -> AttributeId: 319422484 (0x00130a0014) --> pressure

![image](https://github.com/user-attachments/assets/3d423675-7582-4571-b092-b7a5b1a32dda)


**Dump file**
[matter-2a4bd9d95d966aefd2521cccecaf2a8f-Eve Weather 20EBS9901-4b1740986a8ca70f15a63d1d0d6a1e02.json](https://github.com/user-attachments/files/16461658/matter-2a4bd9d95d966aefd2521cccecaf2a8f-Eve.Weather.20EBS9901-4b1740986a8ca70f15a63d1d0d6a1e02.json)
