### PR TITLE
Improve Matter DNS-SD service parsing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,7 +85,9 @@ repos:
         name: 🌟 Starring code with pylint
         language: system
         types: [python]
-        entry: scripts/run-in-env.sh pylint
+        entry: scripts/run-in-env.sh pylint matter_server/ tests/
+        require_serial: true
+        pass_filenames: false
       - id: trailing-whitespace
         name: ✄  Trim Trailing Whitespace
         language: system

--- a/matter_server/server/server.py
+++ b/matter_server/server/server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from functools import cached_property, partial
+import inspect
 import ipaddress
 import logging
 import os
@@ -315,18 +316,24 @@ class MatterServer:
 
     def _register_api_commands(self) -> None:
         """Register all methods decorated as api_command."""
-        for cls in (self, self._device_controller, self.vendor_info):
-            for attr_name in dir(cls):
+        for obj in (self, self._device_controller, self.vendor_info):
+            cls = obj.__class__
+            for attr_name, attr in inspect.getmembers(cls):
                 if attr_name.startswith("_"):
                     continue
-                val = getattr(cls, attr_name)
-                if not hasattr(val, "api_cmd"):
+
+                if isinstance(attr, property):
+                    continue  # skip properties
+
+                # attr is the (unbound) function, we can check for the decorator
+                if not hasattr(attr, "api_cmd"):
                     continue
-                if hasattr(val, "mock_calls"):
-                    # filter out mocks
+                if hasattr(attr, "mock_calls"):
                     continue
-                # method is decorated with our api decorator
-                self.register_api_command(val.api_cmd, val)
+
+                # Bind the function to the instance before registering
+                bound_method = getattr(obj, attr_name)
+                self.register_api_command(attr.api_cmd, bound_method)
 
     async def _handle_info(self, request: web.Request) -> web.Response:
         """Handle info endpoint to serve basic server (version) info."""

--- a/matter_server/server/server.py
+++ b/matter_server/server/server.py
@@ -331,7 +331,7 @@ class MatterServer:
                 if hasattr(attr, "mock_calls"):
                     continue
 
-                # Bind the function to the instance before registering
+                # Get the instance method before registering
                 bound_method = getattr(obj, attr_name)
                 self.register_api_command(attr.api_cmd, bound_method)
 

--- a/tests/test_device_controller.py
+++ b/tests/test_device_controller.py
@@ -1,0 +1,39 @@
+"""Device controller tests."""
+
+import pytest
+
+from matter_server.server.device_controller import RE_MDNS_SERVICE_NAME
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        (
+            "D22DC25523A78A89-0000000000000125._matter._tcp.local.",
+            ("D22DC25523A78A89", "0000000000000125"),
+        ),
+        (
+            "d22dc25523a78a89-0000000000000125._matter._tcp.local.",
+            ("d22dc25523a78a89", "0000000000000125"),
+        ),
+    ],
+)
+def test_valid_mdns_service_names(name, expected):
+    """Test valid mDNS service names."""
+    match = RE_MDNS_SERVICE_NAME.match(name)
+    assert match is not None
+    assert match.groups() == expected
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "D22DC25523A78A89-0000000000000125 (2)._matter._tcp.local.",
+        "D22DC25523A78A89-0000000000000125.._matter._tcp.local.",
+        "G22DC25523A78A89-0000000000000125._matter._tcp.local.",  # invalid hex
+        "D22DC25523A78A89-0000000000000125._matterc._udp.local.",
+    ],
+)
+def test_invalid_mdns_service_names(name):
+    """Test invalid mDNS service names."""
+    assert RE_MDNS_SERVICE_NAME.match(name) is None


### PR DESCRIPTION
Services are now parsed in a more robust way, to avoid issues in cases where the service name is not exactly as expected. This has been observed to be the case for Thread devices, presumably because two Thread border routers attempt to announce the same service name. The service name then becomes a " (2)" suffix, which the old code did not handle well.

We could parse this duplicated messages as well, but generally only a single node should ever announce a service name. If a service name gets announced by two independent devices, the two services likely stem from the same underlying device but simply got duplicated by some environmental factor (e.g. Thread border routers not being in sync on who announces the service name, or badly configured mDNS reflectors duplicating messages on the same network). Only processing the correctly formatted service name is sufficient in these cases.