### PR TITLE
Enforce HTTPS-only for OTA update URLs

### DIFF
--- a/matter_server/server/ota/provider.py
+++ b/matter_server/server/ota/provider.py
@@ -318,17 +318,9 @@ class ExternalOtaProvider:
                 "No OTA checksum type or not supported, OTA will not be checked."
             )
 
-        if parsed_url.scheme in ["http", "https"]:
-            file_path = await self._download_update(url, checksum_alg)
-        elif parsed_url.scheme in ["file"]:
-            file_path = self._ota_provider_base_dir / Path(parsed_url.path[1:])
-            if not await asyncio.to_thread(file_path.exists):
-                LOGGER.warning("Local update file not found: %s", file_path)
-                raise UpdateError("Local update file not found")
-            if checksum_alg:
-                checksum_alg.update(await asyncio.to_thread(file_path.read_bytes))
-        else:
-            raise UpdateError("Unsupported OTA URL scheme")
+        if parsed_url.scheme != "https":
+            raise UpdateError("Only HTTPS URLs are supported for OTA updates")
+        file_path = await self._download_update(url, checksum_alg)
 
         # Download finished, check checksum if necessary
         if checksum_alg:


### PR DESCRIPTION
**Summary**

Remove support for `http://` and `file://` URL schemes in OTA firmware updates. Only `https://` URLs are now accepted.

**Rationale**

- **Matter Specification Compliance.** The Matter specification (Section 11.23.7.8. OTA) requires HTTPS for firmware update URLs. The upstream DCL (Distributed Compliance Ledger) enforces this via validation rules in [tx.proto](https://github.com/zigbee-alliance/distributed-compliance-ledger/blob/7f06138c01868f2b48f53b6f5e76a108129414be/proto/zigbeealliance/distributedcomplianceledger/model/tx.proto#L108).
- **No Custom Path.** I apologize if I’m mistaken, but I don’t seem to have noticed a feature in this plug-in that allows users to configure a custom URL for downloading firmware. Additionally, I don’t recall seeing a similar feature in the Home Assistant that supports user-defined URLs for firmware downloads. 

**Security Concerns**
Due to theoretical security concerns, 
- `http://` allows firmware downloads over unencrypted connections, enabling trivial MITM attacks. 
- `file://` scheme introduces path traversal risk as paths from external sources are not sanitized.

**Changes**

- Remove http:// scheme support
- Remove file:// scheme support
- Reject any non-HTTPS URL with UpdateError