### PR TITLE
Eve cluster part2: Add EveWeather attributes

### DIFF
--- a/matter_server/common/custom_clusters.py
+++ b/matter_server/common/custom_clusters.py
@@ -291,6 +291,7 @@ class EveCluster(Cluster, CustomClusterMixin):
 
             value: int = 0
 
+
 @dataclass
 class NeoCluster(Cluster, CustomClusterMixin):
     """Custom (vendor-specific) cluster for Neo - Vendor ID 4991 (0x137F)."""

--- a/matter_server/common/custom_clusters.py
+++ b/matter_server/common/custom_clusters.py
@@ -99,6 +99,8 @@ class EveCluster(Cluster, CustomClusterMixin):
     wattAccumulatedControlPoint: float32 | None = None
     voltage: float32 | None = None
     current: float32 | None = None
+    altitude: int | None = None
+    pressure: float32 | None = None
 
     class Attributes:
         """Attributes for the Eve Cluster."""

--- a/matter_server/common/custom_clusters.py
+++ b/matter_server/common/custom_clusters.py
@@ -266,7 +266,7 @@ class EveCluster(Cluster, CustomClusterMixin):
                 """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=int)
 
-            value: int = 0
+            value: float32 = 0
 
         @dataclass
         class Pressure(ClusterAttributeDescriptor, CustomClusterAttributeMixin):

--- a/matter_server/common/custom_clusters.py
+++ b/matter_server/common/custom_clusters.py
@@ -249,8 +249,6 @@ class EveCluster(Cluster, CustomClusterMixin):
         class Altitude(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
             """Altitude Attribute within the Eve Cluster."""
 
-            should_poll = False
-
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
                 """Return cluster id."""

--- a/matter_server/common/custom_clusters.py
+++ b/matter_server/common/custom_clusters.py
@@ -85,7 +85,7 @@ class EveCluster(Cluster, CustomClusterMixin):
                     Label="current", Tag=0x130A0009, Type=float32
                 ),
                 ClusterObjectFieldDescriptor(
-                    Label="altitude", Tag=0x130A0013, Type=int
+                    Label="altitude", Tag=0x130A0013, Type=float32
                 ),
                 ClusterObjectFieldDescriptor(
                     Label="pressure", Tag=0x130A0014, Type=float32

--- a/matter_server/common/custom_clusters.py
+++ b/matter_server/common/custom_clusters.py
@@ -99,7 +99,6 @@ class EveCluster(Cluster, CustomClusterMixin):
     wattAccumulatedControlPoint: float32 | None = None
     voltage: float32 | None = None
     current: float32 | None = None
-    altitude: int | None = None
     pressure: float32 | None = None
 
     class Attributes:
@@ -246,29 +245,6 @@ class EveCluster(Cluster, CustomClusterMixin):
             value: float32 = 0
 
         @dataclass
-        class Altitude(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
-            """Altitude Attribute within the Eve Cluster."""
-
-            should_poll = True
-
-            @ChipUtility.classproperty
-            def cluster_id(cls) -> int:
-                """Return cluster id."""
-                return 0x130AFC01
-
-            @ChipUtility.classproperty
-            def attribute_id(cls) -> int:
-                """Return attribute id."""
-                return 0x130A0013
-
-            @ChipUtility.classproperty
-            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                """Return attribute type."""
-                return ClusterObjectFieldDescriptor(Type=int)
-
-            value: int = 0
-
-        @dataclass
         class Pressure(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
             """Pressure Attribute within the Eve Cluster."""
 
@@ -289,7 +265,7 @@ class EveCluster(Cluster, CustomClusterMixin):
                 """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=int)
 
-            value: int = 0
+            value: float32 = 0
 
 
 @dataclass

--- a/matter_server/common/custom_clusters.py
+++ b/matter_server/common/custom_clusters.py
@@ -272,8 +272,6 @@ class EveCluster(Cluster, CustomClusterMixin):
         class Pressure(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
             """Pressure Attribute within the Eve Cluster."""
 
-            should_poll = True
-
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
                 """Return cluster id."""

--- a/matter_server/common/custom_clusters.py
+++ b/matter_server/common/custom_clusters.py
@@ -264,7 +264,7 @@ class EveCluster(Cluster, CustomClusterMixin):
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 """Return attribute type."""
-                return ClusterObjectFieldDescriptor(Type=int)
+                return ClusterObjectFieldDescriptor(Type=float32)
 
             value: float32 = 0
 

--- a/matter_server/common/custom_clusters.py
+++ b/matter_server/common/custom_clusters.py
@@ -263,7 +263,7 @@ class EveCluster(Cluster, CustomClusterMixin):
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
                 """Return attribute type."""
-                return ClusterObjectFieldDescriptor(Type=int)
+                return ClusterObjectFieldDescriptor(Type=float32)
 
             value: float32 = 0
 

--- a/matter_server/common/custom_clusters.py
+++ b/matter_server/common/custom_clusters.py
@@ -99,7 +99,7 @@ class EveCluster(Cluster, CustomClusterMixin):
     wattAccumulatedControlPoint: float32 | None = None
     voltage: float32 | None = None
     current: float32 | None = None
-    altitude: int | None = None
+    altitude: float32 | None = None
     pressure: float32 | None = None
 
     class Attributes:

--- a/matter_server/common/custom_clusters.py
+++ b/matter_server/common/custom_clusters.py
@@ -99,6 +99,7 @@ class EveCluster(Cluster, CustomClusterMixin):
     wattAccumulatedControlPoint: float32 | None = None
     voltage: float32 | None = None
     current: float32 | None = None
+    altitude: int | None = None
     pressure: float32 | None = None
 
     class Attributes:
@@ -243,6 +244,29 @@ class EveCluster(Cluster, CustomClusterMixin):
                 return ClusterObjectFieldDescriptor(Type=float32)
 
             value: float32 = 0
+
+        @dataclass
+        class Altitude(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """Altitude Attribute within the Eve Cluster."""
+
+            should_poll = False
+
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                """Return cluster id."""
+                return 0x130AFC01
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                """Return attribute id."""
+                return 0x130A0013
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
+                return ClusterObjectFieldDescriptor(Type=int)
+
+            value: int = 0
 
         @dataclass
         class Pressure(ClusterAttributeDescriptor, CustomClusterAttributeMixin):

--- a/matter_server/common/custom_clusters.py
+++ b/matter_server/common/custom_clusters.py
@@ -245,6 +245,51 @@ class EveCluster(Cluster, CustomClusterMixin):
 
             value: float32 = 0
 
+        @dataclass
+        class Altitude(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """Altitude Attribute within the Eve Cluster."""
+
+            should_poll = True
+
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                """Return cluster id."""
+                return 0x130AFC01
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                """Return attribute id."""
+                return 0x130A0013
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
+                return ClusterObjectFieldDescriptor(Type=int)
+
+            value: int = 0
+
+        @dataclass
+        class Pressure(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """Pressure Attribute within the Eve Cluster."""
+
+            should_poll = True
+
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                """Return cluster id."""
+                return 0x130AFC01
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                """Return attribute id."""
+                return 0x130A0014
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
+                return ClusterObjectFieldDescriptor(Type=int)
+
+            value: int = 0
 
 @dataclass
 class NeoCluster(Cluster, CustomClusterMixin):


### PR DESCRIPTION
Add Class attribute for Eve Cluster (EveWeather device):
- Altitude
- Pressure

HA core PR: [Add EveWeatherPressure attribute #123565](https://github.com/home-assistant/core/pull/123565)
