### PR TITLE
Add draft ElectricalMeasurement cluster definition

### DIFF
--- a/dashboard/src/client/models/descriptions.ts
+++ b/dashboard/src/client/models/descriptions.ts
@@ -12267,5 +12267,65 @@ export const clusters: Record<number, ClusterDescription> = {
         "type": "uint"
       }
     }
+  },
+  "2820": {
+    "id": 2820,
+    "label": "DraftElectricalMeasurementCluster",
+    "attributes": {
+      "1285": {
+        "id": 1285,
+        "cluster_id": 2820,
+        "label": "RmsVoltage",
+        "type": "uint"
+      },
+      "1288": {
+        "id": 1288,
+        "cluster_id": 2820,
+        "label": "RmsCurrent",
+        "type": "uint"
+      },
+      "1291": {
+        "id": 1291,
+        "cluster_id": 2820,
+        "label": "ActivePower",
+        "type": "uint"
+      },
+      "1536": {
+        "id": 1536,
+        "cluster_id": 2820,
+        "label": "AcVoltageMultiplier",
+        "type": "uint"
+      },
+      "1537": {
+        "id": 1537,
+        "cluster_id": 2820,
+        "label": "AcVoltageDivisor",
+        "type": "uint"
+      },
+      "1538": {
+        "id": 1538,
+        "cluster_id": 2820,
+        "label": "AcCurrentMultiplier",
+        "type": "uint"
+      },
+      "1539": {
+        "id": 1539,
+        "cluster_id": 2820,
+        "label": "AcCurrentDivisor",
+        "type": "uint"
+      },
+      "1540": {
+        "id": 1540,
+        "cluster_id": 2820,
+        "label": "AcPowerMultiplier",
+        "type": "uint"
+      },
+      "1541": {
+        "id": 1541,
+        "cluster_id": 2820,
+        "label": "AcPowerDivisor",
+        "type": "uint"
+      }
+    }
   }
 }

--- a/matter_server/common/custom_clusters.py
+++ b/matter_server/common/custom_clusters.py
@@ -575,6 +575,256 @@ class ThirdRealityMeteringCluster(Cluster, CustomClusterMixin):
             value: uint = 0
 
 
