### PR TITLE
Update to Matter SDK wheels 2024.9.0

### DIFF
--- a/matter_server/server/sdk.py
+++ b/matter_server/server/sdk.py
@@ -338,15 +338,17 @@ class ChipDeviceControllerWrapper:
                 allowPASE=False,
                 timeoutMs=None,
             )
+            transaction = Attribute.AsyncReadTransaction(
+                future, self.server.loop, self._chip_controller, True
+            )
             Attribute.Read(
-                future=future,
-                eventLoop=self.server.loop,
+                transaction=transaction,
                 device=device.deviceProxy,
-                devCtrl=self._chip_controller,
                 attributes=attributes,
                 fabricFiltered=fabric_filtered,
             ).raise_on_error()
-            return await future
+            await future
+            return transaction.GetReadResponse()
 
     async def write_attribute(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "async-timeout",
   "coloredlogs",
   "orjson",
-  "home-assistant-chip-clusters==2024.7.1",
+  "home-assistant-chip-clusters==2024.9.0",
 ]
 description = "Python Matter WebSocket Server"
 license = {text = "Apache-2.0"}
@@ -39,7 +39,7 @@ server = [
   "cryptography==43.0.1",
   "orjson==3.10.7",
   "zeroconf==0.134.0",
-  "home-assistant-chip-core==2024.7.1",
+  "home-assistant-chip-core==2024.9.0",
 ]
 test = [
   "aioresponses==0.7.6",


### PR DESCRIPTION
The 2024.9.0 wheels come with an improved attribute cache handling: The Attribute cache only gets updated when actually uesd. This will save Attribute cache updates in Subscriptions typically, and moves Attribute cache updates for reads out of the SDK thread.