### PR TITLE
Use atomic writes for the storage file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ server = [
   "aiohttp==3.11.10",
   "aiorun==2024.8.1",
   "async-timeout==5.0.1",
+  "atomicwrites==1.4.0",
   "coloredlogs==15.0.1",
   "cryptography==44.0.0",
   "orjson==3.10.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ server = [
   "aiohttp==3.11.10",
   "aiorun==2024.8.1",
   "async-timeout==5.0.1",
-  "atomicwrites==1.4.0",
+  "atomicwrites==1.4.1",
   "coloredlogs==15.0.1",
   "cryptography==44.0.0",
   "orjson==3.10.12",


### PR DESCRIPTION
Prevent our persistent storage file get corrupted if writing fails or power is cut during writing.
This is step 1 because a similar approach is also needed for the sdk's json file which contains the fabric (cryptographic) data.

Related to #977 