+@dataclass
+class DraftElectricalMeasurementCluster(Cluster, CustomClusterMixin):
+    """Custom ElectricalMetering cluster from Matter 1.0 draft specification."""
+
+    id: ClassVar[int] = 0x00000B04
+
+    @ChipUtility.classproperty
+    def descriptor(cls) -> ClusterObjectDescriptor:
+        """Return descriptor for this cluster."""
+        return ClusterObjectDescriptor(
+            Fields=[
+                ClusterObjectFieldDescriptor(
+                    Label="rmsVoltage", Tag=0x00000505, Type=uint
+                ),
+                ClusterObjectFieldDescriptor(
+                    Label="rmsCurrent", Tag=0x00000508, Type=uint
+                ),
+                ClusterObjectFieldDescriptor(
+                    Label="activePower", Tag=0x0000050B, Type=uint
+                ),
+                ClusterObjectFieldDescriptor(
+                    Label="acVoltageMultiplier", Tag=0x00000600, Type=uint
+                ),
+                ClusterObjectFieldDescriptor(
+                    Label="acVoltageDivisor", Tag=0x00000601, Type=uint
+                ),
+                ClusterObjectFieldDescriptor(
+                    Label="acCurrentMultiplier", Tag=0x00000602, Type=uint
+                ),
+                ClusterObjectFieldDescriptor(
+                    Label="acCurrentDivisor", Tag=0x00000603, Type=uint
+                ),
+                ClusterObjectFieldDescriptor(
+                    Label="acPowerMultiplier", Tag=0x00000604, Type=uint
+                ),
+                ClusterObjectFieldDescriptor(
+                    Label="acPowerDivisor", Tag=0x00000605, Type=uint
+                ),
+            ]
+        )
+
+    rmsVoltage: uint | None = None
+    rmsCurrent: uint | None = None
+    activePower: uint | None = None
+    acVoltageMultiplier: uint | None = None
+    acVoltageDivisor: uint | None = None
+    acCurrentMultiplier: uint | None = None
+    acCurrentDivisor: uint | None = None
+    acPowerMultiplier: uint | None = None
+    acPowerDivisor: uint | None = None
+
+    class Attributes:
+        """Attributes for the custom Cluster."""
+
+        @dataclass
+        class RmsVoltage(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """RmsVoltage Attribute within the DraftElectricalMeasurement Cluster."""
+
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                """Return cluster id."""
+                return 0x00000B04
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                """Return attribute id."""
+                return 0x00000505
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
+                return ClusterObjectFieldDescriptor(Type=uint)
+
+            value: uint = 0
+
+        @dataclass
+        class RmsCurrent(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """RmsCurrent Attribute within the DraftElectricalMeasurement Cluster."""
+
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                """Return cluster id."""
+                return 0x00000B04
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                """Return attribute id."""
+                return 0x00000508
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
+                return ClusterObjectFieldDescriptor(Type=uint)
+
+            value: uint = 0
+
+        @dataclass
+        class ActivePower(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """ActivePower Attribute within the DraftElectricalMeasurement Cluster."""
+
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                """Return cluster id."""
+                return 0x00000B04
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                """Return attribute id."""
+                return 0x0000050B
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
+                return ClusterObjectFieldDescriptor(Type=uint)
+
+            value: uint = 0
+
+        @dataclass
+        class AcVoltageMultiplier(
+            ClusterAttributeDescriptor, CustomClusterAttributeMixin
+        ):
+            """AcVoltageMultiplier Attribute within the DraftElectricalMeasurement Cluster."""
+
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                """Return cluster id."""
+                return 0x00000B04
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                """Return attribute id."""
+                return 0x00000600
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
+                return ClusterObjectFieldDescriptor(Type=uint)
+
+            value: uint = 0
+
+        @dataclass
+        class AcVoltageDivisor(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """AcVoltageDivisor Attribute within the DraftElectricalMeasurement Cluster."""
+
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                """Return cluster id."""
+                return 0x00000B04
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                """Return attribute id."""
+                return 0x00000601
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
+                return ClusterObjectFieldDescriptor(Type=uint)
+
+            value: uint = 0
+
+        @dataclass
+        class AcCurrentMultiplier(
+            ClusterAttributeDescriptor, CustomClusterAttributeMixin
+        ):
+            """AcCurrentMultiplier Attribute within the DraftElectricalMeasurement Cluster."""
+
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                """Return cluster id."""
+                return 0x00000B04
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                """Return attribute id."""
+                return 0x00000602
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
+                return ClusterObjectFieldDescriptor(Type=uint)
+
+            value: uint = 0
+
+        @dataclass
+        class AcCurrentDivisor(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """AcCurrentDivisor Attribute within the DraftElectricalMeasurement Cluster."""
+
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                """Return cluster id."""
+                return 0x00000B04
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                """Return attribute id."""
+                return 0x00000603
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
+                return ClusterObjectFieldDescriptor(Type=uint)
+
+            value: uint = 0
+
+        @dataclass
+        class AcPowerMultiplier(
+            ClusterAttributeDescriptor, CustomClusterAttributeMixin
+        ):
+            """AcPowerMultiplier Attribute within the DraftElectricalMeasurement Cluster."""
+
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                """Return cluster id."""
+                return 0x00000B04
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                """Return attribute id."""
+                return 0x00000604
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
+                return ClusterObjectFieldDescriptor(Type=uint)
+
+            value: uint = 0
+
+        @dataclass
+        class AcPowerDivisor(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """AcPowerDivisor Attribute within the DraftElectricalMeasurement Cluster."""
+
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                """Return cluster id."""
+                return 0x00000B04
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                """Return attribute id."""
+                return 0x00000605
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
+                return ClusterObjectFieldDescriptor(Type=uint)
+
+            value: uint = 0
+
+
 def check_polled_attributes(node_data: MatterNodeData) -> set[str]:
     """Check if custom attributes are present in the node data that need to be polled."""
     attributes_to_poll: set[str] = set()


### PR DESCRIPTION
Yandex Smart Socket ([YNDX-00540](https://csa-iot.org/csa_product/yandex-smart-socket/)) use ElectricalMeasurement cluster that was in draft Matter specification but not made in 1.0 spec. It was finally removed in v1.4 branch of Matter SDK (see https://github.com/project-chip/connectedhomeip/pull/35583). 

HA pull request that will use this cluster: https://github.com/home-assistant/core/pull/132920

<img width="488" alt="Screenshot 2024-12-11 at 13 43 22" src="https://github.com/user-attachments/assets/c652e39c-e27b-4dfd-9ea7-604121eaa974">
<img width="481" alt="Screenshot 2024-12-11 at 13 43 32" src="https://github.com/user-attachments/assets/5bbb733a-f1f9-4434-b1b0-04c4f28e080b">
