### PR TITLE
Bump container base image to Debian 12 and Python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bullseye
+FROM python:3.12-slim-bookworm
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
The latest latest build of Matter/CHIP wheels v2024.11.0 require a newer Debian version. This is required because the CHIP wheels build uses the Matter SDK build system, which recently got updated to Ubuntu 24.04. This meant that the native library got linked against a newer glibc version.

Technically, the Python 3.12 update is not related/strictly required. But it seems that the Matter v1.3 version of Matter/CHIP wheels v2024.9.0 runs fine with Python 3.12 already. So it is safe to upgrade the two at once.