### PR TITLE
Add option to disable server interaction

### DIFF
--- a/matter_server/server/__main__.py
+++ b/matter_server/server/__main__.py
@@ -122,6 +122,11 @@ parser.add_argument(
     default=None,
     help="Directory where OTA Provider stores software updates and configuration.",
 )
+parser.add_argument(
+    "--disable-server-interactions",
+    action="store_false",
+    help="Controls disabling server cluster interactions on a controller. This in turn disables advertisement of active controller operational identities.",
+)
 
 args = parser.parse_args()
 
@@ -223,6 +228,7 @@ def main() -> None:
         args.enable_test_net_dcl,
         args.bluetooth_adapter,
         args.ota_provider_dir,
+        args.disable_server_interactions,
     )
 
     async def handle_stop(loop: asyncio.AbstractEventLoop) -> None:

--- a/matter_server/server/server.py
+++ b/matter_server/server/server.py
@@ -95,12 +95,12 @@ def mount_websocket(server: MatterServer, path: str) -> None:
 class MatterServer:
     """Serve Matter stack over WebSockets."""
 
-    # pylint: disable=too-many-instance-attributes,too-many-arguments
+    # pylint: disable=too-many-instance-attributes
 
     _runner: web.AppRunner | None = None
     _http: MultiHostTCPSite | None = None
 
-    def __init__(
+    def __init__(  # noqa: PLR0913, pylint: disable=too-many-arguments
         self,
         storage_path: str,
         vendor_id: int,
@@ -112,6 +112,7 @@ class MatterServer:
         enable_test_net_dcl: bool = False,
         bluetooth_adapter_id: int | None = None,
         ota_provider_dir: Path | None = None,
+        enable_server_interactions: bool = True,
     ) -> None:
         """Initialize the Matter Server."""
         self.storage_path = storage_path
@@ -134,7 +135,7 @@ class MatterServer:
         self.app = web.Application()
         self.loop: asyncio.AbstractEventLoop | None = None
         # Instantiate the Matter Stack using the SDK using the given storage path
-        self.stack = MatterStack(self, bluetooth_adapter_id)
+        self.stack = MatterStack(self, bluetooth_adapter_id, enable_server_interactions)
         self.storage = StorageController(self)
         self.vendor_info = VendorInfo(self)
         # we dynamically register command handlers

--- a/matter_server/server/stack.py
+++ b/matter_server/server/stack.py
@@ -90,6 +90,7 @@ class MatterStack:
         self,
         server: "MatterServer",
         bluetooth_adapter_id: int | None = None,
+        enable_server_interactions: bool = True,
     ) -> None:
         """Initialize Matter Stack."""
         self.logger = logging.getLogger(__name__)
@@ -114,9 +115,11 @@ class MatterStack:
         # Handle log level selection on SDK level
         chip.logging.SetLogFilter(_category_num)
 
+        if not enable_server_interactions:
+            self.logger.warning("Initializing stack with server interactions disabled!")
         self._chip_stack = ChipStack(
             persistentStoragePath=storage_file,
-            enableServerInteractions=True,
+            enableServerInteractions=enable_server_interactions,
         )
 
         # Initialize Certificate Authority Manager


### PR DESCRIPTION
Add a new CLI option to disable server interactions. This is useful for testing, to isolate if enabled server interaction might cause unexpected device behavior.