### PR TITLE
add node binding dialog.

### DIFF
--- a/dashboard/note.md
+++ b/dashboard/note.md
@@ -1,0 +1,12 @@
+```
+                          <div
+                            style="display:flex;flex-direction:row;gap:15px;"
+                          >
+                            <div>${"privilege:" + entry.privilege}</div>
+                            <div>${"authMode:" + entry.authMode}</div>
+                            <div>${"fabricIndex:" + entry.fabricIndex}</div>
+                          </div>
+                          <div>subjects:${JSON.stringify(entry.subjects)}</div>
+                          <div>targets:${JSON.stringify(entry.targets)}</div>
+
+```

--- a/dashboard/src/client/client.ts
+++ b/dashboard/src/client/client.ts
@@ -143,6 +143,21 @@ export class MatterClient {
     await this.sendCommand("update_node", 10, { node_id: nodeId, software_version: softwareVersion });
   }
 
+  async setACLEntry(nodeId: number, entry: any) {
+    return await this.sendCommand("set_acl_entry", 0, {
+      node_id: nodeId,
+      entry: entry,
+    });
+  }
+
+  async setNodeBinding(nodeId: number, endpoint: number, bindings: any) {
+    return await this.sendCommand("set_node_binding", 0, {
+      node_id: nodeId,
+      endpoint: endpoint,
+      bindings: bindings,
+    });
+  }
+
   async sendCommand<T extends keyof APICommands>(
     command: T,
     require_schema: number | undefined = undefined,

--- a/dashboard/src/client/models/model.ts
+++ b/dashboard/src/client/models/model.ts
@@ -105,6 +105,14 @@ export interface APICommands {
     requestArgs: {};
     response: {};
   };
+  set_acl_entry: {
+    requestArgs: {};
+    response: {};
+  };
+  set_node_binding: {
+    requestArgs: {};
+    response: {};
+  };
 }
 
 export interface CommandMessage {

--- a/dashboard/src/components/dialogs/acl/model.ts
+++ b/dashboard/src/components/dialogs/acl/model.ts
@@ -1,0 +1,109 @@
+
+export type AccessControlEntryRawInput = {
+  "1": number;
+  "2": number;
+  "3": number[];
+  "4": null;
+  "254": number;
+};
+
+export type AccessControlTargetStruct = {
+  cluster: number | undefined;
+  endpoint: number | undefined;
+  deviceType: number | undefined;
+};
+
+export type AccessControlEntryStruct = {
+  privilege: number;
+  authMode: number;
+  subjects: number[];
+  targets: AccessControlTargetStruct[] | undefined;
+  fabricIndex: number;
+};
+
+export class AccessControlTargetTransformer {
+  private static readonly KEY_MAPPING: {
+    [inputKey: string]: keyof AccessControlTargetStruct;
+  } = {
+    "0": "cluster",
+    "1": "endpoint",
+    "2": "deviceType",
+  };
+
+  public static transform(input: any): AccessControlTargetStruct {
+    if (!input || typeof input !== "object") {
+      throw new Error("Invalid input: expected an object");
+    }
+
+    const result: Partial<AccessControlTargetStruct> = {};
+    const keyMapping = AccessControlTargetTransformer.KEY_MAPPING;
+
+    for (const key in input) {
+      if (key in keyMapping) {
+        const mappedKey = keyMapping[key];
+        if (mappedKey) {
+          const value = input[key];
+          if (value === undefined) continue;
+          result[mappedKey] = value;
+        }
+      }
+    }
+    return result as AccessControlTargetStruct;
+  }
+}
+
+export class AccessControlEntryDataTransformer {
+  private static readonly KEY_MAPPING: {
+    [inputKey: string]: keyof AccessControlEntryStruct;
+  } = {
+    "1": "privilege",
+    "2": "authMode",
+    "3": "subjects",
+    "4": "targets",
+    "254": "fabricIndex",
+  };
+
+  public static transform(input: any): AccessControlEntryStruct {
+    if (!input || typeof input !== "object") {
+      throw new Error("Invalid input: expected an object");
+    }
+
+    const result: Partial<AccessControlEntryStruct> = {};
+    const keyMapping = AccessControlEntryDataTransformer.KEY_MAPPING;
+
+    for (const key in input) {
+      if (key in keyMapping) {
+        const mappedKey = keyMapping[key];
+        if (mappedKey) {
+          const value = input[key];
+          if (value === undefined) continue;
+          if (mappedKey === "subjects") {
+            result[mappedKey] = Array.isArray(value) ? value : undefined;
+          } else if (mappedKey === "targets") {
+            if (Array.isArray(value)) {
+              const _targets = Object.values(value).map((val) =>
+                AccessControlTargetTransformer.transform(val),
+              );
+              result[mappedKey] = _targets;
+            } else {
+              result[mappedKey] = undefined;
+            }
+          } else {
+            result[mappedKey] = value;
+          }
+        }
+      }
+    }
+
+    if (
+      result.privilege === undefined ||
+      result.authMode === undefined ||
+      result.subjects === undefined ||
+      result.fabricIndex === undefined
+    ) {
+      throw new Error("Missing required fields in AccessControlEntryStruct");
+    }
+
+    return result as AccessControlEntryStruct;
+  }
+}

--- a/dashboard/src/components/dialogs/binding/model.ts
+++ b/dashboard/src/components/dialogs/binding/model.ts
@@ -1,0 +1,116 @@
+export type InputType = {
+  [key: string]: number | number[] | undefined;
+};
+
+export interface BindingEntryStruct {
+  node: number;
+  group: number | undefined;
+  endpoint: number;
+  cluster: number | undefined;
+  fabricIndex: number | undefined;
+}
+
+export type AccessControlEntryStruct = {
+  privilege: number;
+  authMode: number;
+  subjects: number[];
+  targets: number[] | undefined;
+  fabricIndex: number;
+};
+
+export class AccessControlEntryDataTransformer {
+  private static readonly KEY_MAPPING: {
+    [inputKey: string]: keyof AccessControlEntryStruct;
+  } = {
+    "1": "privilege",
+    "2": "authMode",
+    "3": "subjects",
+    "4": "targets",
+    "254": "fabricIndex",
+  };
+
+  public static transform(input: any): AccessControlEntryStruct {
+    if (!input || typeof input !== "object") {
+      throw new Error("Invalid input: expected an object");
+    }
+
+    const result: Partial<AccessControlEntryStruct> = {};
+    const keyMapping = AccessControlEntryDataTransformer.KEY_MAPPING;
+
+    for (const key in input) {
+      if (key in keyMapping) {
+        const mappedKey = keyMapping[key];
+        if (mappedKey) {
+          const value = input[key];
+          if (value === undefined) continue;
+          if (mappedKey === "subjects" || mappedKey === "targets") {
+            result[mappedKey] = Array.isArray(value) ? value : undefined;
+          } else {
+            result[mappedKey] = value;
+          }
+        }
+      }
+    }
+
+    if (
+      result.privilege === undefined ||
+      result.authMode === undefined ||
+      result.subjects === undefined ||
+      result.fabricIndex === undefined
+    ) {
+      throw new Error("Missing required fields in AccessControlEntryStruct");
+    }
+
+    return result as AccessControlEntryStruct;
+  }
+}
+
+export class BindingEntryDataTransformer {
+  private static readonly KEY_MAPPING: {
+    [inputKey: string]: keyof BindingEntryStruct;
+  } = {
+    "1": "node",
+    "3": "endpoint",
+    "4": "cluster",
+    "254": "fabricIndex",
+  };
+
+  public static transform(input: any): BindingEntryStruct {
+    if (!input || typeof input !== "object") {
+      throw new Error("Invalid input: expected an object");
+    }
+
+    const result: Partial<BindingEntryStruct> = {};
+    const keyMapping = BindingEntryDataTransformer.KEY_MAPPING;
+
+    for (const key in input) {
+      if (key in keyMapping) {
+        const mappedKey = keyMapping[key];
+        if (mappedKey) {
+          const value = input[key];
+          if (value === undefined) {
+            continue;
+          }
+          if (mappedKey === "fabricIndex") {
+            result[mappedKey] = value === undefined ? undefined : Number(value);
+          } else if (mappedKey === "node" || mappedKey === "endpoint") {
+            result[mappedKey] = Number(value);
+          } else {
+            result[mappedKey] = value as BindingEntryStruct[typeof mappedKey];
+          }
+        }
+      }
+    }
+
+    // Validate required fields
+    if (
+      result.node === undefined ||
+      result.endpoint === undefined ||
+      result.fabricIndex === undefined
+    ) {
+      throw new Error("Missing required fields in BindingEntryStruct");
+    }
+
+    return result as BindingEntryStruct;
+  }
+}

--- a/dashboard/src/components/dialogs/binding/model.ts
+++ b/dashboard/src/components/dialogs/binding/model.ts
@@ -10,61 +10,6 @@ export interface BindingEntryStruct {
   fabricIndex: number | undefined;
 }
 
-export type AccessControlEntryStruct = {
-  privilege: number;
-  authMode: number;
-  subjects: number[];
-  targets: number[] | undefined;
-  fabricIndex: number;
-};
-
-export class AccessControlEntryDataTransformer {
-  private static readonly KEY_MAPPING: {
-    [inputKey: string]: keyof AccessControlEntryStruct;
-  } = {
-    "1": "privilege",
-    "2": "authMode",
-    "3": "subjects",
-    "4": "targets",
-    "254": "fabricIndex",
-  };
-
-  public static transform(input: any): AccessControlEntryStruct {
-    if (!input || typeof input !== "object") {
-      throw new Error("Invalid input: expected an object");
-    }
-
-    const result: Partial<AccessControlEntryStruct> = {};
-    const keyMapping = AccessControlEntryDataTransformer.KEY_MAPPING;
-
-    for (const key in input) {
-      if (key in keyMapping) {
-        const mappedKey = keyMapping[key];
-        if (mappedKey) {
-          const value = input[key];
-          if (value === undefined) continue;
-          if (mappedKey === "subjects" || mappedKey === "targets") {
-            result[mappedKey] = Array.isArray(value) ? value : undefined;
-          } else {
-            result[mappedKey] = value;
-          }
-        }
-      }
-    }
-
-    if (
-      result.privilege === undefined ||
-      result.authMode === undefined ||
-      result.subjects === undefined ||
-      result.fabricIndex === undefined
-    ) {
-      throw new Error("Missing required fields in AccessControlEntryStruct");
-    }
-
-    return result as AccessControlEntryStruct;
-  }
-}
-
 export class BindingEntryDataTransformer {
   private static readonly KEY_MAPPING: {
     [inputKey: string]: keyof BindingEntryStruct;

--- a/dashboard/src/components/dialogs/binding/node-binding-dialog.ts
+++ b/dashboard/src/components/dialogs/binding/node-binding-dialog.ts
@@ -1,0 +1,251 @@
+import "@material/web/button/text-button";
+import "@material/web/dialog/dialog";
+import "@material/web/list/list";
+import "@material/web/list/list-item";
+import "../../../components/ha-svg-icon";
+import "@material/web/textfield/outlined-text-field";
+import type { MdOutlinedTextField } from "@material/web/textfield/outlined-text-field";
+
+import { html, LitElement } from "lit";
+import { customElement, property, query } from "lit/decorators.js";
+import { MatterNode } from "../../../client/models/node";
+import { preventDefault } from "../../../util/prevent_default";
+import { MatterClient } from "../../../client/client";
+import {
+  InputType,
+  AccessControlEntryStruct,
+  AccessControlEntryDataTransformer,
+  BindingEntryStruct,
+  BindingEntryDataTransformer,
+} from "./model";
+
+@customElement("node-binding-dialog")
+export class NodeBindingDialog extends LitElement {
+  @property({ attribute: false }) public client!: MatterClient;
+
+  @property()
+  public node?: MatterNode;
+
+  @property({ attribute: false })
+  bindingPath!: string;
+
+  @query("md-outlined-text-field[label='target node id']")
+  private _targetNodeId!: MdOutlinedTextField;
+
+  @query("md-outlined-text-field[label='target endpoint']")
+  private _targetEndpoint!: MdOutlinedTextField;
+
+  private _transformBindingStruct(): BindingEntryStruct[] {
+    const bindings_raw: [] = this.node!.attributes[this.bindingPath];
+    return Object.values(bindings_raw).map((value) =>
+      BindingEntryDataTransformer.transform(value)
+    );
+  }
+
+  private _transformACLStruct(
+    targetNodeId: number
+  ): AccessControlEntryStruct[] {
+    const acl_cluster_raw: [InputType] =
+      this.client.nodes[targetNodeId].attributes["0/31/0"];
+    return Object.values(acl_cluster_raw).map((value: InputType) =>
+      AccessControlEntryDataTransformer.transform(value)
+    );
+  }
+
+  async _bindingDelete(index: number) {
+    const endpoint = this.bindingPath.split("/")[0];
+    const bindings = this._transformBindingStruct();
+    const targetNodeId = bindings[index].node;
+
+    try {
+      const acl_cluster = this._transformACLStruct(targetNodeId);
+      const _acl_cluster = acl_cluster
+        .map((entry) => {
+          if (entry.subjects && entry.subjects.includes(this.node!.node_id)) {
+            entry.subjects = entry.subjects.filter(
+              (nodeId) => nodeId !== this.node!.node_id
+            );
+            if (entry.subjects.length === 0) {
+              return null;
+            }
+          }
+          return entry;
+        })
+        .filter((entry) => entry !== null);
+      this.client.setACLEntry(targetNodeId, _acl_cluster);
+    } catch (err) {
+      console.log(err);
+    }
+
+    bindings.splice(index, 1);
+    try {
+      await this.client.setNodeBinding(
+        this.node!.node_id,
+        parseInt(endpoint, 10),
+        bindings
+      );
+      this.node!.attributes[this.bindingPath].splice(index, 1);
+      this.requestUpdate();
+    } catch (err) {
+      console.error("Failed to delete binding:", err);
+    }
+  }
+
+  private async _updateEntry<T>(
+    targetId: number,
+    path: string,
+    entry: T,
+    transformFn: (value: InputType) => T,
+    updateFn: (targetId: number, entries: T[]) => Promise<any>
+  ) {
+    try {
+      const rawEntries: [InputType] =
+        this.client.nodes[targetId].attributes[path];
+      const entries = Object.values(rawEntries).map(transformFn);
+      entries.push(entry);
+      return await updateFn(targetId, entries);
+    } catch (err) {
+      console.log(err);
+    }
+  }
+
+  private async add_target_acl(
+    targetNodeId: number,
+    entry: AccessControlEntryStruct
+  ) {
+    try {
+      const result = (await this._updateEntry(
+        targetNodeId,
+        "0/31/0",
+        entry,
+        AccessControlEntryDataTransformer.transform,
+        this.client.setACLEntry.bind(this.client)
+      )) as { [key: string]: { Status: number } };
+      return result["0"].Status === 0;
+    } catch (err) {
+      console.error("add acl error:", err);
+      return false;
+    }
+  }
+
+  private async add_bindings(
+    endpoint: number,
+    bindingEntry: BindingEntryStruct
+  ) {
+    const bindings = this._transformBindingStruct();
+    bindings.push(bindingEntry);
+    try {
+      const result = (await this.client.setNodeBinding(
+        this.node!.node_id,
+        endpoint,
+        bindings
+      )) as { [key: string]: { Status: number } };
+      return result["0"].Status === 0;
+    } catch (err) {
+      console.log("add bindings error:", err);
+      return false;
+    }
+  }
+
+  async _bindingAdd() {
+    const targetNodeId = parseInt(this._targetNodeId.value, 10);
+    const targetEndpoint = parseInt(this._targetEndpoint.value, 10);
+
+    if (isNaN(targetNodeId) || targetNodeId <= 0) {
+      alert("Please enter a valid target node ID");
+      return;
+    }
+    if (isNaN(targetEndpoint) || targetEndpoint < 0) {
+      alert("Please enter a valid target endpoint");
+      return;
+    }
+
+    const acl_entry: AccessControlEntryStruct = {
+      privilege: 5,
+      authMode: 2,
+      subjects: [this.node!.node_id],
+      targets: undefined,
+      fabricIndex: this.client.connection.serverInfo!.fabric_id,
+    };
+    const result_acl = await this.add_target_acl(targetNodeId, acl_entry);
+    if (!result_acl) return;
+
+    const endpoint = this.bindingPath.split("/")[0];
+    const bindingEntry: BindingEntryStruct = {
+      node: targetNodeId,
+      endpoint: targetEndpoint,
+      group: undefined,
+      cluster: undefined,
+      fabricIndex: undefined,
+    };
+
+    const result_binding = await this.add_bindings(
+      parseInt(endpoint, 10),
+      bindingEntry
+    );
+
+    if (result_binding) {
+      this.requestUpdate();
+    }
+  }
+
+  private _close() {
+    this.shadowRoot!.querySelector("md-dialog")!.close();
+  }
+
+  private _handleClosed() {
+    this.parentNode!.removeChild(this);
+  }
+
+  protected render() {
+    const bindings = this.node!.attributes[this.bindingPath];
+
+    return html`
+      <md-dialog open @cancel=${preventDefault} @closed=${this._handleClosed}>
+        <div slot="headline">
+          <div>Binding Add</div>
+        </div>
+        <div slot="content">
+          <div>
+            <md-list>
+              ${Object.values(bindings).map(
+                (entry, index) => html`
+                  <md-list-item>
+                    <div slot="supporting-text">
+                      ${JSON.stringify(
+                        BindingEntryDataTransformer.transform(entry)
+                      )}
+                    </div>
+                    <div slot="end">
+                      <md-text-button
+                        @click=${() => this._bindingDelete(index)}
+                      >delete</md-text-button
+                    </div>
+                  </md-list-item>
+                `
+              )}
+            </md-list>
+            <div>
+              <md-outlined-text-field
+                label="target node id"
+              ></md-outlined-text-field>
+              <md-outlined-text-field
+                label="target endpoint"
+              ></md-outlined-text-field>
+            </div>
+          </div>
+        </div>
+        <div slot="actions">
+          <md-text-button @click=${this._bindingAdd}>Add</md-text-button>
+          <md-text-button @click=${this._close}>Cancel</md-text-button>
+        </div>
+      </md-dialog>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "node-binding-dialog": NodeBindingDialog;
+  }
+}

--- a/dashboard/src/components/dialogs/binding/node-binding-dialog.ts
+++ b/dashboard/src/components/dialogs/binding/node-binding-dialog.ts
@@ -18,10 +18,14 @@ import {
   BindingEntryStruct,
   BindingEntryDataTransformer,
 } from "./model";
+import { consume } from "@lit/context";
+import { clientContext } from "../../../client/client-context";
 
 @customElement("node-binding-dialog")
 export class NodeBindingDialog extends LitElement {
-  @property({ attribute: false }) public client!: MatterClient;
+  @consume({ context: clientContext, subscribe: true })
+  @property({ attribute: false })
+  public client!: MatterClient;
 
   @property()
   public node?: MatterNode;
@@ -38,17 +42,17 @@ export class NodeBindingDialog extends LitElement {
   private _transformBindingStruct(): BindingEntryStruct[] {
     const bindings_raw: [] = this.node!.attributes[this.bindingPath];
     return Object.values(bindings_raw).map((value) =>
-      BindingEntryDataTransformer.transform(value)
+      BindingEntryDataTransformer.transform(value),
     );
   }
 
   private _transformACLStruct(
-    targetNodeId: number
+    targetNodeId: number,
   ): AccessControlEntryStruct[] {
     const acl_cluster_raw: [InputType] =
       this.client.nodes[targetNodeId].attributes["0/31/0"];
     return Object.values(acl_cluster_raw).map((value: InputType) =>
-      AccessControlEntryDataTransformer.transform(value)
+      AccessControlEntryDataTransformer.transform(value),
     );
   }
 
@@ -63,7 +67,7 @@ export class NodeBindingDialog extends LitElement {
         .map((entry) => {
           if (entry.subjects && entry.subjects.includes(this.node!.node_id)) {
             entry.subjects = entry.subjects.filter(
-              (nodeId) => nodeId !== this.node!.node_id
+              (nodeId) => nodeId !== this.node!.node_id,
             );
             if (entry.subjects.length === 0) {
               return null;
@@ -82,7 +86,7 @@ export class NodeBindingDialog extends LitElement {
       await this.client.setNodeBinding(
         this.node!.node_id,
         parseInt(endpoint, 10),
-        bindings
+        bindings,
       );
       this.node!.attributes[this.bindingPath].splice(index, 1);
       this.requestUpdate();
@@ -96,7 +100,7 @@ export class NodeBindingDialog extends LitElement {
     path: string,
     entry: T,
     transformFn: (value: InputType) => T,
-    updateFn: (targetId: number, entries: T[]) => Promise<any>
+    updateFn: (targetId: number, entries: T[]) => Promise<any>,
   ) {
     try {
       const rawEntries: [InputType] =
@@ -111,7 +115,7 @@ export class NodeBindingDialog extends LitElement {
 
   private async add_target_acl(
     targetNodeId: number,
-    entry: AccessControlEntryStruct
+    entry: AccessControlEntryStruct,
   ) {
     try {
       const result = (await this._updateEntry(
@@ -119,7 +123,7 @@ export class NodeBindingDialog extends LitElement {
         "0/31/0",
         entry,
         AccessControlEntryDataTransformer.transform,
-        this.client.setACLEntry.bind(this.client)
+        this.client.setACLEntry.bind(this.client),
       )) as { [key: string]: { Status: number } };
       return result["0"].Status === 0;
     } catch (err) {
@@ -130,7 +134,7 @@ export class NodeBindingDialog extends LitElement {
 
   private async add_bindings(
     endpoint: number,
-    bindingEntry: BindingEntryStruct
+    bindingEntry: BindingEntryStruct,
   ) {
     const bindings = this._transformBindingStruct();
     bindings.push(bindingEntry);
@@ -138,7 +142,7 @@ export class NodeBindingDialog extends LitElement {
       const result = (await this.client.setNodeBinding(
         this.node!.node_id,
         endpoint,
-        bindings
+        bindings,
       )) as { [key: string]: { Status: number } };
       return result["0"].Status === 0;
     } catch (err) {
@@ -181,7 +185,7 @@ export class NodeBindingDialog extends LitElement {
 
     const result_binding = await this.add_bindings(
       parseInt(endpoint, 10),
-      bindingEntry
+      bindingEntry,
     );
 
     if (result_binding) {
@@ -213,7 +217,7 @@ export class NodeBindingDialog extends LitElement {
                   <md-list-item>
                     <div slot="supporting-text">
                       ${JSON.stringify(
-                        BindingEntryDataTransformer.transform(entry)
+                        BindingEntryDataTransformer.transform(entry),
                       )}
                     </div>
                     <div slot="end">
@@ -222,7 +226,7 @@ export class NodeBindingDialog extends LitElement {
                       >delete</md-text-button
                     </div>
                   </md-list-item>
-                `
+                `,
               )}
             </md-list>
             <div>

--- a/dashboard/src/components/dialogs/binding/show-node-binding-dialog.ts
+++ b/dashboard/src/components/dialogs/binding/show-node-binding-dialog.ts
@@ -4,13 +4,13 @@ import { MatterNode } from "../../../client/models/node";
 export const showNodeBindingDialog = async (
   client: MatterClient,
   node: MatterNode,
-  bindingPath: string
+  endpoint: number,
 ) => {
   await import("./node-binding-dialog");
   const dialog = document.createElement("node-binding-dialog");
   dialog.client = client;
   dialog.node = node;
-  dialog.bindingPath = bindingPath;
+  dialog.endpoint = endpoint;
   document
     .querySelector("matter-dashboard-app")
     ?.renderRoot.appendChild(dialog);

--- a/dashboard/src/components/dialogs/binding/show-node-binding-dialog.ts
+++ b/dashboard/src/components/dialogs/binding/show-node-binding-dialog.ts
@@ -1,0 +1,17 @@
+import { MatterClient } from "../../../client/client";
+import { MatterNode } from "../../../client/models/node";
+
+export const showNodeBindingDialog = async (
+  client: MatterClient,
+  node: MatterNode,
+  bindingPath: string
+) => {
+  await import("./node-binding-dialog");
+  const dialog = document.createElement("node-binding-dialog");
+  dialog.client = client;
+  dialog.node = node;
+  dialog.bindingPath = bindingPath;
+  document
+    .querySelector("matter-dashboard-app")
+    ?.renderRoot.appendChild(dialog);
+};

--- a/dashboard/src/pages/components/context.ts
+++ b/dashboard/src/pages/components/context.ts
@@ -1,4 +1,5 @@
 
 import { createContext  } from "@lit/context";
 
-export const bindingContext = createContext<string>("");
+// export const bindingContext = createContext<string>("");
+export const bindingContext = createContext<number>("binding");

--- a/dashboard/src/pages/components/context.ts
+++ b/dashboard/src/pages/components/context.ts
@@ -1,0 +1,4 @@
+
+import { createContext  } from "@lit/context";
+
+export const bindingContext = createContext<string>("");

--- a/dashboard/src/pages/components/node-details.ts
+++ b/dashboard/src/pages/components/node-details.ts
@@ -52,12 +52,12 @@ export class NodeDetails extends LitElement {
 
   @consume({ context: bindingContext })
   @property({ attribute: false })
-  bindingPath!: string;
+  endpoint!: number;
 
   protected render() {
     if (!this.node) return html``;
 
-    const bindings = this.node.attributes[this.bindingPath];
+    const bindings = this.node.attributes[this.endpoint + "/30/0"];
 
     return html`
       <md-list>
@@ -172,7 +172,7 @@ export class NodeDetails extends LitElement {
 
   private async _binding() {
     try {
-      showNodeBindingDialog(this.client!, this.node!, this.bindingPath!);
+      showNodeBindingDialog(this.client!, this.node!, this.endpoint!);
     } catch (err: any) {
       console.log(err);
     }

--- a/dashboard/src/pages/components/node-details.ts
+++ b/dashboard/src/pages/components/node-details.ts
@@ -108,9 +108,9 @@ export class NodeDetails extends LitElement {
         : html`<md-outlined-button @click=${this._searchUpdate}>Update<ha-svg-icon slot="icon" .path=${mdiUpdate}></ha-svg-icon></md-outlined-button>`}
 
           ${bindings
-            ? html` 
-              <md-outlined-button @click=${this._binding}> 
-                Binding 
+            ? html`
+              <md-outlined-button @click=${this._binding}>
+                Binding
                 <ha-svg-icon slot="icon" .path=${mdiLink}></ha-svg-icon>
               </md-outlined-button>
               `

--- a/dashboard/src/pages/matter-cluster-view.ts
+++ b/dashboard/src/pages/matter-cluster-view.ts
@@ -40,15 +40,12 @@ class MatterClusterView extends LitElement {
   @property()
   public node?: MatterNode;
 
+  @provide({ context: bindingContext })
   @property()
-  public endpoint?: number;
+  public endpoint!: number;
 
   @property()
   public cluster?: number;
-
-  @provide({ context: bindingContext })
-  @property({ attribute: false })
-  bindingPath: string = "";
 
   render() {
     if (!this.node || this.endpoint == undefined || this.cluster == undefined) {
@@ -56,10 +53,6 @@ class MatterClusterView extends LitElement {
         <p>Node, endpoint or cluster not found!</p>
         <button @click=${this._goBack}>Back</button>
       `;
-    }
-
-    if (this.cluster == 30) {
-      this.bindingPath = this.endpoint + "/30/0";
     }
 
     return html`

--- a/dashboard/src/pages/matter-cluster-view.ts
+++ b/dashboard/src/pages/matter-cluster-view.ts
@@ -9,6 +9,9 @@ import { clusters } from "../client/models/descriptions";
 import { MatterNode } from "../client/models/node";
 import { showAlertDialog } from "../components/dialog-box/show-dialog-box";
 import "../components/ha-svg-icon";
+import "../pages/components/node-details";
+import { provide } from "@lit/context";
+import { bindingContext } from "./components/context";
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -43,12 +46,20 @@ class MatterClusterView extends LitElement {
   @property()
   public cluster?: number;
 
+  @provide({ context: bindingContext })
+  @property({ attribute: false })
+  bindingPath: string = "";
+
   render() {
     if (!this.node || this.endpoint == undefined || this.cluster == undefined) {
       return html`
         <p>Node, endpoint or cluster not found!</p>
         <button @click=${this._goBack}>Back</button>
       `;
+    }
+
+    if (this.cluster == 30) {
+      this.bindingPath = this.endpoint + "/30/0";
     }
 
     return html`

--- a/matter_server/common/models.py
+++ b/matter_server/common/models.py
@@ -51,6 +51,10 @@ class APICommand(str, Enum):
     CHECK_NODE_UPDATE = "check_node_update"
     UPDATE_NODE = "update_node"
     SET_DEFAULT_FABRIC_LABEL = "set_default_fabric_label"
+    GET_ACL_ENTRY = "get_acl_entry"
+    SET_ACL_ENTRY = "set_acl_entry"
+    GET_NODE_BINDINGS = "get_node_bindings"
+    SET_NODE_BINDING = "set_node_binding"
 
 
 EventCallBackType = Callable[[EventType, Any], None]

--- a/matter_server/common/models.py
+++ b/matter_server/common/models.py
@@ -51,9 +51,7 @@ class APICommand(str, Enum):
     CHECK_NODE_UPDATE = "check_node_update"
     UPDATE_NODE = "update_node"
     SET_DEFAULT_FABRIC_LABEL = "set_default_fabric_label"
-    GET_ACL_ENTRY = "get_acl_entry"
     SET_ACL_ENTRY = "set_acl_entry"
-    GET_NODE_BINDINGS = "get_node_bindings"
     SET_NODE_BINDING = "set_node_binding"
 
 

--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from chip.ChipDeviceCtrl import ChipDeviceController
 from chip.clusters import Attribute, Objects as Clusters
-from chip.clusters.Attribute import SubscriptionTransaction, ValueDecodeFailure
+from chip.clusters.Attribute import AttributeWriteResult, ValueDecodeFailure
 from chip.clusters.ClusterObjects import ALL_ATTRIBUTES, ALL_CLUSTERS, Cluster
 from chip.discovery import DiscoveryType
 from chip.exceptions import ChipStackError
@@ -867,45 +867,11 @@ class MatterDeviceController:
         self,
         node_id: int,
         entry: list[Clusters.AccessControl.Structs.AccessControlEntryStruct],
-    ):
+    ) -> list[AttributeWriteResult] | None:
         """Set acl entry"""
         return await self._chip_device_controller.write_attribute(
             node_id, [(0, Clusters.AccessControl.Attributes.Acl(entry))]
         )
-
-    @api_command(APICommand.GET_ACL_ENTRY)
-    async def get_acl_entry(self, node_id: int):
-        """Get acl entry"""
-        read_response: (
-            SubscriptionTransaction | Attribute.AsyncReadTransaction.ReadResponse | None
-        ) = await self._chip_device_controller.read_attribute(
-            node_id, [(0, Clusters.AccessControl.Attributes.Acl)]
-        )
-        acl_entities = []
-        if isinstance(read_response, Attribute.AsyncReadTransaction.ReadResponse):
-            acl_entities: list[
-                Clusters.AccessControl.Structs.AccessControlEntryStruct
-            ] = read_response.attributes[0][Clusters.AccessControl][
-                Clusters.AccessControl.Attributes.Acl
-            ]
-        return acl_entities
-
-    @api_command(APICommand.GET_NODE_BINDINGS)
-    async def get_node_bindings(self, node_id: int):
-        """Get node bindings"""
-        read_response: (
-            SubscriptionTransaction | Attribute.AsyncReadTransaction.ReadResponse | None
-        ) = await self._chip_device_controller.read_attribute(
-            node_id, (Clusters.Binding.Attributes.Binding,)
-        )
-
-        bindings = []
-        if isinstance(read_response, Attribute.AsyncReadTransaction.ReadResponse):
-            for k, v in read_response.attributes.items():
-                bindings.append(
-                    {k: v[Clusters.Binding][Clusters.Binding.Attributes.Binding]}
-                )
-        return bindings
 
     @api_command(APICommand.SET_NODE_BINDING)
     async def set_node_binding(
@@ -913,7 +879,7 @@ class MatterDeviceController:
         node_id: int,
         endpoint: int,
         bindings: list[Clusters.Binding.Structs.TargetStruct],
-    ):
+    ) -> list[AttributeWriteResult] | None:
         """Set node binding"""
         return await self._chip_device_controller.write_attribute(
             node_id, [(endpoint, Clusters.Binding.Attributes.Binding(bindings))]


### PR DESCRIPTION
I added a button in the binding cluster of the node to add the binding relationship of the device.
Note: Currently, binding to the endpoints of the device is only supported.

I conducted tests using [light_switch](https://github.com/espressif/esp-matter/tree/main/examples/light_switch) and [light](https://github.com/espressif/esp-matter/tree/main/examples/light) in the esp-matter sdk, and the test results met the requirements.
(One-to-one endpoint control can be achieved, as well as one-to-many endpoint control.)

The operation is as follows
1. Enter the binding cluster of the node, and a 'Binding' button will appear on it.
2. After clicking the 'Binding' button, you can add or delete binding relationships.

As shown in the following figure:
![20250519_183058_22](https://github.com/user-attachments/assets/061b6608-5423-4d6d-9b45-c3b05e91b934)
