### PR TITLE
Bump to Python 3.12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   release:
     types: [published]
 env:
-  PYTHON_VERSION: "3.11"
+  PYTHON_VERSION: "3.12"
   NODE_VERSION: "18.x"
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5.6.0
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -38,8 +38,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.11"
           - "3.12"
+          - "3.13"
 
     steps:
       - name: Check out code from GitHub

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,11 @@ authors = [
   {name = "The Home Assistant Authors", email = "hello@home-assistant.io"},
 ]
 classifiers = [
-  "Development Status :: 3 - Alpha",
+  "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Environment :: Console",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Home Automation",
 ]
 dependencies = [
@@ -26,7 +26,7 @@ description = "Open Home Foundation Matter Server"
 license = {text = "Apache-2.0"}
 name = "python-matter-server"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 # The version is set by GH action on release!
 version = "0.0.0"
 


### PR DESCRIPTION
Bump the project to minimum Python version 3.12. We are using Python 3.12 since #972 in production already. Also the server seems to run fine on Python 3.13, so advertise that as well.