### PR TITLE
Add ignore[arg-type] to fix mypy false positive

### DIFF
--- a/matter_server/server/server.py
+++ b/matter_server/server/server.py
@@ -89,7 +89,7 @@ def mount_websocket(server: MatterServer, path: str) -> None:
         for client in set(clients):
             await client.disconnect()
 
-    server.app.on_shutdown.append(_handle_shutdown)
+    server.app.on_shutdown.append(_handle_shutdown)  # type: ignore[arg-type]
     server.app.router.add_route("GET", path, _handle_ws)
 
 


### PR DESCRIPTION
For unkown reasons, CI pre-commit mypy check suddenly started to fail with:

```
matter_server/server/server.py:92: error: Argument 1 to "append" of "MutableSequence" has incompatible type "Callable[[Application], Coroutine[Any, Any, None]]"; expected "Callable[[Callable[[Application], Awaitable[None]]], Awaitable[object]]"  [arg-type]
```

It seems to be a false positive. Simply ignore the line for now.