### PR TITLE
ci: weekly scheduled container rebuild for fresh base layers

### DIFF
--- a/.github/workflows/rebuild-container.yml
+++ b/.github/workflows/rebuild-container.yml
@@ -1,0 +1,58 @@
+name: Rebuild container image (scheduled)
+
+# Weekly rebuild of the python-matter-server container with a fresh
+# python:3.12-slim-bookworm base. This catches OS security fixes that
+# accumulate between PyPI releases — same Dockerfile, no source changes,
+# rebuilt against the latest published python-matter-server version.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Sunday 04:00 UTC
+    - cron: '0 4 * * 0'
+
+jobs:
+  rebuild-container:
+    name: Rebuild container with fresh base
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Look up latest released python-matter-server version
+        id: ver
+        run: |
+          LATEST=$(curl -fsS https://pypi.org/pypi/python-matter-server/json | jq -r .info.version)
+          if [ -z "$LATEST" ] || [ "$LATEST" = "null" ]; then
+            echo "Could not fetch latest version from PyPI" >&2
+            exit 1
+          fi
+          echo "version=$LATEST" >> "$GITHUB_OUTPUT"
+          echo "minor=${LATEST%.*}" >> "$GITHUB_OUTPUT"
+          echo "major=${LATEST%%.*}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to the GitHub container registry
+        uses: docker/login-action@v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.0.0
+
+      - name: Build and push refreshed :stable
+        uses: docker/build-push-action@v7.1.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          file: Dockerfile
+          pull: true
+          push: true
+          build-args: "PYTHON_MATTER_SERVER=${{ steps.ver.outputs.version }}"
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/python-matter-server:${{ steps.ver.outputs.version }},
+            ghcr.io/${{ github.repository_owner }}/python-matter-server:${{ steps.ver.outputs.minor }},
+            ghcr.io/${{ github.repository_owner }}/python-matter-server:${{ steps.ver.outputs.major }},
+            ghcr.io/${{ github.repository_owner }}/python-matter-server:stable


### PR DESCRIPTION
### Motivation

The `ghcr.io/home-assistant-libs/python-matter-server` container is built and published only on `release: published` (via `release.yml`'s `build-and-push-container-image` job). Between releases, the `python:3.12-slim-bookworm` base accumulates security fixes that aren't picked up — the `:stable` tag drifts behind on OS-package CVEs.

Latest published image scanned with trivy on `2026-05-02`:

| Severity | Count |
|---|---|
| CRITICAL | 6 |
| HIGH | 23 |

All findings are in OS packages (libssl/libxml2/etc) shipped by the slim-bookworm base. Rebuilding the existing `Dockerfile` against current `python:3.12-slim-bookworm` reduces these to **0 HIGH/CRITICAL** without any source change.

### Change

Adds a new workflow `.github/workflows/rebuild-container.yml` that:

1. Triggers weekly (Sun 04:00 UTC) and on `workflow_dispatch`
2. Looks up the latest published `python-matter-server` version from PyPI (matches what release.yml does, just from a different signal)
3. Rebuilds with `pull: true` (forces fresh base) using the existing `Dockerfile`
4. Re-tags `:stable` (and `:major.minor.patch` / `:minor` / `:major`) — exactly the same set of tags `release.yml` produces

The new workflow is **independent of `release.yml`** — it never touches PyPI publishing or the version-validation logic. Tagged release publishes still work exactly as before.

### Why a separate workflow

Adding `schedule:` directly to `release.yml` would also trigger the `build-and-publish-pypi` job, which has tag-format validation that would fail on a non-release-context run. A separate workflow avoids re-engineering that logic.

### Verified locally

`docker build --pull --build-arg PYTHON_MATTER_SERVER=8.1.2 -t local/matter-server:rebuilt .` against current `python:3.12-slim-bookworm` → **0 HIGH/CRITICAL OS CVEs**. Container starts clean, `Matter Server successfully initialized`.

### Adjustments welcome

- Cron cadence (currently weekly Sunday 04:00 UTC)
- Tag set (could trim to `:stable` only if preferred)
- Skipping pre-releases (currently the workflow doesn't distinguish — PyPI's `latest` is always a stable release per your existing release flow)