### PR TITLE
Include underlying error details in commissioning failure messages

### DIFF
--- a/matter_server/server/device_controller.py
+++ b/matter_server/server/device_controller.py
@@ -318,7 +318,11 @@ class MatterDeviceController:
         :return: The NodeInfo of the commissioned device.
         """
         if not network_only and not self.server.bluetooth_enabled:
-            raise NodeCommissionFailed("Bluetooth commissioning is not available.")
+            raise NodeCommissionFailed(
+                "Bluetooth commissioning is not available. "
+                "Ensure a Bluetooth adapter is configured in the Matter Server settings, "
+                "or use network_only mode if the device is already on the network."
+            )
 
         node_id = self._get_next_node_id()
         LOGGER.info(
@@ -342,7 +346,7 @@ class MatterDeviceController:
                 raise RuntimeError("Returned Node ID must match requested Node ID")
         except ChipStackError as err:
             raise NodeCommissionFailed(
-                f"Commission with code failed for node {node_id}."
+                f"Commission with code failed for node {node_id}: {err}"
             ) from err
 
         LOGGER.info("Matter commissioning of Node ID %s successful.", node_id)
@@ -428,7 +432,7 @@ class MatterDeviceController:
                 raise RuntimeError("Returned Node ID must match requested Node ID")
         except ChipStackError as err:
             raise NodeCommissionFailed(
-                f"Commissioning failed for node {node_id}."
+                f"Commissioning failed for node {node_id}: {err}"
             ) from err
 
         LOGGER.info("Matter commissioning of Node ID %s successful.", node_id)
@@ -595,7 +599,9 @@ class MatterDeviceController:
                 )
             )
         except ChipStackError as err:
-            raise NodeInterviewFailed(f"Failed to interview node {node_id}") from err
+            raise NodeInterviewFailed(
+                f"Failed to interview node {node_id}: {err}"
+            ) from err
 
         # Set label if specified and needed
         if self._default_fabric_label:

--- a/matter_server/server/sdk.py
+++ b/matter_server/server/sdk.py
@@ -398,7 +398,7 @@ class ChipDeviceControllerWrapper:
                 if attempt >= retries:
                     # when we're out of retries, raise NodeNotResolving
                     raise NodeNotResolving(
-                        f"Unable to establish CASE session with Node {node_id}"
+                        f"Unable to establish CASE session with Node {node_id}: {err}"
                     ) from err
                 await asyncio.sleep(2 + attempt)
             finally:


### PR DESCRIPTION
## Summary

When Matter commissioning fails, the `ChipStackError` from the CHIP SDK is caught and re-raised as `NodeCommissionFailed` with a generic message like *"Commission with code failed for node 42."* — the specific error (e.g. invalid pairing code checksum, wrong code length, Bluetooth not available, WiFi network not found) is discarded. Users have to enable debug logging and read tracebacks to find out *why* commissioning failed.

This PR propagates the original error message into all commissioning-related exceptions:

- **`NodeCommissionFailed`** in `commission_with_code` and `commission_on_network` — appends `: {err}` so the CHIP SDK error reason is visible
- **`NodeInterviewFailed`** in `_interview_node` — same treatment
- **`NodeNotResolving`** in `sdk.py` CASE session establishment — same treatment
- **Bluetooth availability check** — expands the one-line message with a hint to configure a Bluetooth adapter or use `network_only` mode

## Motivation

While commissioning a Matter device (Brighter lamp) via Home Assistant, every failure showed the same unhelpful message: *"Commission with code failed for node X"*. The actual errors — invalid pairing code checksum, wrong code length, Bluetooth not configured, WiFi network not found — were only visible in verbose server logs. I had to read the python-matter-server source to understand the error wrapping chain. This small change makes commissioning failures self-diagnosable directly from the Home Assistant UI.

### Before
```
Commission with code failed for node 42.
```

### After
```
Commission with code failed for node 42: ChipStackError: CHIP Error 0x0000002F: Integrity check failed
```

## Changes

- `matter_server/server/device_controller.py`: Include `{err}` in `NodeCommissionFailed` and `NodeInterviewFailed` messages; expand Bluetooth error with actionable guidance
- `matter_server/server/sdk.py`: Include `{err}` in `NodeNotResolving` message

## Test plan

- [ ] Verify commissioning with an invalid pairing code shows the CHIP SDK error in the raised exception message
- [ ] Verify commissioning without Bluetooth configured shows the expanded guidance message
- [ ] Verify commissioning on network with wrong PIN code includes the SDK error
- [ ] Verify interview failure includes the SDK error
- [ ] Verify CASE session failure includes the SDK error
- [ ] Existing tests pass (no test changes needed — error messages are not asserted on)

🤖 Generated with [Claude Code](https://claude.com/claude-code)