### PR TITLE
Add docs to allowed PR labels

### DIFF
--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -20,4 +20,4 @@ jobs:
         uses: ludeeus/action-require-labels@1.1.0
         with:
          labels: >-
-            breaking-change, bugfix, refactor, new-feature, maintenance, ci, dependencies
+            breaking-change, bugfix, refactor, new-feature, maintenance, ci, dependencies, docs


### PR DESCRIPTION
Allow docs as label which is useful for PRs only touching README.md/docs directory.