### PR TITLE
Add fabric label on commissioning

### DIFF
--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -131,7 +131,7 @@ class MatterClient:
             return node
         raise NodeNotExists(f"Node {node_id} does not exist or is not yet interviewed")
 
-    async def set_default_fabric_label(self, label: str) -> None:
+    async def set_default_fabric_label(self, label: str | None) -> None:
         """Set the default fabric label."""
         await self.send_command(
             APICommand.SET_DEFAULT_FABRIC_LABEL, require_schema=11, label=label

--- a/matter_server/client/client.py
+++ b/matter_server/client/client.py
@@ -131,6 +131,12 @@ class MatterClient:
             return node
         raise NodeNotExists(f"Node {node_id} does not exist or is not yet interviewed")
 
+    async def set_default_fabric_label(self, label: str) -> None:
+        """Set the default fabric label."""
+        await self.send_command(
+            APICommand.SET_DEFAULT_FABRIC_LABEL, require_schema=11, label=label
+        )
+
     async def commission_with_code(
         self, code: str, network_only: bool = False
     ) -> MatterNodeData:

--- a/matter_server/common/const.py
+++ b/matter_server/common/const.py
@@ -2,7 +2,7 @@
 
 # schema version is used to determine compatibility between server and client
 # bump schema if we add new features and/or make other (breaking) changes
-SCHEMA_VERSION = 10
+SCHEMA_VERSION = 11
 
 
 VERBOSE_LOG_LEVEL = 5

--- a/matter_server/common/models.py
+++ b/matter_server/common/models.py
@@ -50,6 +50,7 @@ class APICommand(str, Enum):
     IMPORT_TEST_NODE = "import_test_node"
     CHECK_NODE_UPDATE = "check_node_update"
     UPDATE_NODE = "update_node"
+    SET_DEFAULT_FABRIC_LABEL = "set_default_fabric_label"
 
 
 EventCallBackType = Callable[[EventType, Any], None]

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -166,6 +166,7 @@ class MatterDeviceController:
         self._custom_attribute_poller_timer: asyncio.TimerHandle | None = None
         self._custom_attribute_poller_task: asyncio.Task | None = None
         self._attribute_update_callbacks: dict[int, list[Callable]] = {}
+        self._default_fabric_label: str = "Home Assistant"
 
     async def initialize(self) -> None:
         """Initialize the device controller."""
@@ -280,6 +281,11 @@ class MatterDeviceController:
             return node
         raise NodeNotExists(f"Node {node_id} does not exist or is not yet interviewed")
 
+    @api_command(APICommand.SET_DEFAULT_FABRIC_LABEL)
+    async def set_default_fabric_label(self, label: str) -> None:
+        """Set the default fabric label."""
+        self._default_fabric_label = label
+
     @api_command(APICommand.COMMISSION_WITH_CODE)
     async def commission_with_code(
         self, code: str, network_only: bool = False
@@ -320,7 +326,7 @@ class MatterDeviceController:
                 node_id,
                 0,
                 Clusters.OperationalCredentials.Commands.UpdateFabricLabel(
-                    "Home Assistant"
+                    self._default_fabric_label
                 ),
             )
         except ChipStackError as err:

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -315,6 +315,14 @@ class MatterDeviceController:
             LOGGER.info("Commissioned Node ID: %s vs %s", commissioned_node_id, node_id)
             if commissioned_node_id != node_id:
                 raise RuntimeError("Returned Node ID must match requested Node ID")
+
+            await self._chip_device_controller.send_command(
+                node_id,
+                0,
+                Clusters.OperationalCredentials.Commands.UpdateFabricLabel(
+                    "Home Assistant"
+                ),
+            )
         except ChipStackError as err:
             raise NodeCommissionFailed(
                 f"Commission with code failed for node {node_id}."


### PR DESCRIPTION
Add a fabric label right after commissioning. This will make it easier for other platforms to identify what particular fabrics a device is commissioned with.