### PR TITLE
Select OTA Provider port randomly

### DIFF
--- a/matter_server/server/ota/provider.py
+++ b/matter_server/server/ota/provider.py
@@ -175,7 +175,7 @@ class ExternalOtaProvider:
             "--discriminator",
             str(ota_provider_discriminator),
             "--secured-device-port",
-            "5540",
+            "0",
             "--KVS",
             str(self._ota_provider_dir / f"chip_kvs_ota_provider_{timestamp}"),
             "--filepath",


### PR DESCRIPTION
Instead of using a fixed port for OTA Provider, pass 0 to let the Matter SDK/bind() syscall select a random port. This allows multiple OTA Providers to run on the same host without port conflicts.

Fixes: https://github.com/home-assistant/core/issues/125130