### PR TITLE
Dashboard: Add suggested url via url param when missing stored url

### DIFF
--- a/dashboard/src/entrypoint/main.ts
+++ b/dashboard/src/entrypoint/main.ts
@@ -22,6 +22,10 @@ async function main() {
         alert("Unable to connect without URL");
         return;
       }
+      if (suggestedUrl) {
+        // Remove suggested url from address without redirecting
+        history.pushState({}, "", window.location.pathname);
+      }
       localStorage.setItem("matterURL", storageUrl);
     }
     url = storageUrl;


### PR DESCRIPTION
This PR allows the user to specify a `url` query param which will be used as a suggested URL when first connecting to the matter server.

By default `ws://localhost:5580/ws` will be autofilled into the browser prompt. With this change, a user can bookmark the URL to the matter server (dashboard) with a pre-filled `url` query parameter like `http://localhost:50104/?url=ws://somwhere-different/ws`.

I aknowledge that once a URL has been entered, it's stored in the browser's localstorage. I've configured Firefox to delete any site data on restart which would make me enter the correct URL each time. The default behavior with omitted `url` query param will not change.

<img width="742" height="466" alt="Screenshot 2026-01-03 at 12 25 45" src="https://github.com/user-attachments/assets/addc8ebe-638a-4044-9783-5ebccf6c16ec" />
