### PR TITLE
Abort update when device goes offline

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -1588,6 +1588,11 @@ class MatterDeviceController:
         node_logger.info("Node considered offline, shutdown subscription")
         await self._chip_device_controller.shutdown_subscription(node_id)
 
+        # inform listeners for update callbacks that this subscription is now offline
+        if node_id in self._attribute_update_callbacks:
+            for callback in self._attribute_update_callbacks[node_id]:
+                self._loop.create_task(callback(None, None, None))
+
         # mark node as unavailable (if it wasn't already)
         self._node_unavailable(node_id)
 

--- a/matter_server/server/ota/provider.py
+++ b/matter_server/server/ota/provider.py
@@ -353,6 +353,12 @@ class ExternalOtaProvider:
     ) -> None:
         """Check the update state of a node and take appropriate action."""
 
+        if path is None:
+            self._ota_done.set_exception(
+                UpdateError("Device went offline during OTA update")
+            )
+            return
+
         if str(path) != OTA_SOFTWARE_UPDATE_REQUESTOR_UPDATE_STATE_ATTRIBUTE_PATH:
             return
 


### PR DESCRIPTION
In case the subscription of the device gets shutdown, stop the update process and return an error to the client.