### PR TITLE
Drop temporary workaround for Poll Control

### DIFF
--- a/scripts/generate_devices.py
+++ b/scripts/generate_devices.py
@@ -113,9 +113,6 @@ class DeviceType:
                         # It's optional server cluster
                         or cluster["@serverLocked"] == "false"
                     )
-                    # Temporary: PollControl will be removed from matter_devices.xml
-                    # https://github.com/project-chip/connectedhomeip/pull/22718
-                    and cluster["@cluster"] != "Poll Control"
                 )
                 + ",}"  # extra comma to force black to do a cluster per line
             )


### PR DESCRIPTION
The Poll Control cluster got removed a while ago, so just get rid of the workaround.