### PR TITLE
Log primary interface used by Python Matter server on startup

### DIFF
--- a/matter_server/server/server.py
+++ b/matter_server/server/server.py
@@ -147,6 +147,11 @@ class MatterServer:
             raise RuntimeError(
                 "Minimum supported schema version can't be higher than current schema version."
             )
+        self.logger.info("Matter Server initialized")
+        self.logger.info(
+            "Using '%s' as primary interface (for link-local addresses)",
+            self.primary_interface,
+        )
 
     @cached_property
     def device_controller(self) -> MatterDeviceController:


### PR DESCRIPTION
The Matter SDK initializes the network diagnostic cluster on startup which prints its own primary interface name. This leads to confusion to what primary interface the Matter Server itself is using. Print the primary interface used by the Python Matter server separately as well.

See https://github.com/home-assistant/addons/pull/4092#issuecomment-3164029245