### PR TITLE
Update node.ts to handle non-string label data

### DIFF
--- a/dashboard/src/client/models/node.ts
+++ b/dashboard/src/client/models/node.ts
@@ -21,7 +21,7 @@ export class MatterNode {
 
   get nodeLabel(): string {
     const label = this.attributes["0/40/5"];
-    if (!label) return '';
+    if (typeof label !== "string") return '';
     if (label.includes("\u0000\u0000")) return '';
     return label.trim();
   }


### PR DESCRIPTION
As reported in https://github.com/home-assistant/core/issues/156671 there is a case in which label is not a string but an object:
```
{
    "TLVValue": null,
    "Reason": "InteractionModelError: Failure (0x1)"
}
```
This then causes an error in the rendering of the dashboard.

Ideally we would figure out where the bad data comes from. But this should fix the symptom.