### PR TITLE
Remove unnecessary libgirepository dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,6 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgirepository1.0-dev
           python -m pip install --upgrade pip
           pip install -e .[server]
           pip install -e .[test]


### PR DESCRIPTION
The library was a requirement of the CHIP Python REPL (iirc), which is not being used for tests.