### PR TITLE
Add sorting to attributes in matter cluster view

### DIFF
--- a/dashboard/src/pages/matter-cluster-view.ts
+++ b/dashboard/src/pages/matter-cluster-view.ts
@@ -30,7 +30,8 @@ function clusterAttributes(
     .map((key) => {
       const attributeKey = Number(key.split("/")[2]);
       return { key: attributeKey, value: attributes[key] };
-    }, []);
+    }, [])
+    .toSorted((a, b) => a.key - b.key);
 }
 
 @customElement("matter-cluster-view")


### PR DESCRIPTION
Sort attributes by key in matter cluster view.
currently attributes are not sorted always. see 655xx attributes
<img width="671" height="996" alt="grafik" src="https://github.com/user-attachments/assets/94492804-24ee-4eee-b60b-e10624f96012" />
