### PR TITLE
Expose Tcp support as False for now

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -569,7 +569,8 @@ class MatterDeviceController:
                 pairing_hint=x.pairingHint,
                 mrp_retry_interval_idle=x.mrpRetryIntervalIdle,
                 mrp_retry_interval_active=x.mrpRetryIntervalActive,
-                supports_tcp=False, # TCP is provisional, so no devices out there anyway
+                # TCP is provisional, so no devices out there anyway
+                supports_tcp=False,
                 addresses=x.addresses,
                 rotating_id=x.rotatingId,
             )


### PR DESCRIPTION
The matter.js migration will fix this reliably. For now and with the fact that there are no TCP devices out there because TCP is provisional and is coming earliest with Matter 1.5 we can fix #1207 by setting it to False.

#fixes #1207