### PR TITLE
Always use multicasts for service discovery

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -24,7 +24,13 @@ from chip.clusters.ClusterObjects import ALL_ATTRIBUTES, ALL_CLUSTERS, Cluster
 from chip.discovery import DiscoveryType
 from chip.exceptions import ChipStackError
 from chip.native import PyChipError
-from zeroconf import BadTypeInNameException, IPVersion, ServiceStateChange, Zeroconf
+from zeroconf import (
+    BadTypeInNameException,
+    DNSQuestionType,
+    IPVersion,
+    ServiceStateChange,
+    Zeroconf,
+)
 from zeroconf.asyncio import AsyncServiceBrowser, AsyncServiceInfo, AsyncZeroconf
 
 from matter_server.common.const import VERBOSE_LOG_LEVEL
@@ -220,6 +226,7 @@ class MatterDeviceController:
             self._aiozc.zeroconf,
             services,
             handlers=[self._on_mdns_service_state_change],
+            question_type=DNSQuestionType.QM,
         )
 
     async def stop(self) -> None:


### PR DESCRIPTION
The unicast service discovery leads to unicast responses. However, only a single process can receive a unicast response. This is a problem since the Matter Server is most likely not the only mDNS client on a given host.

By default, the service discovery starts with an unicast request first and continues with multicast requests from then onwards (the first multicast request is sent about 200ms later). So service discovery worked with the default initialization too. But with this change we get rid of the unicast request speeding up the service discovery slightly.